### PR TITLE
chore(gitmagic): update contributing.json - has no issue

### DIFF
--- a/contributing.json
+++ b/contributing.json
@@ -1,17 +1,15 @@
 {
-  "commit": {
-    "subject_cannot_be_empty": true,
-    "subject_must_be_longer_than": 4,
-    "subject_must_be_single_line": true
-  },
   "pull_request": {
     "subject_cannot_be_empty": true,
-    "subject_must_be_longer_than": 4,
+    "subject_must_be_longer_than": 8,
     "subject_must_be_shorter_than": 101,
+    "subject_must_start_with_case": "lower",
     "subject_must_not_end_with_dot": true,
     "subject_must_include_prefix": {
       "prefixes": ["feat", "fix", "docs", "style", "refactor", "perf", "test", "chore"],
-      "require_after_prefix": "(*): "
-    }
+      "require_after_prefix": "(*): * - *"
+    },
+    "subject_must_include_jira_issue": "end",
+    "body_cannot_be_empty": true
   }
 }


### PR DESCRIPTION
This PR updates gitmagic's rules.

Subjects must now look like: `feat(component): action - JIRA issue`. If there's no JIRA issue, then it should be `feat(component): action - has no issue`.  

Furthermore, you must now include a body to your PR, which should give some useful information (what it fixes, how to test).

Finally, there's no more rule on the commit messages. We don't need any since we use "squash and merge" on the PRs