### PR TITLE
feat(dialog): add component - INNO-679

### DIFF
--- a/framework/components/ecl-dialogs/README.md
+++ b/framework/components/ecl-dialogs/README.md
@@ -1,0 +1,9 @@
+# Dialogs
+
+A dialog is an application window that is designed to interrupt the current processing of an application in order to prompt the user to enter information or require a response.
+
+## Resources
+
+- [WAI-ARIA dialog role](https://www.w3.org/TR/2009/WD-wai-aria-20091215/roles#dialog)
+- [Using the dialog role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role)
+- [Creating an accessible dialog](https://bitsofco.de/accessible-modal-dialog/)

--- a/framework/components/ecl-dialogs/dialogs.js
+++ b/framework/components/ecl-dialogs/dialogs.js
@@ -43,16 +43,17 @@ export const dialogs = (
   const focusableElements = [].slice.call(
     queryAll(
       `
-        a[href],
-        area[href],
-        input:not([disabled]),
-        select:not([disabled]),
-        textarea:not([disabled]),
-        button:not([disabled]),
-        [tabindex="0"]
+        #${dialogWindowId} a[href],
+        #${dialogWindowId} area[href],
+        #${dialogWindowId} input:not([disabled]),
+        #${dialogWindowId} select:not([disabled]),
+        #${dialogWindowId} textarea:not([disabled]),
+        #${dialogWindowId} button:not([disabled]),
+        #${dialogWindowId} [tabindex="0"]
       `
     )
   );
+
   // Use this variable to return focus on element after dialog being closed.
   let focusedElBeforeOpen = null;
 
@@ -124,14 +125,10 @@ export const dialogs = (
     firstFocusableElement.focus();
 
     // Close dialog when clicked out of the dialog window.
-    dialogOverlay.addEventListener('click', () => {
-      close();
-    });
+    dialogOverlay.addEventListener('click', close);
 
     // Handle tabbing, esc and keyboard in the dialog window.
-    dialogWindow.addEventListener('keydown', e => {
-      handleKeyDown(e);
-    });
+    dialogWindow.addEventListener('keydown', handleKeyDown);
   }
 
   // BIND EVENTS

--- a/framework/components/ecl-dialogs/dialogs.js
+++ b/framework/components/ecl-dialogs/dialogs.js
@@ -1,0 +1,178 @@
+import { queryAll } from '@ec-europa/ecl-base/helpers/dom';
+
+/**
+ * @param {object} options Object containing configuration overrides
+ *
+ * Available options:
+ * - options.triggerElementsSelector - any selector to which event listeners
+ * are attached. When clicked on any element with such a selector, a dialog opens.
+ *
+ * - options.dialogWindowId - id of target dialog window. Defaults to `ecl-dialog`.
+ *
+ * - options.dialogOverlayId - id of target dialog window. Defaults to `ecl-overlay`.
+ * Overlay element is created in the document if not provided by the user.
+ */
+export const dialogs = (
+  {
+    triggerElementsSelector: triggerElementsSelector = '[data-ecl-dialog]',
+    dialogWindowId: dialogWindowId = 'ecl-dialog',
+    dialogOverlayId: dialogOverlayId = 'ecl-overlay',
+  } = {}
+) => {
+  // SUPPORTS
+  if (!('querySelector' in document) || !('addEventListener' in window)) {
+    return null;
+  }
+
+  // SETUP
+  const triggerElements = queryAll(triggerElementsSelector);
+  const dialogWindow = document.getElementById(dialogWindowId);
+  let dialogOverlay = document.getElementById(dialogOverlayId);
+
+  // Create an overlay element if the user does not supply one.
+  if (!dialogOverlay) {
+    const element = document.createElement('div');
+    element.setAttribute('id', 'ecl-overlay');
+    element.setAttribute('class', 'ecl-dialog__overlay');
+    document.body.append(element);
+    dialogOverlay = element;
+  }
+
+  // What we can focus on in the modal.
+  const focusableElements = [].slice.call(
+    queryAll(
+      `
+        a[href],
+        area[href],
+        input:not([disabled]),
+        select:not([disabled]),
+        textarea:not([disabled]),
+        button:not([disabled]),
+        [tabindex="0"]
+      `
+    )
+  );
+  // Use this variable to return focus on element after dialog being closed.
+  let focusedElBeforeOpen = null;
+
+  // Specific elements to take care when openning and closing the dialog.
+  const firstFocusableElement = focusableElements[0];
+  const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+  // EVENTS
+  // Hide dialog and overlay elements.
+  function close() {
+    dialogWindow.setAttribute('aria-hidden', true);
+    dialogOverlay.setAttribute('aria-hidden', true);
+
+    if (focusedElBeforeOpen) {
+      focusedElBeforeOpen.focus();
+    }
+  }
+
+  // Keyboard behaviors.
+  function handleKeyDown(e) {
+    const KEY_TAB = 9;
+    const KEY_ESC = 27;
+
+    function handleBackwardTab() {
+      if (document.activeElement === firstFocusableElement) {
+        e.preventDefault();
+        lastFocusableElement.focus();
+      }
+    }
+
+    function handleForwardTab() {
+      if (document.activeElement === lastFocusableElement) {
+        e.preventDefault();
+        firstFocusableElement.focus();
+      }
+    }
+
+    switch (e.keyCode) {
+      // Keep tabbing in the scope of the dialog.
+      case KEY_TAB:
+        if (focusableElements.length === 1) {
+          e.preventDefault();
+          break;
+        }
+        if (e.shiftKey) {
+          handleBackwardTab();
+        } else {
+          handleForwardTab();
+        }
+        break;
+      case KEY_ESC:
+        close();
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Show dialog and overlay elements.
+  function open() {
+    dialogWindow.setAttribute('aria-hidden', false);
+    dialogOverlay.setAttribute('aria-hidden', false);
+
+    // This is the element to have the focus after closing the dialog.
+    // Usually the element which triggered the dialog.
+    focusedElBeforeOpen = document.activeElement;
+
+    // Focus on the first element in the dialog.
+    firstFocusableElement.focus();
+
+    // Close dialog when clicked out of the dialog window.
+    dialogOverlay.addEventListener('click', () => {
+      close();
+    });
+
+    // Handle tabbing, esc and keyboard in the dialog window.
+    dialogWindow.addEventListener('keydown', e => {
+      handleKeyDown(e);
+    });
+  }
+
+  // BIND EVENTS
+  function bindDialogEvents(elements) {
+    elements.forEach(element => element.addEventListener('click', open));
+
+    // const closeButtons = document.querySelectorAll('.ecl-message__dismiss');
+    queryAll('.ecl-message__dismiss').forEach(button => {
+      button.addEventListener('click', close);
+    });
+  }
+
+  // UNBIND EVENTS
+  function unbindDialogEvents(elements) {
+    elements.forEach(element => element.removeEventListener('click', open));
+
+    // const closeButtons = document.querySelectorAll('.ecl-message__dismiss');
+    queryAll('.ecl-message__dismiss').forEach(button => {
+      button.removeEventListener('click', close);
+    });
+  }
+
+  // DESTROY
+  function destroy() {
+    unbindDialogEvents(triggerElements);
+  }
+
+  // INIT
+  function init() {
+    if (triggerElements.length) {
+      bindDialogEvents(triggerElements);
+    }
+  }
+
+  init();
+
+  // REVEAL API
+  return {
+    init,
+    destroy,
+  };
+};
+
+// module exports
+export default dialogs;

--- a/framework/components/ecl-dialogs/dialogs.js
+++ b/framework/components/ecl-dialogs/dialogs.js
@@ -43,14 +43,15 @@ export const dialogs = (
   const focusableElements = [].slice.call(
     queryAll(
       `
-        #${dialogWindowId} a[href],
-        #${dialogWindowId} area[href],
-        #${dialogWindowId} input:not([disabled]),
-        #${dialogWindowId} select:not([disabled]),
-        #${dialogWindowId} textarea:not([disabled]),
-        #${dialogWindowId} button:not([disabled]),
-        #${dialogWindowId} [tabindex="0"]
-      `
+        a[href],
+        area[href],
+        input:not([disabled]),
+        select:not([disabled]),
+        textarea:not([disabled]),
+        button:not([disabled]),
+        [tabindex="0"]
+      `,
+      dialogWindow
     )
   );
 
@@ -125,10 +126,14 @@ export const dialogs = (
     firstFocusableElement.focus();
 
     // Close dialog when clicked out of the dialog window.
-    dialogOverlay.addEventListener('click', close);
+    dialogOverlay.addEventListener('click', () => {
+      close();
+    });
 
     // Handle tabbing, esc and keyboard in the dialog window.
-    dialogWindow.addEventListener('keydown', handleKeyDown);
+    dialogWindow.addEventListener('keydown', e => {
+      handleKeyDown(e);
+    });
   }
 
   // BIND EVENTS

--- a/framework/components/ecl-dialogs/dialogs.js
+++ b/framework/components/ecl-dialogs/dialogs.js
@@ -126,14 +126,10 @@ export const dialogs = (
     firstFocusableElement.focus();
 
     // Close dialog when clicked out of the dialog window.
-    dialogOverlay.addEventListener('click', () => {
-      close();
-    });
+    dialogOverlay.addEventListener('click', close);
 
     // Handle tabbing, esc and keyboard in the dialog window.
-    dialogWindow.addEventListener('keydown', e => {
-      handleKeyDown(e);
-    });
+    dialogWindow.addEventListener('keydown', handleKeyDown);
   }
 
   // BIND EVENTS

--- a/framework/components/ecl-dialogs/dialogs.js
+++ b/framework/components/ecl-dialogs/dialogs.js
@@ -34,6 +34,7 @@ export const dialogs = (
     const element = document.createElement('div');
     element.setAttribute('id', 'ecl-overlay');
     element.setAttribute('class', 'ecl-dialog__overlay');
+    element.setAttribute('aria-hidden', 'true');
     document.body.append(element);
     dialogOverlay = element;
   }

--- a/framework/components/ecl-dialogs/ecl-dialogs.config.js
+++ b/framework/components/ecl-dialogs/ecl-dialogs.config.js
@@ -1,11 +1,30 @@
 module.exports = {
   title: 'Dialogs',
   label: 'Dialogs',
+  preview: '@preview-center-transparent',
   status: 'ready',
   tags: ['molecule'],
   context: {
     _demo: {
       scripts: `
+        // This is only for demo purposes to facilitate end-users.
+
+        // Create a link.
+        var link = document.createElement('a');
+        var text = document.createTextNode('Open dialog');
+
+        // Include textual content.
+        link.appendChild(text);
+        link.title = "Click to test the modal";
+
+        // Add necessary demo attributes.
+        link.setAttribute('href', '#dialog');
+        link.setAttribute('class', 'ecl-link');
+        link.setAttribute('data-ecl-dialog', 'ecl-dialog');
+
+        // Show the link
+        document.body.append(link);
+
         document.addEventListener('DOMContentLoaded', function () {
             ECL.dialogs();
         });
@@ -15,6 +34,7 @@ module.exports = {
       { name: 'aria-labelledby', value: 'dialog-title' },
       { name: 'aria-describedby', value: 'dialog-description' },
       { name: 'id', value: 'ecl-dialog' },
+      { name: 'aria-hidden', value: 'true' },
     ],
     dialog_title: {
       value: 'Example title',

--- a/framework/components/ecl-dialogs/ecl-dialogs.config.js
+++ b/framework/components/ecl-dialogs/ecl-dialogs.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+  title: 'Dialogs',
+  label: 'Dialogs',
+  status: 'ready',
+  tags: ['molecule'],
+  context: {
+    _demo: {
+      scripts: `
+        document.addEventListener('DOMContentLoaded', function () {
+            ECL.dialogs();
+        });
+      `,
+    },
+    extra_attributes: [
+      { name: 'aria-labelledby', value: 'dialog-title' },
+      { name: 'aria-describedby', value: 'dialog-description' },
+      { name: 'id', value: 'ecl-dialog' },
+    ],
+    dialog_title: {
+      value: 'Example title',
+      id: 'dialog-title',
+    },
+    dialog_description: {
+      value: 'Example description',
+      id: 'dialog-description',
+    },
+    dismiss: {
+      label: 'Dismiss this dialog window',
+    },
+  },
+};

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -14,15 +14,6 @@
   transform: translate(-50%, -50%);
   width: 90%;
   z-index: map-get($ecl-z-index, 'modal');
-
-  &[aria-hidden='true'],
-  &:not([aria-hidden='true']) {
-    display: none;
-  }
-
-  &[aria-hidden='false'] {
-    display: block;
-  }
 }
 
 .ecl-dialog__overlay {
@@ -33,13 +24,4 @@
   top: 0;
   width: 100%;
   z-index: map-get($ecl-z-index, 'highlight');
-
-  &[aria-hidden='true'],
-  &:not([aria-hidden='true']) {
-    display: none;
-  }
-
-  &[aria-hidden='false'] {
-    display: block;
-  }
 }

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -1,0 +1,45 @@
+/**
+ * Dialog
+ * @define dialog
+ */
+
+.ecl-dialog {
+  background-color: #fff;
+  left: 50%;
+  margin: 0;
+  padding: map-get($ecl-spacing, m);
+  position: fixed;
+  text-align: center;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 90%;
+  z-index: map-get($ecl-z-index, 'modal');
+
+  &[aria-hidden='true'],
+  &:not([aria-hidden='true']) {
+    display: none;
+  }
+
+  &[aria-hidden='false'] {
+    display: block;
+  }
+}
+
+.ecl-dialog__overlay {
+  background-color: rgba(0, 0, 0, 0.7);
+  height: 100%;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: map-get($ecl-z-index, 'highlight');
+
+  &[aria-hidden='true'],
+  &:not([aria-hidden='true']) {
+    display: none;
+  }
+
+  &[aria-hidden='false'] {
+    display: block;
+  }
+}

--- a/framework/components/ecl-dialogs/ecl-dialogs.twig
+++ b/framework/components/ecl-dialogs/ecl-dialogs.twig
@@ -1,0 +1,77 @@
+{#
+  - extra_attributes: [{
+      name: attribute name
+      value: attribute value
+    }]
+
+    Note that the `role="dialog"` attribute is added by default to extra_attributes set.
+
+  - extra_classes: additional classes to add to the component. 'ecl-dialog' is added by default.
+
+  - dialog_title: {
+    value: the title of the dialog (default: '')
+    id: the id to match an `aria-labelledby` attribute (default: '')
+    classes: classes to apply to dialog title field (default: 'ecl-sr-only')
+  }
+
+  - dialog_description: {
+    value: the description of the dialog (default: '')
+    id: the id to match an `aria-describedby` attribute (default: '')
+    classes: classes to apply to dialog description field (default: 'ecl-sr-only')
+  }
+
+  - body (block): content of the dialog (default: lorem ipsum text)
+
+  - dismiss: {
+    label: the value for the button label to close the dialog window (default: 'Dismiss this dialog window')
+  }
+#}
+
+{% set dialog_title = {
+  value: dialog_title.value|default(''),
+  id: dialog_title.id|default(''),
+  classes: dialog_title.classes|default('ecl-sr-only'),
+} %}
+
+{% set dialog_description = {
+  value: dialog_description.value|default(''),
+  id: dialog_description.id|default(''),
+  classes: dialog_description.classes|default('ecl-sr-only'),
+} %}
+
+{% set dismiss = {
+  label: dimiss.label|default('Dismiss this dialog window'),
+} %}
+
+{# Internal properties #}
+
+{% set _css_classes = 'ecl-dialog' %}
+{% set _extra_attributes = '' %}
+
+{# Internal logic - Process properties #}
+
+{% if extra_classes is defined %}
+  {% set _css_classes = _css_classes ~ ' ' ~ extra_classes %}
+{% endif %}
+
+{% if extra_attributes is defined %}
+  {% for attr in extra_attributes %}
+    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value ~ '"' %}
+  {% endfor %}
+{% endif %}
+
+{# Print result #}
+<div class="{{ _css_classes }}" {{ _extra_attributes }} role="dialog">
+  {% if dialog_title is defined %}
+  <h1 id="{{ dialog_title.id }}" class="{{ dialog_title.classes }}">{{ dialog_title.value }}</h1>
+  {% endif %}
+  {% if dialog_description is defined %}
+  <p id="{{ dialog_description.id }}" class="{{ dialog_description.classes }}">{{ dialog_description.value }}</p>
+  {% endif %}
+  {% block body %}
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce et augue quis est dignissim lacinia. Curabitur interdum iaculis sagittis. Maecenas sodales elit est, et suscipit nisl vulputate eget. Mauris vel pulvinar odio. Sed diam turpis, cursus vel congue vel, lobortis a ipsum. Donec vel quam nec enim tristique efficitur at eget nisl.
+  {% endblock %}
+  {% if dismiss is defined %}
+  <button type="button" class="ecl-message__dismiss" aria-label="{{ dismiss.label }}">&times;</button>
+  {% endif %}
+</div>

--- a/framework/components/ecl-dialogs/package.json
+++ b/framework/components/ecl-dialogs/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ec-europa/ecl-dialogs",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "0.1.0",
+  "description": "ECL Dialogs component.",
+  "main": "ecl-dialogs.scss",
+  "style": "ecl-dialogs.scss",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@ec-europa/ecl-base": "^0.6.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library#readme"
+}

--- a/framework/index.js
+++ b/framework/index.js
@@ -10,6 +10,7 @@
 
 export * from './components/ecl-accordions/accordions';
 export * from './components/ecl-dropdowns/ecl-dropdowns';
+export * from './components/ecl-dialogs/dialogs';
 export * from './components/ecl-expandables/expandables';
 // export * from './components/ecl-files/files';
 export * from './components/ecl-forms/ecl-forms-file-uploads/ecl-forms-file-uploads';

--- a/framework/index.scss
+++ b/framework/index.scss
@@ -66,6 +66,7 @@
 @import 'components/ecl-comments';
 @import 'components/ecl-context-navs';
 @import 'components/ecl-datepickers';
+@import 'components/ecl-dialogs';
 @import 'components/ecl-dropdowns';
 @import 'components/ecl-expandables';
 @import 'components/ecl-featured-items';


### PR DESCRIPTION
# PR description

Named dialog to be closer to the web specifications.
To test, please add `<a href="#dialog" class="ecl-link" data-ecl-dialog="ecl-dialog">Open dialog</a>` or similar trigger in the template to be able to run the code.

I feel this part can be better, I welcome suggestions whether should I rework a bit this from the other component. 
```
<button type="button" class="ecl-message__dismiss" aria-label="{{ dismiss.label }}">&times;</button>
``` 

I haven't included tests, as there is nothing visual without adding an actual trigger.

As this is a single-commit pull request, if you want to see history of commits, this is the [branch I will delete](https://github.com/ec-europa/europa-component-library/pull/294), but keep only for reference purpose.

# QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [x] `package.json` is up-to-date and `@ec-europa/ecl-base` is part of the dependencies
- [x] I have given the fractal status “ready” to my component
- [x] I have declared `@define mycomponent` in the SCSS file
- [x] I have specified `margin: 0;` on the CSS component
- [ ] I have provided tests
- [x] I follow the naming guidelines
- [ ] the component supports composition
- [ ] the template is fully functional
- [x] I have filled the README.md file (at least a few lines)
- [x] I have checked the dependencies
- [x] there are no hardcoded strings (all content come from the context)
