### PR TITLE
fix(ecl-links): remove .ecl-editor links after pseudo - INNO-864

### DIFF
--- a/framework/components/ecl-links/_editor-links.scss
+++ b/framework/components/ecl-links/_editor-links.scss
@@ -3,8 +3,3 @@
 .ecl-editor a {
   @include link();
 }
-
-/* stylelint-disable-next-line */
-.ecl-editor a[href^='http'] {
-  @include link-external();
-}


### PR DESCRIPTION
# PR description

remove `::after` pseudo for all links inside `.ecl-editor`

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

* [ ] `package.json` is up-to-date and `@ec-europa/ecl-base` is part of the dependencies
* [ ] I have checked the dependencies
* [ ] I have given the fractal status “ready” to my component
* [ ] I have declared `@define mycomponent` in the SCSS file
* [ ] I have specified `margin: 0;` on the CSS component
* [ ] I have provided tests
* [ ] I follow the naming guidelines
* [ ] the component supports composition
* [ ] there are no hardcoded strings (all content come from the context)
* [ ] I have filled the README.md file (at least a few lines)
* [ ] My component is listed in the root README
* [ ] My PR has the right label(s)
