### PR TITLE
feat(dialog): provide new dialog variant - INNO-873

### DIFF
--- a/framework/components/ecl-dialogs/README.md
+++ b/framework/components/ecl-dialogs/README.md
@@ -4,6 +4,15 @@ A dialog is an application window that is designed to interrupt the current
 processing of an application in order to prompt the user to enter information or
 require a response.
 
+## Normal dialog (default)
+
+Default implementation of the dialog. Will display an horizontally and vertically centered
+container with the text. When pressed, a top-right dismiss button will remove the container and its transparent overlay. The small container goes fullscreen for screens smaller than 480px.
+
+## Wide dialog
+
+Contrary to the normal dialog, when shown this variant of the dialog will always fill the entire screen no matter the user's screen size
+
 ## Resources
 
 * [WAI-ARIA dialog role](https://www.w3.org/TR/2009/WD-wai-aria-20091215/roles#dialog)

--- a/framework/components/ecl-dialogs/dialogs.js
+++ b/framework/components/ecl-dialogs/dialogs.js
@@ -69,6 +69,8 @@ export const dialogs = ({
     if (focusedElBeforeOpen) {
       focusedElBeforeOpen.focus();
     }
+
+    document.querySelector('body').classList.remove('ecl-u-disablescroll');
   }
 
   // Keyboard behaviors.
@@ -128,6 +130,8 @@ export const dialogs = ({
 
     // Handle tabbing, esc and keyboard in the dialog window.
     dialogWindow.addEventListener('keydown', handleKeyDown);
+
+    document.querySelector('body').classList.add('ecl-u-disablescroll');
   }
 
   // BIND EVENTS

--- a/framework/components/ecl-dialogs/ecl-dialogs.config.js
+++ b/framework/components/ecl-dialogs/ecl-dialogs.config.js
@@ -1,40 +1,60 @@
+const context = {
+  _demo: {
+    scripts: `
+      document.addEventListener('DOMContentLoaded', function () {
+        // This is only for demo purposes to facilitate end-users.
+
+        // Create a link.
+        var link = document.createElement('a');
+        var text = document.createTextNode('Open dialog');
+
+        // Include textual content.
+        link.appendChild(text);
+        link.title = "Click to test the modal";
+
+        // Add necessary demo attributes.
+        link.setAttribute('href', '#dialog');
+        link.setAttribute('class', 'ecl-link');
+        link.setAttribute('data-ecl-dialog', 'ecl-dialog');
+
+        // Show the link
+        document.body.appendChild(link);
+
+        ECL.dialogs();
+      });
+    `,
+  },
+  dialog_description: {
+    value: 'Example description',
+  },
+  dismiss: {
+    label: 'Dismiss this dialog window',
+  },
+};
+
 module.exports = {
   title: 'Dialogs',
   label: 'Dialogs',
+  collated: false,
   preview: '@preview-center-transparent',
   status: 'ready',
   tags: ['molecule'],
-  context: {
-    _demo: {
-      scripts: `
-        document.addEventListener('DOMContentLoaded', function () {
-          // This is only for demo purposes to facilitate end-users.
-
-          // Create a link.
-          var link = document.createElement('a');
-          var text = document.createTextNode('Open dialog');
-
-          // Include textual content.
-          link.appendChild(text);
-          link.title = "Click to test the modal";
-
-          // Add necessary demo attributes.
-          link.setAttribute('href', '#dialog');
-          link.setAttribute('class', 'ecl-link');
-          link.setAttribute('data-ecl-dialog', 'ecl-dialog');
-
-          // Show the link
-          document.body.appendChild(link);
-
-          ECL.dialogs();
-        });
-      `,
+  default: 'default',
+  variants: [
+    {
+      name: 'default',
+      label: 'Normal',
+      context: Object.assign({}, context, {
+        variant: 'default',
+      }),
     },
-    dialog_description: {
-      value: 'Example description',
+    {
+      name: 'wide',
+      label: 'Wide',
+      context: Object.assign({}, context, {
+        variant: 'wide',
+        theme: 'wide',
+      }),
     },
-    dismiss: {
-      label: 'Dismiss this dialog window',
-    },
-  },
+  ],
 };

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -45,28 +45,6 @@
   background-color: rgba($ecl-color-primary, 0.95);
 }
 
-/* stylelint-disable */
-.ecl-message__dismiss--inverted {
-  background-image: none;
-  color: #fff;
-  cursor: pointer;
-  font-size: 0.889em;
-  text-decoration: underline;
-
-  &::after {
-    border: 1px solid #fff;
-    border-radius: 50%;
-    content: '\00D7';
-    display: inline-block;
-    float: right;
-    height: 1.5em;
-    margin-left: 0.5em;
-    text-align: center;
-    width: 1.5em;
-  }
-}
-/* stylelint-enable */
-
 .ecl-dialog--wide .ecl-dialog__body {
   overflow: initial;
   width: 100%;

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -16,6 +16,10 @@
   z-index: map-get($ecl-z-index, 'modal');
 }
 
+.ecl-dialog--transparent {
+  background-color: transparent;
+}
+
 .ecl-dialog[aria-hidden='true'] {
   display: none;
 }
@@ -35,6 +39,10 @@
   z-index: map-get($ecl-z-index, 'highlight');
 }
 
+.ecl-dialog__overlay--blue {
+  background-color: rgba($ecl-color-primary, 0.95);
+}
+
 @include ecl-media-breakpoint-up('sm') {
   .ecl-dialog {
     height: auto;
@@ -44,5 +52,13 @@
     top: 50%;
     transform: translate(-50%, -50%);
     width: auto;
+  }
+
+  .ecl-dialog--wide {
+    height: 100%;
+    left: 0;
+    right: 0;
+    top: 0;
+    transform: none;
   }
 }

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -1,8 +1,6 @@
 /**
  * Dialog
  * @define dialog
- * @define u-bg-primary
- * @define button--is-active
  */
 
 .ecl-dialog {
@@ -53,7 +51,7 @@
 .ecl-dialog__title {
   clear: both;
   color: #fff;
-  font-size: 1.222em;
+  font-size: $ecl-font-size;
   margin: 0;
   padding: 2em 0;
 }

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -1,6 +1,7 @@
 /**
  * Dialog
  * @define dialog
+ * @define u-bg-primary
  */
 
 .ecl-dialog {
@@ -18,6 +19,11 @@
 
 .ecl-dialog--transparent {
   background-color: transparent;
+
+  /* postcss-bem-linter: ignore */
+  .ecl-u-bg-primary {
+    background-color: transparent;
+  }
 }
 
 .ecl-dialog[aria-hidden='true'] {
@@ -41,6 +47,10 @@
 
 .ecl-dialog__overlay--blue {
   background-color: rgba($ecl-color-primary, 0.95);
+}
+
+.ecl-dialog--wide .ecl-dialog__body {
+  width: 100%;
 }
 
 @include ecl-media-breakpoint-up('sm') {

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -2,6 +2,7 @@
  * Dialog
  * @define dialog
  * @define u-bg-primary
+ * @define button--is-active
  */
 
 .ecl-dialog {
@@ -44,9 +45,19 @@
   background-color: rgba($ecl-color-primary, 0.95);
 }
 
-.ecl-dialog--wide .ecl-dialog__body {
-  overflow: initial;
-  width: 100%;
+.ecl-dialog--wide {
+  .ecl-dialog__body {
+    overflow: initial;
+    width: 100%;
+  }
+}
+
+.ecl-dialog__title {
+  clear: both;
+  color: #fff;
+  font-size: 1.222em;
+  margin: 0;
+  padding: 2em 0;
 }
 
 @include ecl-media-breakpoint-up('sm') {

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -19,11 +19,6 @@
 
 .ecl-dialog--transparent {
   background-color: transparent;
-
-  /* postcss-bem-linter: ignore */
-  .ecl-u-bg-primary {
-    background-color: transparent;
-  }
 }
 
 .ecl-dialog[aria-hidden='true'] {
@@ -50,6 +45,7 @@
 }
 
 .ecl-dialog--wide .ecl-dialog__body {
+  overflow: initial;
   width: 100%;
 }
 
@@ -67,6 +63,7 @@
   .ecl-dialog--wide {
     height: 100%;
     left: 0;
+    overflow: auto;
     right: 0;
     top: 0;
     transform: none;

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -51,7 +51,7 @@
 .ecl-dialog__title {
   clear: both;
   color: #fff;
-  font-size: $ecl-font-size;
+  font-size: map-get($ecl-font-size, 'l');
   margin: 0;
   padding: 2em 0;
 }

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -45,11 +45,31 @@
   background-color: rgba($ecl-color-primary, 0.95);
 }
 
-.ecl-dialog--wide {
-  .ecl-dialog__body {
-    overflow: initial;
-    width: 100%;
+/* stylelint-disable */
+.ecl-message__dismiss--inverted {
+  background-image: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.889em;
+  text-decoration: underline;
+
+  &::after {
+    border: 1px solid #fff;
+    border-radius: 50%;
+    content: '\00D7';
+    display: inline-block;
+    float: right;
+    height: 1.5em;
+    margin-left: 0.5em;
+    text-align: center;
+    width: 1.5em;
   }
+}
+/* stylelint-enable */
+
+.ecl-dialog--wide .ecl-dialog__body {
+  overflow: initial;
+  width: 100%;
 }
 
 .ecl-dialog__title {

--- a/framework/components/ecl-dialogs/ecl-dialogs.scss
+++ b/framework/components/ecl-dialogs/ecl-dialogs.scss
@@ -44,7 +44,7 @@
 }
 
 .ecl-dialog--wide .ecl-dialog__body {
-  overflow: initial;
+  overflow: visible;
   width: 100%;
 }
 
@@ -53,7 +53,7 @@
   color: #fff;
   font-size: map-get($ecl-font-size, 'l');
   margin: 0;
-  padding: 2em 0;
+  padding: map-get($ecl-spacing, 'l') 0;
 }
 
 @include ecl-media-breakpoint-up('sm') {

--- a/framework/components/ecl-dialogs/ecl-dialogs.twig
+++ b/framework/components/ecl-dialogs/ecl-dialogs.twig
@@ -97,19 +97,16 @@
 
 {# Print result #}
 <div class="{{ _css_class }}" {{ _extra_attributes }} role="dialog">
-  {% if variant == 'default' %}
-    <h3 id="{{ _dialog_title.id }}" class="ecl-heading ecl-heading--h3 {{ _dialog_title.classes }}">{{ _dialog_title.value }}</h3>
-    {% if dialog_description is defined %}
-      <p id="{{ _dialog_description.id }}" class="{{ _dialog_description.classes }}">{{ _dialog_description.value }}</p>
-    {% endif %}
-    <div class="ecl-dialog__body">
-      {% block dialog_body %}
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce et augue quis est dignissim lacinia. Curabitur interdum iaculis sagittis. Maecenas sodales elit est, et suscipit nisl vulputate eget. Mauris vel pulvinar odio. Sed diam turpis, cursus vel congue vel, lobortis a ipsum. Donec vel quam nec enim tristique efficitur at eget nisl.
-      {% endblock %}
-    </div>
-  {% elseif variant == 'wide'%}
-    <p>Hello, I am wide</p>
+  <h3 id="{{ _dialog_title.id }}" class="ecl-heading ecl-heading--h3 {{ _dialog_title.classes }}">{{ _dialog_title.value }}</h3>
+  {% if dialog_description is defined %}
+    <p id="{{ _dialog_description.id }}" class="{{ _dialog_description.classes }}">{{ _dialog_description.value }}</p>
   {% endif %}
+  <div class="ecl-dialog__body">
+    {% block dialog_body %}
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce et augue quis est dignissim lacinia. Curabitur interdum iaculis sagittis. Maecenas sodales elit est, et suscipit nisl vulputate eget. Mauris vel pulvinar odio. Sed diam turpis, cursus vel congue vel, lobortis a ipsum. Donec vel quam nec enim tristique efficitur at eget nisl.
+    {% endblock %}
+  </div>
+
   {% if dismiss is defined %}
     <button type="button" class="ecl-message__dismiss" aria-label="{{ dismiss.label }}">&times;</button>
   {% endif %}

--- a/framework/components/ecl-dialogs/ecl-dialogs.twig
+++ b/framework/components/ecl-dialogs/ecl-dialogs.twig
@@ -40,6 +40,7 @@
   - dialog_body (mixed): content of the dialog (default: lorem ipsum text)
 
   - dismiss: {
+    hide: hide the default dismiss button in case you want to include a custom one in the "dialog_body" block (default: false)
     label: the value for the button label to close the dialog window (default: 'Dismiss this dialog window')
   }
 #}
@@ -65,6 +66,7 @@
 }|merge(dialog_description|default({})) %}
 
 {% set dismiss = {
+  hide: dismiss.hide|default(false),
   label: dimiss.label|default('Dismiss this dialog window'),
 } %}
 
@@ -107,7 +109,7 @@
     {% endblock %}
   </div>
 
-  {% if dismiss is defined %}
+  {% if not dismiss.hide %}
     <button type="button" class="ecl-message__dismiss" aria-label="{{ dismiss.label }}">&times;</button>
   {% endif %}
 </div>

--- a/framework/components/ecl-dialogs/ecl-dialogs.twig
+++ b/framework/components/ecl-dialogs/ecl-dialogs.twig
@@ -46,6 +46,7 @@
 
 {# Internal properties #}
 
+{% set variant = variant|default('default') %}
 {% set _dialog_id = dialog_id|default('ecl-dialog') %}
 {% set _dialog_aria_labelledby = dialog_aria_labelledby|default('ecl-dialog-title') %}
 {% set _dialog_aria_describedby = dialog_aria_describedby|default('ecl-dialog-description') %}
@@ -96,16 +97,20 @@
 
 {# Print result #}
 <div class="{{ _css_class }}" {{ _extra_attributes }} role="dialog">
-  <h3 id="{{ _dialog_title.id }}" class="ecl-heading ecl-heading--h3 {{ _dialog_title.classes }}">{{ _dialog_title.value }}</h3>
-  {% if dialog_description is defined %}
-  <p id="{{ _dialog_description.id }}" class="{{ _dialog_description.classes }}">{{ _dialog_description.value }}</p>
+  {% if variant == 'default' %}
+    <h3 id="{{ _dialog_title.id }}" class="ecl-heading ecl-heading--h3 {{ _dialog_title.classes }}">{{ _dialog_title.value }}</h3>
+    {% if dialog_description is defined %}
+      <p id="{{ _dialog_description.id }}" class="{{ _dialog_description.classes }}">{{ _dialog_description.value }}</p>
+    {% endif %}
+    <div class="ecl-dialog__body">
+      {% block dialog_body %}
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce et augue quis est dignissim lacinia. Curabitur interdum iaculis sagittis. Maecenas sodales elit est, et suscipit nisl vulputate eget. Mauris vel pulvinar odio. Sed diam turpis, cursus vel congue vel, lobortis a ipsum. Donec vel quam nec enim tristique efficitur at eget nisl.
+      {% endblock %}
+    </div>
+  {% elseif variant == 'wide'%}
+    <p>Hello, I am wide</p>
   {% endif %}
-  <div class="ecl-dialog__body">
-    {% block dialog_body %}
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce et augue quis est dignissim lacinia. Curabitur interdum iaculis sagittis. Maecenas sodales elit est, et suscipit nisl vulputate eget. Mauris vel pulvinar odio. Sed diam turpis, cursus vel congue vel, lobortis a ipsum. Donec vel quam nec enim tristique efficitur at eget nisl.
-    {% endblock %}
-  </div>
   {% if dismiss is defined %}
-  <button type="button" class="ecl-message__dismiss" aria-label="{{ dismiss.label }}">&times;</button>
+    <button type="button" class="ecl-message__dismiss" aria-label="{{ dismiss.label }}">&times;</button>
   {% endif %}
 </div>

--- a/framework/components/ecl-messages/_messages.scss
+++ b/framework/components/ecl-messages/_messages.scss
@@ -83,4 +83,8 @@
     text-align: center;
     width: 1.5em;
   }
+
+  &:hover {
+    background-image: none;
+  }
 }

--- a/framework/components/ecl-messages/_messages.scss
+++ b/framework/components/ecl-messages/_messages.scss
@@ -64,3 +64,23 @@
     background-image: url('../images/close_hover.svg');
   }
 }
+
+.ecl-message__dismiss--inverted {
+  background-image: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.889em;
+  text-decoration: underline;
+
+  &::after {
+    border: 1px solid #fff;
+    border-radius: 50%;
+    content: '\00D7';
+    display: inline-block;
+    float: right;
+    height: 1.5em;
+    margin-left: 0.5em;
+    text-align: center;
+    width: 1.5em;
+  }
+}


### PR DESCRIPTION
# PR description

Creation of the new `wide` variant that will display the `ecl-dialog` on the entire screen. This branch is constantly being merged with #530 so please review that first.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

* [x] `package.json` is up-to-date and `@ec-europa/ecl-base` is part of the dependencies
* [x] I have checked the dependencies
* [x] I have given the fractal status “ready” to my component
* [x] I have declared `@define mycomponent` in the SCSS file
* [x] I have specified `margin: 0;` on the CSS component
* [x] I have provided tests
* [x] I follow the naming guidelines
* [x] the component supports composition
* [x] there are no hardcoded strings (all content come from the context)
* [x] I have filled the README.md file (at least a few lines)
* [x] My component is listed in the root README
* [x] My PR has the right label(s)
