### PR TITLE
fix(dependency): add missing ecl-language-list dependency - no issue

### DIFF
--- a/packages/presets/ecl-preset-full/package.json
+++ b/packages/presets/ecl-preset-full/package.json
@@ -49,6 +49,7 @@
     "@ec-europa/ecl-labels": "^0.7.0",
     "@ec-europa/ecl-lang-select-pages": "^0.8.0",
     "@ec-europa/ecl-lang-select-sites": "^0.9.0",
+    "@ec-europa/ecl-language-list": "^0.1.0",
     "@ec-europa/ecl-legacy-bootstrap-grid": "^0.3.2",
     "@ec-europa/ecl-link-blocks": "^0.8.3",
     "@ec-europa/ecl-links": "^0.10.3",


### PR DESCRIPTION
# PR description

Add missing dependency. `ecl-language-list` was not listed in `ecl-preset-full`