### PR TITLE
fix(typography): add missing spacing in ecl-editor - INNO-871

### DIFF
--- a/framework/content/ecl-typography/ecl-typography-headings/_editor-headings.scss
+++ b/framework/content/ecl-typography/ecl-typography-headings/_editor-headings.scss
@@ -1,22 +1,33 @@
 // Headers
 @import 'headings-mixins';
 
+.ecl-editor {
+  * + h1 {
+    margin-top: map-get($ecl-spacing, 'xxl');
+  }
+
+  * + h2 {
+    margin-top: map-get($ecl-spacing, 'xl');
+  }
+
+  * + h3 {
+    margin-top: map-get($ecl-spacing, 'l');
+  }
+}
+
 .ecl-editor h1 {
   @include heading();
   @include heading-1();
-  margin-top: map-get($ecl-spacing, 'xxl');
 }
 
 .ecl-editor h2 {
   @include heading();
   @include heading-2();
-  margin-top: map-get($ecl-spacing, 'xl');
 }
 
 .ecl-editor h3 {
   @include heading();
   @include heading-3();
-  margin-top: map-get($ecl-spacing, 'l');
 }
 
 .ecl-editor h4 {

--- a/framework/content/ecl-typography/ecl-typography-headings/_editor-headings.scss
+++ b/framework/content/ecl-typography/ecl-typography-headings/_editor-headings.scss
@@ -4,16 +4,19 @@
 .ecl-editor h1 {
   @include heading();
   @include heading-1();
+  margin-top: map-get($ecl-spacing, 'xxl');
 }
 
 .ecl-editor h2 {
   @include heading();
   @include heading-2();
+  margin-top: map-get($ecl-spacing, 'xl');
 }
 
 .ecl-editor h3 {
   @include heading();
   @include heading-3();
+  margin-top: map-get($ecl-spacing, 'l');
 }
 
 .ecl-editor h4 {

--- a/framework/content/ecl-typography/ecl-typography-headings/_editor-headings.scss
+++ b/framework/content/ecl-typography/ecl-typography-headings/_editor-headings.scss
@@ -1,20 +1,6 @@
 // Headers
 @import 'headings-mixins';
 
-.ecl-editor {
-  * + h1 {
-    margin-top: map-get($ecl-spacing, 'xxl');
-  }
-
-  * + h2 {
-    margin-top: map-get($ecl-spacing, 'xl');
-  }
-
-  * + h3 {
-    margin-top: map-get($ecl-spacing, 'l');
-  }
-}
-
 .ecl-editor h1 {
   @include heading();
   @include heading-1();
@@ -38,4 +24,18 @@
 .ecl-editor h5 {
   @include heading();
   @include heading-5();
+}
+
+.ecl-editor {
+  * + h1 {
+    margin-top: map-get($ecl-spacing, 'xxl');
+  }
+
+  * + h2 {
+    margin-top: map-get($ecl-spacing, 'xl');
+  }
+
+  * + h3 {
+    margin-top: map-get($ecl-spacing, 'l');
+  }
 }

--- a/framework/content/ecl-typography/ecl-typography-headings/_headings-mixins.scss
+++ b/framework/content/ecl-typography/ecl-typography-headings/_headings-mixins.scss
@@ -1,5 +1,5 @@
 @mixin heading() {
-  margin: 0;
+  margin: 0 0 map-get($ecl-spacing, 'm');
   padding: 0;
 }
 

--- a/framework/content/ecl-typography/ecl-typography-headings/_headings.scss
+++ b/framework/content/ecl-typography/ecl-typography-headings/_headings.scss
@@ -3,8 +3,6 @@
 
 .ecl-heading {
   @include heading();
-
-  margin-bottom: map-get($ecl-spacing, 'm');
 }
 
 .ecl-heading--h1 {


### PR DESCRIPTION
# PR description

Adds margin top for headings inside the ecl-editor

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

* [ ] `package.json` is up-to-date and `@ec-europa/ecl-base` is part of the dependencies
* [x] I have checked the dependencies
* [x] I have given the fractal status “ready” to my component
* [x] I have declared `@define mycomponent` in the SCSS file
* [ ] I have specified `margin: 0;` on the CSS component
* [ ] I have provided tests
* [x] I follow the naming guidelines
* [x] the component supports composition
* [x] there are no hardcoded strings (all content come from the context)
* [x] I have filled the README.md file (at least a few lines)
* [x] My component is listed in the root README
* [ ] My PR has the right label(s)
