### PR TITLE
fix(ecl-components): add raw modifier - INNO-925

### DIFF
--- a/framework/components/ecl-banners/ecl-banners.twig
+++ b/framework/components/ecl-banners/ecl-banners.twig
@@ -25,6 +25,6 @@
   {% endfor %}
 {% endif %}
 
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% include '@ec-europa/ecl-blockquotes' with { 'extra_classes': 'ecl-blockquote--small ecl-banner__quote' }|merge(quote) %}
 </div>

--- a/framework/components/ecl-blockquotes/ecl-blockquotes.twig
+++ b/framework/components/ecl-blockquotes/ecl-blockquotes.twig
@@ -23,7 +23,7 @@
   {% endfor %}
 {% endif %}
 
-<blockquote class="{{ _css_classes }}"{{ _extra_attributes }}>
+<blockquote class="{{ _css_classes }}"{{ _extra_attributes|raw }}>
   <p class="ecl-paragraph ecl-blockquote__body">{{ body|default("")|trim }}</p>
   {% if author is defined and author is not empty %}
   <footer class="ecl-blockquote__author">―&thinsp;<cite>{{ author }}</cite></footer>

--- a/framework/components/ecl-buttons/ecl-buttons.twig
+++ b/framework/components/ecl-buttons/ecl-buttons.twig
@@ -47,7 +47,7 @@
 {# Print result #}
 
 {% if _type == 'link' %}
-  <a href="{{ _href }}" class="{{ _css_class }}"{{ _extra_attributes }}>{% block link_label_block _label %}</a>
+  <a href="{{ _href }}" class="{{ _css_class }}"{{ _extra_attributes|raw }}>{% block link_label_block _label %}</a>
 {% else %}
   <button class="{{ _css_class }}"{{ _extra_attributes|raw }}>{% block button_label_block _label %}</button>
 {% endif %}

--- a/framework/components/ecl-buttons/ecl-buttons.twig
+++ b/framework/components/ecl-buttons/ecl-buttons.twig
@@ -49,5 +49,5 @@
 {% if _type == 'link' %}
   <a href="{{ _href }}" class="{{ _css_class }}"{{ _extra_attributes }}>{% block link_label_block _label %}</a>
 {% else %}
-  <button class="{{ _css_class }}"{{ _extra_attributes }}>{% block button_label_block _label %}</button>
+  <button class="{{ _css_class }}"{{ _extra_attributes|raw }}>{% block button_label_block _label %}</button>
 {% endif %}

--- a/framework/components/ecl-carousels/ecl-carousels.twig
+++ b/framework/components/ecl-carousels/ecl-carousels.twig
@@ -98,7 +98,7 @@ Usage:
 {% set _heading_attributes = _heading_attributes ~ 'id="' ~ _heading_id ~ '"' %}
 
 {# Print result #}
-<section class="{{ _css_class }}" {{ _extra_attributes }}>
+<section class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <h3 class="ecl-headings ecl-headings--h3 ecl-u-sr-only" {{ _heading_attributes }} >{{ _heading_title }}</h3>
   <div class="ecl-carousel__list-wrapper">
     <ul class="ecl-carousel__list ecl-list--unstyled">

--- a/framework/components/ecl-comments/ecl-comments.twig
+++ b/framework/components/ecl-comments/ecl-comments.twig
@@ -33,7 +33,7 @@
   {% endfor %}
 {% endif %}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   {% if image is defined %}
   <div class="ecl-comment__image-wrapper">
     <img class="ecl-comment__image" src="{{ image.src }}" alt="{{ image.alt }}">

--- a/framework/components/ecl-context-navs/ecl-context-navs.twig
+++ b/framework/components/ecl-context-navs/ecl-context-navs.twig
@@ -33,7 +33,7 @@
 
 {# Print the result  #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <span class="ecl-context-nav__label">{{ label }}</span>
   {% if items is defined and items is iterable %}
   <ul class="ecl-context-nav__list">

--- a/framework/components/ecl-date-blocks/ecl-date-blocks.twig
+++ b/framework/components/ecl-date-blocks/ecl-date-blocks.twig
@@ -37,7 +37,7 @@
 
 {# Print the result  #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-date-block__body">
     {% if week_day != '' %}
     <span class="ecl-date-block__week-day">{{ week_day }}</span>

--- a/framework/components/ecl-datepickers/ecl-datepickers.twig
+++ b/framework/components/ecl-datepickers/ecl-datepickers.twig
@@ -25,7 +25,7 @@
 {% endif %}
 
 {% spaceless %}
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% include '@ec-europa/ecl-forms-text-inputs' with {
     'type': 'text',
     'id': _id,

--- a/framework/components/ecl-dialogs/ecl-dialogs.twig
+++ b/framework/components/ecl-dialogs/ecl-dialogs.twig
@@ -98,7 +98,7 @@
 {% set _extra_attributes = _extra_attributes ~ ' ' ~ 'aria-hidden="' ~ _dialog_aria_hidden ~ '"' %}
 
 {# Print result #}
-<div class="{{ _css_class }}" {{ _extra_attributes }} role="dialog">
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }} role="dialog">
   <h3 id="{{ _dialog_title.id }}" class="ecl-heading ecl-heading--h3 {{ _dialog_title.classes }}">{{ _dialog_title.value }}</h3>
   {% if dialog_description is defined %}
     <p id="{{ _dialog_description.id }}" class="{{ _dialog_description.classes }}">{{ _dialog_description.value }}</p>

--- a/framework/components/ecl-featured-items/ecl-featured-items.twig
+++ b/framework/components/ecl-featured-items/ecl-featured-items.twig
@@ -43,7 +43,7 @@
 
 {# Print result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-featured-item__image">
     <img src="{{ image.src }}" alt="{{ image.alt }}" />
   </div>

--- a/framework/components/ecl-files/ecl-files.twig
+++ b/framework/components/ecl-files/ecl-files.twig
@@ -76,7 +76,7 @@
   {% if variant == "translation" %}
 
 <!-- Translations -->
-<section class="{{ _css_class }}"{{ _extra_attributes }}>
+<section class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <div class="ecl-file__body">
     <div class="ecl-row">
       <div class=" ecl-col ecl-col-md-8">
@@ -140,7 +140,7 @@
   {% elseif variant == "link" %}
 
 <!-- Links -->
-<section class="{{ _css_class }}"{{ _extra_attributes }}>
+<section class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if links is defined %}
     {% for link in links %}
       <a
@@ -159,7 +159,7 @@
   {% elseif variant == "image" %}
 
 <!-- Images -->
-<section class="{{ _css_class }}"{{ _extra_attributes }}>
+<section class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <img class="ecl-file__image" src="{{ src }}" alt="{{ alt }}">
   <div class="ecl-file__caption">{{ caption }}</div>
 </section>
@@ -167,7 +167,7 @@
   {% elseif variant == "video" %}
 
 <!-- Videos -->
-<section class="{{ _css_class }}"{{ _extra_attributes }}>
+<section class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if src is defined %}
     {% if is_iframe is defined and is_iframe %}
   <div {% if ratio is defined %} class="ecl-u-ratio-{{ ratio }}" {% endif %}>
@@ -187,7 +187,7 @@
 {% else %}
 
 <!-- Default -->
-<section class="{{ _css_class }}"{{ _extra_attributes }}>
+<section class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <div class="ecl-file__body">
     <div class="ecl-row">
       <div class=" ecl-col ecl-col-md-8">

--- a/framework/components/ecl-forms/ecl-forms-feedback-messages/ecl-forms-feedback-messages.twig
+++ b/framework/components/ecl-forms/ecl-forms-feedback-messages/ecl-forms-feedback-messages.twig
@@ -26,7 +26,7 @@
   {% endfor %}
 {% endif %}
 
-<div class="{{ _css_class }}" role="alert"{{ _extra_attributes }}>
+<div class="{{ _css_class }}" role="alert"{{ _extra_attributes|raw }}>
   <div class="ecl-feedback-message__title" role="heading">{{ title }}</div>
   <p class="ecl-feedback-message__body">{{ body }}</p>
 </div>

--- a/framework/components/ecl-forms/ecl-forms-fieldsets/ecl-forms-fieldsets.twig
+++ b/framework/components/ecl-forms/ecl-forms-fieldsets/ecl-forms-fieldsets.twig
@@ -15,6 +15,6 @@
   {% endfor %}
 {% endif %}
 
-<fieldset class="{{ _css_class }}"{{ _extra_attributes }}>
+<fieldset class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% block fieldset content %}
 </fieldset>

--- a/framework/components/ecl-forms/ecl-forms-file-uploads/ecl-forms-file-uploads.twig
+++ b/framework/components/ecl-forms/ecl-forms-file-uploads/ecl-forms-file-uploads.twig
@@ -49,7 +49,7 @@
 
 {# Print the result  #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-file-upload__value" tabindex="0">{{ value }}</div>
   <label for="{{ id }}">
     <span class="ecl-file-upload__browse" role="button" aria-controls="{{ id }}" tabindex="0">{{ label_browse }}</span>

--- a/framework/components/ecl-forms/ecl-forms-form-groups/ecl-forms-form-groups.twig
+++ b/framework/components/ecl-forms/ecl-forms-form-groups/ecl-forms-form-groups.twig
@@ -1,18 +1,11 @@
 {# Internal properties #}
 
 {% set _css_class = 'ecl-form-group' %}
-{% set _extra_attributes = '' %}
 
 {# Internal logic - Process properties #}
 
 {% if extra_class is defined %}
   {% set _css_class = _css_class ~ ' ' ~ extra_class %}
-{% endif %}
-
-{% if extra_attributes is defined %}
-  {% for attr in extra_attributes %}
-    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value ~ '"' %}
-  {% endfor %}
 {% endif %}
 
 <div class="ecl-form-group">

--- a/framework/components/ecl-forms/ecl-forms-help-blocks/ecl-forms-help-blocks.twig
+++ b/framework/components/ecl-forms/ecl-forms-help-blocks/ecl-forms-help-blocks.twig
@@ -23,4 +23,4 @@
   {% endfor %}
 {% endif %}
 
-<p class="{{ _css_class }}"{{ _extra_attributes }}>{% block help_block content %}</p>
+<p class="{{ _css_class }}"{{ _extra_attributes|raw }}>{% block help_block content %}</p>

--- a/framework/components/ecl-forms/ecl-forms-labels/ecl-forms-labels.twig
+++ b/framework/components/ecl-forms/ecl-forms-labels/ecl-forms-labels.twig
@@ -18,4 +18,4 @@
   {% endfor %}
 {% endif %}
 
-<label class="{{ _css_class }}"{{ _extra_attributes }}{{ for_attribute is defined ? ' for="' ~ for_attribute ~ '"'  : '' }}>{% block label label %}</label>
+<label class="{{ _css_class }}"{{ _extra_attributes|raw }}{{ for_attribute is defined ? ' for="' ~ for_attribute ~ '"'  : '' }}>{% block label label %}</label>

--- a/framework/components/ecl-forms/ecl-forms-legends/ecl-forms-legends.twig
+++ b/framework/components/ecl-forms/ecl-forms-legends/ecl-forms-legends.twig
@@ -21,7 +21,7 @@
 {% endif %}
 
 {% spaceless %}
-<legend class="{{ _css_class }}"{{ _extra_attributes }}>
+<legend class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {%- block legend content -%}
 </legend>
 {% endspaceless %}

--- a/framework/components/ecl-forms/ecl-forms-selects/ecl-forms-selects.twig
+++ b/framework/components/ecl-forms/ecl-forms-selects/ecl-forms-selects.twig
@@ -46,7 +46,7 @@
   class="{{ _css_class }}"
   id="{{ id }}"
   name="{{ name }}"
-  {{ _extra_attributes }}
+  {{ _extra_attributes|raw }}
 >
 {% block options %}
   {% for option in options %}

--- a/framework/components/ecl-labels/ecl-labels.twig
+++ b/framework/components/ecl-labels/ecl-labels.twig
@@ -31,4 +31,4 @@
 
 {# Print the result  #}
 
-<span class="{{ _css_class }}" {{ _extra_attributes }}>{{ body }}</span>
+<span class="{{ _css_class }}" {{ _extra_attributes|raw }}>{{ body }}</span>

--- a/framework/components/ecl-lang-select-pages/ecl-lang-select-pages.twig
+++ b/framework/components/ecl-lang-select-pages/ecl-lang-select-pages.twig
@@ -34,7 +34,7 @@
   {% endfor %}
 {% endif %}
 
-<section class="{{ _css_class }}" {{ _extra_attributes }}>
+<section class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <span class="ecl-icon ecl-icon--generic-lang ecl-lang-select-page__icon"></span>
   <span class="ecl-lang-select-page__unavailable">{{ _unavailable }}</span>
   <select class="ecl-lang-select-page__dropdown" aria-label="{{ _dropdown_label }}">

--- a/framework/components/ecl-lang-select-sites/ecl-lang-select-sites.twig
+++ b/framework/components/ecl-lang-select-sites/ecl-lang-select-sites.twig
@@ -24,7 +24,7 @@
   {% endfor %}
 {% endif %}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <a href="{{ _link }}" class="ecl-lang-select-sites__link">
     <span class="ecl-lang-select-sites__label">{{ _language }}</span>
     <span class="ecl-lang-select-sites__code">

--- a/framework/components/ecl-language-list/ecl-language-list.twig
+++ b/framework/components/ecl-language-list/ecl-language-list.twig
@@ -69,7 +69,7 @@
 {% endset %}
 
 {# Print result #}
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if _variant == 'overlay' %}
     {# Custom Dialog-overlay for the 'overlay' variant #}
     <div id="ecl-overlay-language-list" class="ecl-dialog__overlay ecl-dialog__overlay--blue" aria-hidden="true"></div>

--- a/framework/components/ecl-link-blocks/ecl-link-blocks.twig
+++ b/framework/components/ecl-link-blocks/ecl-link-blocks.twig
@@ -27,7 +27,7 @@
   {% endfor %}
 {% endif %}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   {% if title != '' %}
     <div class="ecl-link-block__title">{{ title }}</div>
   {% endif %}

--- a/framework/components/ecl-links/ecl-links.twig
+++ b/framework/components/ecl-links/ecl-links.twig
@@ -31,4 +31,4 @@
 {% endif %}
 
 {# Print result #}
-<a class="{{ _css_class }}" href="{{ _href }}"{{ _extra_attributes }}>{% block label _label %}</a>
+<a class="{{ _css_class }}" href="{{ _href }}"{{ _extra_attributes|raw }}>{% block label _label %}</a>

--- a/framework/components/ecl-list-items/ecl-list-items.twig
+++ b/framework/components/ecl-list-items/ecl-list-items.twig
@@ -50,7 +50,7 @@
 
 {# Print result #}
 
-<li class="{{ _css_class }}" {{ _extra_attributes }}>
+<li class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <a href="{{ href }}" class="ecl-link ecl-list-item__link">
     <div class="ecl-u-sr-only">{{ _screen_reader }}</div>
 

--- a/framework/components/ecl-listings/ecl-listings.twig
+++ b/framework/components/ecl-listings/ecl-listings.twig
@@ -29,7 +29,7 @@
 
 {# Print result #}
 
-<ul class="{{ _css_class }}" {{ _extra_attributes }}>
+<ul class="{{ _css_class }}" {{ _extra_attributes|raw }}>
 
 {% for item in items %}
 

--- a/framework/components/ecl-meta/ecl-meta.twig
+++ b/framework/components/ecl-meta/ecl-meta.twig
@@ -29,7 +29,7 @@
 
 {# Print result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   {% for meta in metas %}
 
     <span class="ecl-meta__item">{{ meta }}</span>

--- a/framework/components/ecl-navigation/ecl-navigation-lists/ecl-navigation-lists.twig
+++ b/framework/components/ecl-navigation/ecl-navigation-lists/ecl-navigation-lists.twig
@@ -29,7 +29,7 @@
 
 {# Print result #}
 
-<nav class="{{ _css_class }}" {{ _extra_attributes }}>
+<nav class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <h2 class="ecl-u-sr-only">{{ title|default('Navigation') }}</h2>
   <ul class="ecl-navigation-list ecl-navigation-list--{{ variant|default('default') }}">
     {% for link in links %}

--- a/framework/components/ecl-navigation/ecl-navigation-menus/ecl-navigation-menus.twig
+++ b/framework/components/ecl-navigation/ecl-navigation-menus/ecl-navigation-menus.twig
@@ -40,7 +40,7 @@
 
 {# Print the result  #}
 
-<nav class="{{ _css_class }}" aria-label="{{ menu_aria_label }}"{{ _extra_attributes }}>
+<nav class="{{ _css_class }}" aria-label="{{ menu_aria_label }}"{{ _extra_attributes|raw }}>
   <div class="ecl-container">
     <button class="ecl-navigation-menu__toggle ecl-navigation-menu__hamburger ecl-navigation-menu__hamburger--squeeze" aria-controls="nav-menu-expandable-root" aria-expanded="false">
       <span class="ecl-navigation-menu__hamburger-box">

--- a/framework/components/ecl-pagers/ecl-pagers.twig
+++ b/framework/components/ecl-pagers/ecl-pagers.twig
@@ -42,7 +42,7 @@
 {# Print the result  #}
 
 <nav class="ecl-pager__wrapper" aria-label="pagination">
-  <ul class="{{ _css_class }}" {{ _extra_attributes }}>
+  <ul class="{{ _css_class }}" {{ _extra_attributes|raw }}>
     {% if current_page > 1 %}
     <li class="ecl-pager__item ecl-pager__item--previous">
       <a class="ecl-pager__link" title="{{ title_previous }}" href="{{ fragment_url }}={{ current_page - 1 }}">{{ label_previous }}</a>

--- a/framework/components/ecl-profile-topbars/ecl-profile-topbars.twig
+++ b/framework/components/ecl-profile-topbars/ecl-profile-topbars.twig
@@ -30,7 +30,7 @@
 
 {# Print result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-container">
     <div class="ecl-row">
       <div class="ecl-col-md-2">

--- a/framework/components/ecl-search-forms/ecl-search-forms.twig
+++ b/framework/components/ecl-search-forms/ecl-search-forms.twig
@@ -33,7 +33,7 @@
 {% endif %}
 
 {# Print result #}
-<form class="{{ _css_class }}"{{ _extra_attributes }}>
+<form class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <label class="ecl-search-form__textfield-wrapper">
     <span class="ecl-u-sr-only">{{ _aria_label }}</span>
     {% include '@ec-europa/ecl-forms-text-inputs' with {

--- a/framework/components/ecl-site-headers/ecl-site-headers.twig
+++ b/framework/components/ecl-site-headers/ecl-site-headers.twig
@@ -49,7 +49,7 @@
 {% endif %}
 
 {# Print result #}
-<header class="{{ _css_class }}" role="banner"{{ _extra_attributes }}>
+<header class="{{ _css_class }}" role="banner"{{ _extra_attributes|raw }}>
 
   {% if user_menu is defined and user_menu is iterable %}
   <div class="ecl-container">

--- a/framework/components/ecl-site-switchers/ecl-site-switchers.twig
+++ b/framework/components/ecl-site-switchers/ecl-site-switchers.twig
@@ -33,7 +33,7 @@
 {% endif %}
 
 {# Print result #}
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <ul class="ecl-site-switcher__list ecl-container">
       <li class="ecl-site-switcher__option{{ political.is_active ? ' ecl-site-switcher__option--is-selected' : '' }}"><a class="ecl-link ecl-site-switcher__link" href="{{ political.href }}">{{ political.label }}</a></li>
       <li class="ecl-site-switcher__option{{ info.is_active ? ' ecl-site-switcher__option--is-selected' : '' }}"><a class="ecl-link ecl-site-switcher__link" href="{{ info.href }}">{{ info.label }}</a></li>

--- a/framework/components/ecl-skip-links/ecl-skip-links.twig
+++ b/framework/components/ecl-skip-links/ecl-skip-links.twig
@@ -29,6 +29,6 @@
 
 {# Print result #}
 
-<div class="{{ _css_class }}" id="{{ _id }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" id="{{ _id }}" {{ _extra_attributes|raw }}>
   <a href="{{ _href }}" class="ecl-skip-link">{{ _label }}</a>
 </div>

--- a/framework/components/ecl-social-icons/ecl-social-icons.twig
+++ b/framework/components/ecl-social-icons/ecl-social-icons.twig
@@ -52,5 +52,5 @@
   extra_attributes: _extra_attributes,
 } %}
 {% else %}
-<span class="{{ _css_class }}" {{ _extra_attributes }}>{{ label }}</span>
+<span class="{{ _css_class }}" {{ _extra_attributes|raw }}>{{ label }}</span>
 {% endif %}

--- a/framework/components/ecl-social-media-links/ecl-social-media-links.twig
+++ b/framework/components/ecl-social-media-links/ecl-social-media-links.twig
@@ -48,7 +48,7 @@
 
 {# Print result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   {% block text_block %}
   {% if has_text == true %}
   <p class="ecl-paragraph">{{ _text }}</p>

--- a/framework/components/ecl-tables/ecl-tables.twig
+++ b/framework/components/ecl-tables/ecl-tables.twig
@@ -41,7 +41,7 @@
 
 {# Print result #}
 
-<table class="{{ _css_class }}" {{ _extra_attributes }}>
+<table class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <thead>
     {% for header in headers %}
     <tr>

--- a/framework/components/ecl-tags/ecl-tags.twig
+++ b/framework/components/ecl-tags/ecl-tags.twig
@@ -32,7 +32,7 @@
   {% endfor %}
 {% endif %}
 
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if _label is not empty %}
     <span class="ecl-tag__label">{{ label }}</span>
   {% endif %}

--- a/framework/components/ecl-timelines/ecl-timelines.twig
+++ b/framework/components/ecl-timelines/ecl-timelines.twig
@@ -28,7 +28,7 @@
   {% endfor %}
 {% endif %}
 
-<section class="{{ _css_class }}"{{ _extra_attributes }}>
+<section class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <ul class="ecl-timeline__list">
     {% for item in items %}
     <li class="ecl-timeline__item{{ limit is defined and limit > 0 and loop.index > limit ? ' ecl-timeline__item--over-limit' : '' }}">

--- a/framework/content/ecl-images/ecl-images.twig
+++ b/framework/content/ecl-images/ecl-images.twig
@@ -38,7 +38,7 @@
 
 <picture
   {% if _css_class is not empty %}class="{{ _css_class }}"{% endif %}
-  {{ _extra_attributes }}>
+  {{ _extra_attributes|raw }}>
 
   {% if srcs.xl is defined and srcs.xl is not empty %}
   <source media="(min-width: 1200px)" srcset="{{ srcs.xl }}">
@@ -69,6 +69,6 @@
   {% if _css_class is not empty %}class="{{ _css_class }}"{% endif %}
   alt="{{ alt }}"
   src="{{ _src }}"
-  {{ _extra_attributes }} />
+  {{ _extra_attributes|raw }} />
 
 {% endif %}


### PR DESCRIPTION
# PR description

It seems we are having a misalignment between how PHP Twig renders extra attributes array and how TwigJS does.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

* [x] `package.json` is up-to-date and `@ec-europa/ecl-base` is part of the dependencies
* [x] I have checked the dependencies
* [x] I have given the fractal status “ready” to my component
* [x] I have declared `@define mycomponent` in the SCSS file
* [x] I have specified `margin: 0;` on the CSS component
* [x] I have provided tests
* [x] I follow the naming guidelines
* [x] the component supports composition
* [x] there are no hardcoded strings (all content come from the context)
* [x] I have filled the README.md file (at least a few lines)
* [x] My component is listed in the root README
* [x] My PR has the right label(s)
