### PR TITLE
fix(eslintignore): fix eslintignore rules - no issue

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,3 @@
-/dist
+dist
 /static/framework
 node_modules
-
-# this is only for prettier (atom extension doesn't support .prettierignore)
-package.json


### PR DESCRIPTION
Because there was a `dist` folder in `demo/webpack`, running `yarn lint:js` ran forever. Now fixed.

+ unnecessary rule removed