### PR TITLE
refactor(tests): introduce new goToComponent command - INNO-927

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
     "start:ec": "cd packages/styleguides/ec && npm run start",
     "start:eu": "cd packages/styleguides/eu && npm run start",
     "test:coding-conventions": "npm run lint",
-    "test:functional": "run-s test:functional:*",
-    "test:functional:ec": "wdio test/wdio.conf.js",
-    "test:functional:eu": "FLAVOR=eu wdio test/wdio.conf.js"
+    "test:functional": "wdio test/wdio.conf.js"
   },
   "devDependencies": {
     "@ec-europa/ecl-qa": "0.4.0",

--- a/src/flavors/ec/components/ecl-buttons-ec/test/spec/buttons.js
+++ b/src/flavors/ec/components/ecl-buttons-ec/test/spec/buttons.js
@@ -15,7 +15,7 @@ describe('buttons', () => {
     describe(`--${variant}`, () => {
       before(() => {
         // Go to url
-        browser.url(`ecl-buttons-ec--${variant}.html`);
+        browser.goToComponent('ecl-buttons-ec', variant);
 
         // Inject axe-core (for accessibility tests)
         browser.injectAxeCore();
@@ -50,7 +50,7 @@ describe('buttons', () => {
       context('with hover state', () => {
         before(() => {
           // Reload
-          browser.url(`ecl-buttons-ec--${variant}.html`);
+          browser.goToComponent('ecl-buttons-ec', variant);
           browser.injectAxeCore();
           browser.pause(500);
 

--- a/test/utils/getFlavor.js
+++ b/test/utils/getFlavor.js
@@ -1,1 +1,0 @@
-module.exports = () => (process.env.FLAVOR ? process.env.FLAVOR : 'ec');

--- a/test/utils/specs.js
+++ b/test/utils/specs.js
@@ -21,7 +21,7 @@ module.exports.getSpecs = () => {
   // By default, test all the specs
   const pattern = path.resolve(
     __dirname,
-    '../../src/flavors/ec/**/test/spec/**/*.js'
+    '../../src/flavors/**/test/spec/**/*.js'
   );
   let specs = glob.sync(pattern, { ignore: ['**/node_modules/**'] });
 

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -33,10 +33,10 @@ const localServer = !isDrone; // with drone, builds are pushed onto AWS S3
 // Other properties
 const useSauceConnect = localServer && !isTravis; // travis uses its own Sauce Connect launcher
 const baseUrl = localServer
-  ? 'http://localhost:3000'
+  ? 'http://localhost:3000/'
   : `http://inno-ecl.s3-website-eu-west-1.amazonaws.com/build/${
       process.env.DRONE_BUILD_NUMBER
-    }`;
+    }/`;
 
 require('dotenv').config(); // eslint-disable-line import/no-extraneous-dependencies
 
@@ -201,7 +201,7 @@ exports.config = {
 
     browser.addCommand('goToComponent', (component, variant) => {
       const flavor = component.match(/(ec|eu)$/g);
-      const prefix = `/flavors/${flavor}/components/preview`;
+      const prefix = `flavors/${flavor}/components/preview`;
       const page = `${component}${variant && `--${variant}`}.html`;
       return browser.url(`${prefix}/${page}`);
     });

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -21,8 +21,6 @@ const { getCapabilities } = require('./utils/capabilities');
 const { isTravis } = require('./utils/travis');
 const { isDrone } = require('./utils/drone');
 
-const flavor = require('./utils/getFlavor')();
-
 const tunnelIdentifier =
   isTravis || isDrone
     ? process.env[`${isTravis ? 'TRAVIS' : 'DRONE'}_JOB_NUMBER`]
@@ -35,10 +33,10 @@ const localServer = !isDrone; // with drone, builds are pushed onto AWS S3
 // Other properties
 const useSauceConnect = localServer && !isTravis; // travis uses its own Sauce Connect launcher
 const baseUrl = localServer
-  ? `http://localhost:3000/flavors/${flavor}/components/preview/`
+  ? 'http://localhost:3000'
   : `http://inno-ecl.s3-website-eu-west-1.amazonaws.com/build/${
       process.env.DRONE_BUILD_NUMBER
-    }/flavors/${flavor}/components/preview/`;
+    }`;
 
 require('dotenv').config(); // eslint-disable-line import/no-extraneous-dependencies
 
@@ -200,5 +198,12 @@ exports.config = {
       injectHTMLInspector.bind(browser)
     );
     browser.addCommand('runHTMLInspector', runHTMLInspector.bind(browser));
+
+    browser.addCommand('goToComponent', (component, variant) => {
+      const flavor = component.match(/(ec|eu)$/g);
+      const prefix = `/flavors/${flavor}/components/preview`;
+      const page = `${component}${variant && `--${variant}`}.html`;
+      return browser.url(`${prefix}/${page}`);
+    });
   },
 };


### PR DESCRIPTION
No distinction between EC tests and EU tests. New `browser.goToComponent` to be used instead of `browser.url`