### PR TITLE
fix(reset): remove typography rules from reset - INNO-949

### DIFF
--- a/src/generic/generic-base/mixins/index.scss
+++ b/src/generic/generic-base/mixins/index.scss
@@ -7,10 +7,3 @@
 @import './hidden-print';
 @import './media-caption';
 @import './screen-readers';
-
-@mixin ecl-font() {
-  font-family: $ecl-font-family-base;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizelegibility;
-}

--- a/src/generic/generic-base/mixins/index.scss
+++ b/src/generic/generic-base/mixins/index.scss
@@ -7,3 +7,10 @@
 @import './hidden-print';
 @import './media-caption';
 @import './screen-readers';
+
+@mixin ecl-font() {
+  font-family: $ecl-font-family-base;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizelegibility;
+}

--- a/src/generic/generic-base/reset.scss
+++ b/src/generic/generic-base/reset.scss
@@ -1,9 +1,0 @@
-// ECL Reset
-@mixin reset() {
-  body {
-    font-family: $ecl-font-family-base;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizelegibility;
-  }
-}

--- a/src/generic/generic-style-typography/README.md
+++ b/src/generic/generic-style-typography/README.md
@@ -1,0 +1,1 @@
+# Typography

--- a/src/generic/generic-style-typography/_mixins.scss
+++ b/src/generic/generic-style-typography/_mixins.scss
@@ -1,0 +1,6 @@
+@mixin typography() {
+  font-family: $ecl-font-family-base;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizelegibility;
+}

--- a/src/generic/generic-style-typography/generic-style-typography.scss
+++ b/src/generic/generic-style-typography/generic-style-typography.scss
@@ -1,0 +1,12 @@
+/**
+ * Typography rules
+ * @define typography
+ */
+
+@import './mixins';
+
+@mixin ecl-typography() {
+  .ecl-typography {
+    @include typography();
+  }
+}

--- a/src/generic/generic-style-typography/package.json
+++ b/src/generic/generic-style-typography/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@ecl/generic-style-typography",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "0.0.1",
+  "description": "ECL Typography",
+  "style": "generic-style-typography.scss",
+  "publishConfig": { "access": "public" },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": ["ecl", "europa-component-library", "design-system"],
+  "sass": "generic-style-typography.scss"
+}

--- a/src/systems/ec/_partials/_preview-breadcrumbs.twig
+++ b/src/systems/ec/_partials/_preview-breadcrumbs.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
@@ -6,8 +16,13 @@
     <title>Preview Layout</title>
     <script>document.documentElement.classList.remove('no-js');</script>
     <link media="all" rel="stylesheet" href="{{ '/ec-preset-full/styles/europa.css' | path }}">
+    <style>
+      body {
+        background-color: #004494
+      }
+    </style>
   </head>
-  <body style="background-color: #004494">
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/ec-preset-full/scripts/europa.js' | path }}"></script>
     {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/ec/_partials/_preview-center-transparent.twig
+++ b/src/systems/ec/_partials/_preview-center-transparent.twig
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
   {% set global = _target.context.global %}
   {% if global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
   {% endif %}
   {% if global.language is defined %}
-    {% set bodyClass = global.language %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">

--- a/src/systems/ec/_partials/_preview-datepickers.twig
+++ b/src/systems/ec/_partials/_preview-datepickers.twig
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
-  {% if _target.context.global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">
@@ -13,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/ec-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/ec-preset-full/scripts/europa.js' | path }}"></script>
     {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/ec/_partials/_preview-forms-file-uploads.twig
+++ b/src/systems/ec/_partials/_preview-forms-file-uploads.twig
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
-  {% if _target.context.global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">
@@ -13,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/ec-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/ec-preset-full/scripts/europa.js' | path }}"></script>
     <script type="text/javascript">document.addEventListener('DOMContentLoaded', function() { ECL.fileUploads(); });</script>

--- a/src/systems/ec/_partials/_preview-full-page.twig
+++ b/src/systems/ec/_partials/_preview-full-page.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
 <head>
   <meta charset="utf-8">
@@ -7,7 +17,7 @@
   <script>document.documentElement.classList.remove('no-js');</script>
   <link media="all" rel="stylesheet" href="{{ '/ec-preset-full/styles/europa.css' | path }}">
 </head>
-<body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+<body class="{{ bodyClass }}">
   {% include '@ecl/ec-component-skip-link' with {
       'href': '#main-content',
       'label': 'Skip to main content'

--- a/src/systems/ec/_partials/_preview-inpage-navigation.twig
+++ b/src/systems/ec/_partials/_preview-inpage-navigation.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography ecl-u-mh-l' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
@@ -7,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/ec-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}" {% else %} class="ecl-u-mh-l" {% endif %}>
+  <body class="{{ bodyClass }}">
     <div class="ecl-row ecl-u-z-navigation ecl-u-pt-xl">
       {{ yield }}
       <div class="ecl-col-md-9">

--- a/src/systems/ec/_partials/_preview-no-demo.twig
+++ b/src/systems/ec/_partials/_preview-no-demo.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
@@ -13,7 +23,7 @@
       }
     </style>
   </head>
-  <body>
+  <body class="{{ bodyClass }}">
     <h1>No demo available...</h1>
   </body>
 </html>

--- a/src/systems/ec/_partials/_preview-palette.twig
+++ b/src/systems/ec/_partials/_preview-palette.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
@@ -73,7 +83,7 @@
     }
     </style>
   </head>
-  <body>
+  <body class="{{ bodyClass }}">
     <ul class="list-palette">
       {{ yield }}
     </ul>

--- a/src/systems/ec/_partials/_preview-splash-page.twig
+++ b/src/systems/ec/_partials/_preview-splash-page.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
 <head>
   <meta charset="utf-8">
@@ -12,7 +22,7 @@
     }
   </style>
 </head>
-<body>
+<body class="{{ bodyClass }}">
   {{ yield }}
   <script src="{{ '/ec-preset-full/scripts/europa.js' | path }}"></script>
 </body>

--- a/src/systems/ec/_partials/_preview-tables.twig
+++ b/src/systems/ec/_partials/_preview-tables.twig
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
-  {% if _target.context.global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">
@@ -13,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/ec-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/ec-preset-full/scripts/europa.js' | path }}"></script>
     {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/ec/_partials/_preview-website.twig
+++ b/src/systems/ec/_partials/_preview-website.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
 <head>
   <meta charset="utf-8">
@@ -7,7 +17,7 @@
   <script>document.documentElement.classList.remove('no-js');</script>
   <link media="all" rel="stylesheet" href="{{ '/ec-preset-full/styles/europa.css' | path }}">
 </head>
-<body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+<body class="{{ bodyClass }}">
   {{ yield }}
   <script src="{{ '/ec-preset-full/scripts/europa.js' | path }}"></script>
   {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/ec/_partials/_preview.twig
+++ b/src/systems/ec/_partials/_preview.twig
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
-  {% if _target.context.global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">
@@ -13,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/ec-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/ec-preset-full/scripts/europa.js' | path }}"></script>
     {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/ec/ec-base/reset.scss
+++ b/src/systems/ec/ec-base/reset.scss
@@ -1,5 +1,0 @@
-// ECL Reset
-
-@import '@ecl/generic-base/reset';
-
-@include reset();

--- a/src/systems/ec/ec-preset/ec-preset-base/_imports.scss
+++ b/src/systems/ec/ec-preset/ec-preset-base/_imports.scss
@@ -6,6 +6,7 @@
 @import '@ecl/ec-style-image/ec-style-image';
 
 // Typography
+@import '@ecl/ec-style-typography/ec-style-typography';
 @import '@ecl/ec-style-typography-heading/ec-style-typography-heading';
 @import '@ecl/ec-style-typography-list/ec-style-typography-list';
 @import '@ecl/ec-style-typography-paragraph/ec-style-typography-paragraph';

--- a/src/systems/ec/ec-preset/ec-preset-base/_imports.scss
+++ b/src/systems/ec/ec-preset/ec-preset-base/_imports.scss
@@ -1,6 +1,5 @@
 // Core variables and mixins + reset
 @import '@ecl/ec-base/ec-base';
-@import '@ecl/ec-base/reset';
 
 // Icons & Images
 @import '@ecl/ec-style-icon/ec-style-icon';

--- a/src/systems/ec/ec-preset/ec-preset-base/package.json
+++ b/src/systems/ec/ec-preset/ec-preset-base/package.json
@@ -10,6 +10,7 @@
     "@ecl/ec-base": "^0.0.1",
     "@ecl/ec-style-icon": "^0.0.1",
     "@ecl/ec-style-image": "^0.0.1",
+    "@ecl/ec-style-typography": "^0.0.1",
     "@ecl/ec-style-typography-heading": "^0.0.1",
     "@ecl/ec-style-typography-list": "^0.0.1",
     "@ecl/ec-style-typography-paragraph": "^0.0.1",

--- a/src/systems/ec/ec-style/ec-style-typography/ec-style-typography/README.md
+++ b/src/systems/ec/ec-style/ec-style-typography/ec-style-typography/README.md
@@ -1,3 +1,7 @@
 # Typography
 
 Be careful when applying the `.ecl-typography` class.
+
+If you embed the ECL in an existing website, don't apply this class on the `body` or it will affect the existing styles. Apply it on the top-level ECL element.
+
+If the ECL is your main framework, then you can add the `.ecl-typography` class to the `body` element.

--- a/src/systems/ec/ec-style/ec-style-typography/ec-style-typography/README.md
+++ b/src/systems/ec/ec-style/ec-style-typography/ec-style-typography/README.md
@@ -1,0 +1,3 @@
+# Typography
+
+Be careful when applying the `.ecl-typography` class.

--- a/src/systems/ec/ec-style/ec-style-typography/ec-style-typography/ec-style-typography.scss
+++ b/src/systems/ec/ec-style/ec-style-typography/ec-style-typography/ec-style-typography.scss
@@ -1,0 +1,8 @@
+/**
+ * Typography rules
+ * @define typography
+ */
+
+@import '@ecl/generic-style-typography/generic-style-typography';
+
+@include ecl-typography();

--- a/src/systems/ec/ec-style/ec-style-typography/ec-style-typography/package.json
+++ b/src/systems/ec/ec-style/ec-style-typography/ec-style-typography/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ecl/ec-style-typography",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "0.0.1",
+  "description": "ECL Typography",
+  "style": "ec-style-typography.scss",
+  "publishConfig": { "access": "public" },
+  "dependencies": {
+    "@ecl/ec-base": "^0.0.1",
+    "@ecl/generic-style-typography": "^0.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": ["ecl", "europa-component-library", "design-system"],
+  "sass": "ec-style-typography.scss"
+}

--- a/src/systems/eu/_partials/_preview-breadcrumbs.twig
+++ b/src/systems/eu/_partials/_preview-breadcrumbs.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
@@ -6,8 +16,13 @@
     <title>Preview Layout</title>
     <script>document.documentElement.classList.remove('no-js');</script>
     <link media="all" rel="stylesheet" href="{{ '/eu-preset-full/styles/europa.css' | path }}">
+    <style>
+      body {
+        background-color: #004494;
+      }
+    </style>
   </head>
-  <body style="background-color: #004494">
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/eu-preset-full/scripts/europa.js' | path }}"></script>
     {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/eu/_partials/_preview-center-transparent.twig
+++ b/src/systems/eu/_partials/_preview-center-transparent.twig
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
   {% set global = _target.context.global %}
   {% if global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
   {% endif %}
   {% if global.language is defined %}
-    {% set bodyClass = global.language %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">

--- a/src/systems/eu/_partials/_preview-datepickers.twig
+++ b/src/systems/eu/_partials/_preview-datepickers.twig
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
-  {% if _target.context.global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">
@@ -13,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/eu-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/eu-preset-full/scripts/europa.js' | path }}"></script>
     {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/eu/_partials/_preview-forms-file-uploads.twig
+++ b/src/systems/eu/_partials/_preview-forms-file-uploads.twig
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
-  {% if _target.context.global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">
@@ -13,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/eu-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/eu-preset-full/scripts/europa.js' | path }}"></script>
     <script type="text/javascript">document.addEventListener('DOMContentLoaded', function() { ECL.fileUploads(); });</script>

--- a/src/systems/eu/_partials/_preview-full-page.twig
+++ b/src/systems/eu/_partials/_preview-full-page.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
 <head>
   <meta charset="utf-8">
@@ -7,7 +17,7 @@
   <script>document.documentElement.classList.remove('no-js');</script>
   <link media="all" rel="stylesheet" href="{{ '/eu-preset-full/styles/europa.css' | path }}">
 </head>
-<body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+<body class="{{ bodyClass }}">
   {% include '@ecl/eu-component-skip-link' with {
       'href': '#main-content',
       'label': 'Skip to main content'

--- a/src/systems/eu/_partials/_preview-inpage-navigation.twig
+++ b/src/systems/eu/_partials/_preview-inpage-navigation.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography ecl-u-mh-l' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
@@ -7,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/eu-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}" {% else %} class="ecl-u-mh-l" {% endif %}>
+  <body class="{{ bodyClass }}">
     <div class="ecl-row ecl-u-z-navigation ecl-u-pt-xl">
       {{ yield }}
       <div class="ecl-col-md-9">

--- a/src/systems/eu/_partials/_preview-no-demo.twig
+++ b/src/systems/eu/_partials/_preview-no-demo.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
@@ -13,7 +23,7 @@
       }
     </style>
   </head>
-  <body>
+  <body class="{{ bodyClass }}">
     <h1>No demo available...</h1>
   </body>
 </html>

--- a/src/systems/eu/_partials/_preview-palette.twig
+++ b/src/systems/eu/_partials/_preview-palette.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
@@ -73,7 +83,7 @@
     }
     </style>
   </head>
-  <body>
+  <body class="{{ bodyClass }}">
     <ul class="list-palette">
       {{ yield }}
     </ul>

--- a/src/systems/eu/_partials/_preview-splash-page.twig
+++ b/src/systems/eu/_partials/_preview-splash-page.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
 <head>
   <meta charset="utf-8">
@@ -12,7 +22,7 @@
     }
   </style>
 </head>
-<body>
+<body class="{{ bodyClass }}">
   {{ yield }}
   <script src="{{ '/eu-preset-full/scripts/europa.js' | path }}"></script>
 </body>

--- a/src/systems/eu/_partials/_preview-tables.twig
+++ b/src/systems/eu/_partials/_preview-tables.twig
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
-  {% if _target.context.global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">
@@ -13,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/eu-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/eu-preset-full/scripts/europa.js' | path }}"></script>
     {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/eu/_partials/_preview-website.twig
+++ b/src/systems/eu/_partials/_preview-website.twig
@@ -1,4 +1,14 @@
 <!DOCTYPE html>
+{% set bodyClass = 'ecl-typography' %}
+{% if _target.context is defined and _target.context.global is defined %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
+  {% endif %}
+{% endif %}
 <html lang="en" class="no-js">
 <head>
   <meta charset="utf-8">
@@ -6,7 +16,7 @@
   <script>document.documentElement.classList.remove('no-js');</script>
   <link media="all" rel="stylesheet" href="{{ '/eu-preset-full/styles/europa.css' | path }}">
 </head>
-<body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+<body class="{{ bodyClass }}">
   {{ yield }}
   <script src="{{ '/eu-preset-full/scripts/europa.js' | path }}"></script>
   {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/eu/_partials/_preview.twig
+++ b/src/systems/eu/_partials/_preview.twig
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-{% set bodyClass = '' %}
+{% set bodyClass = 'ecl-typography' %}
 {% if _target.context is defined and _target.context.global is defined %}
-  {% if _target.context.global.svg is defined %}
-    {% set bodyClass = 'no-svg' %}
+  {% set global = _target.context.global %}
+  {% if global.svg is defined %}
+    {% set bodyClass = bodyClass ~ ' no-svg' %}
+  {% endif %}
+  {% if global.language is defined %}
+    {% set bodyClass = bodyClass ~ ' language-' ~ global.language %}
   {% endif %}
 {% endif %}
 <html lang="en" class="no-js">
@@ -13,7 +17,7 @@
     <script>document.documentElement.classList.remove('no-js');</script>
     <link rel="stylesheet" href="{{ '/eu-preset-full/styles/europa.css' | path }}">
   </head>
-  <body{% if _target.context and _target.context.global and _target.context.global.language %} class="language-{{ _target.context.global.language }}"{% endif %}>
+  <body class="{{ bodyClass }}">
     {{ yield }}
     <script src="{{ '/eu-preset-full/scripts/europa.js' | path }}"></script>
     {% if _target.context._demo and _target.context._demo.scripts %}

--- a/src/systems/eu/eu-base/reset.scss
+++ b/src/systems/eu/eu-base/reset.scss
@@ -1,5 +1,0 @@
-// ECL Reset
-
-@import '@ecl/generic-base/reset';
-
-@include reset();

--- a/src/systems/eu/eu-preset/eu-preset-base/_imports.scss
+++ b/src/systems/eu/eu-preset/eu-preset-base/_imports.scss
@@ -1,6 +1,5 @@
 // Core variables and mixins + reset
 @import '@ecl/eu-base/eu-base';
-@import '@ecl/eu-base/reset';
 
 // Icons & Images
 @import '@ecl/eu-style-icon/eu-style-icon';

--- a/src/systems/eu/eu-preset/eu-preset-base/_imports.scss
+++ b/src/systems/eu/eu-preset/eu-preset-base/_imports.scss
@@ -6,6 +6,7 @@
 @import '@ecl/eu-style-image/eu-style-image';
 
 // Typography
+@import '@ecl/eu-style-typography/eu-style-typography';
 @import '@ecl/eu-style-typography-heading/eu-style-typography-heading';
 @import '@ecl/eu-style-typography-list/eu-style-typography-list';
 @import '@ecl/eu-style-typography-paragraph/eu-style-typography-paragraph';

--- a/src/systems/eu/eu-preset/eu-preset-base/package.json
+++ b/src/systems/eu/eu-preset/eu-preset-base/package.json
@@ -10,6 +10,7 @@
     "@ecl/eu-base": "^0.0.1",
     "@ecl/eu-style-icon": "^0.0.1",
     "@ecl/eu-style-image": "^0.0.1",
+    "@ecl/eu-style-typography": "^0.0.1",
     "@ecl/eu-style-typography-heading": "^0.0.1",
     "@ecl/eu-style-typography-list": "^0.0.1",
     "@ecl/eu-style-typography-paragraph": "^0.0.1",

--- a/src/systems/eu/eu-style/eu-style-typography/eu-style-typography/README.md
+++ b/src/systems/eu/eu-style/eu-style-typography/eu-style-typography/README.md
@@ -1,3 +1,7 @@
 # Typography
 
 Be careful when applying the `.ecl-typography` class.
+
+If you embed the ECL in an existing website, don't apply this class on the `body` or it will affect the existing styles. Apply it on the top-level ECL element.
+
+If the ECL is your main framework, then you can add the `.ecl-typography` class to the `body` element.

--- a/src/systems/eu/eu-style/eu-style-typography/eu-style-typography/README.md
+++ b/src/systems/eu/eu-style/eu-style-typography/eu-style-typography/README.md
@@ -1,0 +1,3 @@
+# Typography
+
+Be careful when applying the `.ecl-typography` class.

--- a/src/systems/eu/eu-style/eu-style-typography/eu-style-typography/eu-style-typography.scss
+++ b/src/systems/eu/eu-style/eu-style-typography/eu-style-typography/eu-style-typography.scss
@@ -1,0 +1,8 @@
+/**
+ * Typography rules
+ * @define typography
+ */
+
+@import '@ecl/generic-style-typography/generic-style-typography';
+
+@include ecl-typography();

--- a/src/systems/eu/eu-style/eu-style-typography/eu-style-typography/package.json
+++ b/src/systems/eu/eu-style/eu-style-typography/eu-style-typography/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ecl/eu-style-typography",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "0.0.1",
+  "description": "ECL Typography",
+  "style": "eu-style-typography.scss",
+  "publishConfig": { "access": "public" },
+  "dependencies": {
+    "@ecl/eu-base": "^0.0.1",
+    "@ecl/generic-style-typography": "^0.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": ["ecl", "europa-component-library", "design-system"],
+  "sass": "eu-style-typography.scss"
+}

--- a/tools/fractal-theme/views/layouts/skeleton.nunj
+++ b/tools/fractal-theme/views/layouts/skeleton.nunj
@@ -15,7 +15,7 @@
     <script>var cl = document.querySelector('html').classList; cl.remove('no-js'); cl.add('has-js');</script>
     {% include 'partials/head.nunj' %}
 </head>
-<body class="language-en">
+<body class="ecl-typography language-en">
   {% include 'partials/header.nunj' %}
   <main>
     <a id="main-content" tabindex="-1"></a>

--- a/website/index.html
+++ b/website/index.html
@@ -38,7 +38,7 @@ cl.add('has-js');
   <link rel="stylesheet" href="/ec/themes/ecl-fractal-theme/css/fractal.css?cachebust=0.13.2" type="text/css">
   <title>EC System | EC System</title>
 </head>
-<body class="language-en">
+<body class="language-en ecl-typography">
   <div class="ecl-skip-link__wrapper" id="skip-link">
     <a href="#main-content" class="ecl-skip-link">Skip to main content</a>
   </div>


### PR DESCRIPTION
It's the final PR regarding the reset 🕐🎉🍾

Two options:
1. apply a class on the most top-level acceptable DOM element (easy way: body), like I did here with `.ecl-typography`
2. refactor almost all the components to explicitly apply the font rules, _à la_ https://github.com/carbon-design-system/carbon-components/search?l=SCSS&q=font-family&type=

I went with option 1 because it was faster but option 2 is more robust. It could be part of the normalization process :D cc @emeryro  