### PR TITLE
fix(dialog): fix z-index issue - INNO-984

### DIFF
--- a/src/generic/generic-component-dialog/generic-component-dialog.scss
+++ b/src/generic/generic-component-dialog/generic-component-dialog.scss
@@ -38,7 +38,7 @@
     position: fixed;
     top: 0;
     width: 100%;
-    z-index: map-get($ecl-z-index, 'modal');
+    z-index: map-get($ecl-z-index, 'modal') - 1;
   }
 
   .ecl-dialog__overlay[aria-hidden='true'] {

--- a/src/generic/generic-component-dialog/generic-component-dialog.scss
+++ b/src/generic/generic-component-dialog/generic-component-dialog.scss
@@ -38,7 +38,7 @@
     position: fixed;
     top: 0;
     width: 100%;
-    z-index: map-get($ecl-z-index, 'highlight');
+    z-index: map-get($ecl-z-index, 'modal');
   }
 
   .ecl-dialog__overlay[aria-hidden='true'] {


### PR DESCRIPTION
Fixes the z-index issue of the modal's overlay

Current: https://next--europa-component-library.netlify.com/ec/components/preview/ec-template-page--with-menu

After: https://deploy-preview-632--europa-component-library.netlify.com/ec/components/preview/ec-template-page--with-menu

Procedure: open the megamenu then click on the language switcher