### PR TITLE
fix(inpage-nav): fix inpage-nav - INNO-943

### DIFF
--- a/src/generic/generic-component-inpage-navigation/data/demo.js
+++ b/src/generic/generic-component-inpage-navigation/data/demo.js
@@ -18,6 +18,10 @@ module.exports = {
   links,
   extra_classes: 'ecl-col-md-3 ecl-u-align-self-start ',
   _demo: {
-    scripts: `document.addEventListener('DOMContentLoaded', function () { ECL.navigationInpages(); });`,
+    scripts: `
+      document.addEventListener('DOMContentLoaded', function () {
+        ECL.navigationInpages();
+      });
+    `,
   },
 };

--- a/src/generic/generic-component-inpage-navigation/generic-component-inpage-navigation.js
+++ b/src/generic/generic-component-inpage-navigation/generic-component-inpage-navigation.js
@@ -2,7 +2,6 @@
  * Navigation inpage related behaviors.
  */
 
-import stickybits from 'stickybits';
 import gumshoe from 'gumshoejs';
 import { toggleExpandable } from '@ecl/generic-component-expandable';
 
@@ -11,7 +10,6 @@ import { toggleExpandable } from '@ecl/generic-component-expandable';
  */
 export const navigationInpages = ({
   stickySelector: stickySelector = '.ecl-inpage-navigation',
-  stickyOffset: stickyOffset = 0,
   spySelector: spySelector = '.ecl-inpage-navigation__link',
   spyClass: spyClass = 'ecl-inpage-navigation__link--is-active',
   spyTrigger: spyTrigger = '.ecl-inpage-navigation__trigger',
@@ -27,35 +25,23 @@ export const navigationInpages = ({
   )
     return null;
 
-  let stickyInstance;
-
   // ACTIONS
-  function initSticky() {
-    stickyInstance = stickybits(stickySelector, {
-      stickyBitStickyOffset: stickyOffset,
-      useStickyClasses: true,
-      parentClass: 'ecl-inpage-navigation__parent',
-      stickyClass: 'ecl-inpage-navigation--sticky',
-      stuckClass: 'ecl-inpage-navigation--stuck',
-      stickyChangeClass: 'ecl-inpage-navigation--changed',
-    });
-  }
 
-  function destroySticky() {
-    if (stickyInstance) {
-      stickyInstance.cleanup();
-    }
-  }
-
-  function initScrollSpy() {
+  function initScrollSpy(inpageNavElement) {
     gumshoe.init({
       selector: spySelector,
       activeClass: spyClass,
       offset: spyOffset,
       callback(nav) {
-        if (!nav) return;
         const navigationTitle = document.querySelector(spyTrigger);
-        navigationTitle.innerHTML = nav.nav.innerHTML;
+
+        if (!nav) {
+          inpageNavElement.classList.remove('ecl-inpage-navigation--visible');
+          navigationTitle.innerHTML = '';
+        } else {
+          inpageNavElement.classList.add('ecl-inpage-navigation--visible');
+          navigationTitle.innerHTML = nav.nav.innerHTML;
+        }
       },
     });
   }
@@ -70,8 +56,8 @@ export const navigationInpages = ({
     const toggleElement = inpageNavElement.querySelector(toggleSelector);
     const navLinks = inpageNavElement.querySelectorAll(linksSelector);
 
-    initSticky();
-    initScrollSpy();
+    // initSticky();
+    initScrollSpy(inpageNavElement);
 
     toggleElement.addEventListener('click', e => {
       toggleExpandable(toggleElement, { context: inpageNavElement });
@@ -91,7 +77,6 @@ export const navigationInpages = ({
   // Destroy
   function destroy() {
     destroyScrollSpy();
-    destroySticky();
   }
 
   init();

--- a/src/generic/generic-component-inpage-navigation/generic-component-inpage-navigation.scss
+++ b/src/generic/generic-component-inpage-navigation/generic-component-inpage-navigation.scss
@@ -94,8 +94,7 @@ $ecl-inpage-navigation-link-padding-vertical: (
     padding: $ecl-inpage-navigation-link-padding-vertical 0;
   }
 
-  .ecl-inpage-navigation--sticky,
-  .ecl-inpage-navigation--stuck {
+  .ecl-inpage-navigation--visible {
     .ecl-inpage-navigation__trigger {
       display: block;
     }
@@ -103,8 +102,7 @@ $ecl-inpage-navigation-link-padding-vertical: (
 
   /* stylelint-disable-next-line order/order */
   @include ecl-media-breakpoint-down('sm') {
-    .ecl-inpage-navigation--sticky,
-    .ecl-inpage-navigation--stuck {
+    .ecl-inpage-navigation--visible {
       .ecl-inpage-navigation__body {
         background-color: $ecl-color-primary;
         left: 0;
@@ -120,10 +118,21 @@ $ecl-inpage-navigation-link-padding-vertical: (
         padding: map-get($ecl-spacing, 'xxs') map-get($ecl-spacing, 'xs');
         text-decoration: underline;
       }
+
+      .ecl-inpage-navigation__link:visited {
+        color: #fff;
+      }
     }
   }
 
   @include ecl-media-breakpoint-up('md') {
+    .ecl-inpage-navigation {
+      @supports (position: sticky) {
+        position: sticky;
+        top: 0;
+      }
+    }
+
     .ecl-inpage-navigation__title {
       display: block;
     }
@@ -155,8 +164,7 @@ $ecl-inpage-navigation-link-padding-vertical: (
       border-left-color: $ecl-color-primary;
     }
 
-    .ecl-inpage-navigation--sticky,
-    .ecl-inpage-navigation--stuck {
+    .ecl-inpage-navigation--visible {
       .ecl-inpage-navigation__trigger {
         display: none;
       }

--- a/src/generic/generic-component-inpage-navigation/package.json
+++ b/src/generic/generic-component-inpage-navigation/package.json
@@ -11,8 +11,7 @@
     "@ecl/generic-component-expandable": "^1.0.0",
     "@ecl/generic-component-link": "^1.0.0",
     "@ecl/generic-style-icon": "^1.0.0",
-    "gumshoejs": "3.5.0",
-    "stickybits": "3.2.3"
+    "gumshoejs": "3.5.0"
   },
   "devDependencies": {
     "@ecl/generic-style-typography-paragraph": "^1.0.0"

--- a/src/systems/ec/_partials/_preview-inpage-navigation.twig
+++ b/src/systems/ec/_partials/_preview-inpage-navigation.twig
@@ -31,7 +31,7 @@
           Example row
         </div>
       </div>
-      <div class="ecl-row ecl-u-mv-xl">
+      <div class="ecl-row ecl-u-mv-xl" id="sticky-container">
         {{ yield }}
         <div class="ecl-col-md-9">
           <h2 class="ecl-heading ecl-heading--h2" id="inline-nav-1">Heading 1</h2>

--- a/src/systems/ec/ec-component/ec-component-navigation/ec-component-inpage-navigation/package.json
+++ b/src/systems/ec/ec-component/ec-component-navigation/ec-component-inpage-navigation/package.json
@@ -18,8 +18,7 @@
     "@ecl/ec-component-link": "^1.0.0",
     "@ecl/ec-style-icon": "^1.0.0",
     "@ecl/generic-component-inpage-navigation": "^1.0.0",
-    "gumshoejs": "3.5.0",
-    "stickybits": "3.2.3"
+    "gumshoejs": "3.5.0"
   },
   "devDependencies": {
     "@ecl/ec-style-typography-paragraph": "^1.0.0",

--- a/src/systems/eu/eu-component/eu-component-navigation/eu-component-inpage-navigation/package.json
+++ b/src/systems/eu/eu-component/eu-component-navigation/eu-component-inpage-navigation/package.json
@@ -18,8 +18,7 @@
     "@ecl/eu-component-link": "^1.0.0",
     "@ecl/eu-style-icon": "^1.0.0",
     "@ecl/generic-component-inpage-navigation": "^1.0.0",
-    "gumshoejs": "3.5.0",
-    "stickybits": "3.2.3"
+    "gumshoejs": "3.5.0"
   },
   "devDependencies": {
     "@ecl/eu-style-typography-paragraph": "^1.0.0",


### PR DESCRIPTION
The goal of this PR is to finally have the `inpage navigation` component working correctly.

IMHO, the sticky behavior should be considered as a progressive enhancement. If the browser supports `position: sticky`, then the nav will be sticky. Otherwise, it will just go away with the rest of the page.