### PR TITLE
chore(build): copy generic templates on change - INNO-994

### DIFF
--- a/tools/ec-styleguide/package.json
+++ b/tools/ec-styleguide/package.json
@@ -8,23 +8,27 @@
   "scripts": {
     "build:preset":
       "cd ../../src/systems/ec/ec-preset/ec-preset-website && npm run build",
-    "clean": "rimraf ./static/ec-preset-website",
+    "clean": "rimraf ./static/ec-preset-website ../../src/systems/ec/_imports",
     "copy:preset":
       "ncp ../../src/systems/ec/ec-preset/ec-preset-website/dist ./static/ec-preset-website",
-    "dist":
-      "npm run clean && npm run copy:preset && cross-env NODE_ENV=production fractal build",
-    "postinstall":
+    "copy:templates":
       "copyfiles -f '../../node_modules/@ecl/generic-*/**/*.twig' ../../src/systems/ec/_imports",
+    "dist":
+      "npm run clean && npm run copy:preset && npm run copy:templates && cross-env NODE_ENV=production fractal build",
     "serve": "fractal start --sync",
-    "start": "npm-run-all clean build:preset --parallel serve watch:preset",
+    "start":
+      "npm-run-all clean copy:templates build:preset --parallel serve watch:*",
     "watch:preset":
-      "cd ../../src/systems/ec/ec-preset/ec-preset-website && npm run watch"
+      "cd ../../src/systems/ec/ec-preset/ec-preset-website && npm run watch",
+    "watch:templates":
+      "chokidar \"../../src/generic/**/*.twig\" --c \"npm run copy:templates\""
   },
   "devDependencies": {
     "@ecl/ec-preset-website": "^1.1.0",
     "@ecl/fractal-theme": "^1.0.1",
     "@ecl/fractal-twig": "^1.0.1",
     "@frctl/fractal": "1.1.7",
+    "chokidar-cli": "1.2.0",
     "copyfiles": "2.0.0",
     "cross-env": "5.1.6",
     "ncp": "2.0.0",

--- a/tools/eu-styleguide/package.json
+++ b/tools/eu-styleguide/package.json
@@ -8,23 +8,27 @@
   "scripts": {
     "build:preset":
       "cd ../../src/systems/eu/eu-preset/eu-preset-website && npm run build",
-    "clean": "rimraf ./static/eu-preset-website",
+    "clean": "rimraf ./static/eu-preset-website ../../src/systems/eu/_imports",
     "copy:preset":
       "ncp ../../src/systems/eu/eu-preset/eu-preset-website/dist ./static/eu-preset-website",
-    "dist":
-      "npm run clean && npm run copy:preset && cross-env NODE_ENV=production fractal build",
-    "postinstall":
+    "copy:templates":
       "copyfiles -f '../../node_modules/@ecl/generic-*/**/*.twig' ../../src/systems/eu/_imports",
+    "dist":
+      "npm run clean && npm run copy:preset && npm run copy:templates && cross-env NODE_ENV=production fractal build",
     "serve": "fractal start --sync",
-    "start": "npm-run-all clean build:preset --parallel serve watch:preset",
+    "start":
+      "npm-run-all clean copy:templates build:preset --parallel serve watch:*",
     "watch:preset":
-      "cd ../../src/systems/eu/eu-preset/eu-preset-website && npm run watch"
+      "cd ../../src/systems/eu/eu-preset/eu-preset-website && npm run watch",
+    "watch:templates":
+      "chokidar \"../../src/generic/**/*.twig\" --c \"npm run copy:templates\""
   },
   "devDependencies": {
     "@ecl/eu-preset-website": "^1.1.0",
     "@ecl/fractal-theme": "^1.0.1",
     "@ecl/fractal-twig": "^1.0.1",
     "@frctl/fractal": "1.1.7",
+    "chokidar-cli": "1.2.0",
     "copyfiles": "2.0.0",
     "cross-env": "5.1.6",
     "ncp": "2.0.0",


### PR DESCRIPTION
To test:
- checkout the branch
- `yarn`
- `yarn start:ec` or `yarn start:eu`
- update a generic component -> the template is copied into the `{ec|eu}/_imports` folder, but the view is not rebuilt
- open the related system component's config.js, add or remove a comment -> this will trigger a fractal build of the component and update the view in the browser