### PR TITLE
fix(patches): apply some patches from Open Europa - INNO-1090

### DIFF
--- a/src/generic/generic-component-button/generic-component-button.twig
+++ b/src/generic/generic-component-button/generic-component-button.twig
@@ -54,7 +54,7 @@
 {# Print the result #}
 
 {% if _type == 'link' %}
-  <a href="{{ _href }}" class="{{ _css_class }}"{{ _extra_attributes|raw }}>{% block link_label_block _label %}</a>
+  <a href="{{ _href }}" class="{{ _css_class }}"{{ _extra_attributes|raw }}>{% block link_label_block _label|raw %}</a>
 {% else %}
-  <button class="{{ _css_class }}"{{ _extra_attributes|raw }}>{% block button_label_block _label %}</button>
+  <button class="{{ _css_class }}"{{ _extra_attributes|raw }}>{% block button_label_block _label|raw %}</button>
 {% endif %}

--- a/src/generic/generic-component-dialog/generic-component-dialog.twig
+++ b/src/generic/generic-component-dialog/generic-component-dialog.twig
@@ -32,7 +32,7 @@
 {# Internal properties #}
 
 {% set _dialog_id = dialog_id|default('ecl-dialog') %}
-{% set _dialog_aria_hidden = dialog_aria_hidden|default(true) %}
+{% set _dialog_aria_hidden = dialog_aria_hidden|default('true') %}
 
 {% set _dialog_title = {
   value: 'Dialog',

--- a/src/generic/generic-component-language-list/generic-component-language-list.twig
+++ b/src/generic/generic-component-language-list/generic-component-language-list.twig
@@ -108,12 +108,20 @@
 
 <div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if _variant == 'overlay' %}
+  {% set _selected_language = [] %}
+    {% for _language in _languages %}
+      {% if _language.is_active %}
+        {% set _selected_language = _language %}
+      {% endif %}
+    {% endfor %}
     {# Custom Dialog-overlay for the 'overlay' variant #}
     <div id="ecl-overlay-language-list" class="ecl-dialog__overlay ecl-dialog__overlay--blue" aria-hidden="true"></div>
     {% include '@ecl/generic-component-lang-select-site' with {
       'extra_attributes': [{name: 'data-ecl-dialog', value: 'ecl-dialog'}, {name: 'id', value: 'ecl-lang-select-sites__overlay'}],
       'extra_classes': 'ecl-link',
-      'link': _link
+      'link': _link,
+      'language': _selected_language.label,
+      'code': _selected_language.lang
     } only %}
     {% embed '@ecl/generic-component-dialog' with {
       'variant': 'wide',

--- a/src/systems/ec/ec-component/ec-component-dialog/ec-component-dialog.twig
+++ b/src/systems/ec/ec-component/ec-component-dialog/ec-component-dialog.twig
@@ -32,7 +32,7 @@
 {# Internal properties #}
 
 {% set _dialog_id = dialog_id|default('ecl-dialog') %}
-{% set _dialog_aria_hidden = dialog_aria_hidden|default(true) %}
+{% set _dialog_aria_hidden = dialog_aria_hidden|default('true') %}
 
 {% set _dialog_title = {
   value: 'Dialog',

--- a/src/systems/ec/ec-component/ec-component-language-list/ec-component-language-list.twig
+++ b/src/systems/ec/ec-component/ec-component-language-list/ec-component-language-list.twig
@@ -108,12 +108,20 @@
 
 <div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if _variant == 'overlay' %}
+    {% set _selected_language = [] %}
+    {% for language in _languages %}
+      {% if language.is_active %}
+        {% set _selected_language = language %}
+      {% endif %}
+    {% endfor %}
     {# Custom Dialog-overlay for the 'overlay' variant #}
     <div id="ecl-overlay-language-list" class="ecl-dialog__overlay ecl-dialog__overlay--blue" aria-hidden="true"></div>
     {% include '@ecl/ec-component-lang-select-site' with {
       'extra_attributes': [{name: 'data-ecl-dialog', value: 'ecl-dialog'}, {name: 'id', value: 'ecl-lang-select-sites__overlay'}],
       'extra_classes': 'ecl-link',
-      'link': _link
+      'link': _link,
+      'language': _selected_language.label,
+      'code': _selected_language.lang
     } only %}
     {% embed '@ecl/ec-component-dialog' with {
       'variant': 'wide',

--- a/src/systems/ec/ec-component/ec-component-language-list/ec-component-language-list.twig
+++ b/src/systems/ec/ec-component/ec-component-language-list/ec-component-language-list.twig
@@ -109,9 +109,9 @@
 <div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if _variant == 'overlay' %}
     {% set _selected_language = [] %}
-    {% for language in _languages %}
-      {% if language.is_active %}
-        {% set _selected_language = language %}
+    {% for _language in _languages %}
+      {% if _language.is_active %}
+        {% set _selected_language = _language %}
       {% endif %}
     {% endfor %}
     {# Custom Dialog-overlay for the 'overlay' variant #}

--- a/src/systems/eu/eu-component/eu-component-dialog/eu-component-dialog.twig
+++ b/src/systems/eu/eu-component/eu-component-dialog/eu-component-dialog.twig
@@ -32,7 +32,7 @@
 {# Internal properties #}
 
 {% set _dialog_id = dialog_id|default('ecl-dialog') %}
-{% set _dialog_aria_hidden = dialog_aria_hidden|default(true) %}
+{% set _dialog_aria_hidden = dialog_aria_hidden|default('true') %}
 
 {% set _dialog_title = {
   value: 'Dialog',

--- a/src/systems/eu/eu-component/eu-component-language-list/eu-component-language-list.twig
+++ b/src/systems/eu/eu-component/eu-component-language-list/eu-component-language-list.twig
@@ -108,12 +108,20 @@
 
 <div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if _variant == 'overlay' %}
+    {% set _selected_language = [] %}
+    {% for language in _languages %}
+      {% if language.is_active %}
+        {% set _selected_language = language %}
+      {% endif %}
+    {% endfor %}
     {# Custom Dialog-overlay for the 'overlay' variant #}
     <div id="ecl-overlay-language-list" class="ecl-dialog__overlay ecl-dialog__overlay--blue" aria-hidden="true"></div>
     {% include '@ecl/eu-component-lang-select-site' with {
       'extra_attributes': [{name: 'data-ecl-dialog', value: 'ecl-dialog'}, {name: 'id', value: 'ecl-lang-select-sites__overlay'}],
       'extra_classes': 'ecl-link',
-      'link': _link
+      'link': _link,
+      'language': _selected_language.label,
+      'code': _selected_language.lang
     } only %}
     {% embed '@ecl/eu-component-dialog' with {
       'variant': 'wide',

--- a/src/systems/eu/eu-component/eu-component-language-list/eu-component-language-list.twig
+++ b/src/systems/eu/eu-component/eu-component-language-list/eu-component-language-list.twig
@@ -109,9 +109,9 @@
 <div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if _variant == 'overlay' %}
     {% set _selected_language = [] %}
-    {% for language in _languages %}
-      {% if language.is_active %}
-        {% set _selected_language = language %}
+    {% for _language in _languages %}
+      {% if _language.is_active %}
+        {% set _selected_language = _language %}
       {% endif %}
     {% endfor %}
     {# Custom Dialog-overlay for the 'overlay' variant #}


### PR DESCRIPTION
# PR description

Patches applied:
- ec-component-dialog+1.0.0.patch: update default value of parameter
- ec-component-language-list+1.0.1.patch: use active language for language list button
- generic-component-button+1.0.0.patch: add '|raw' to the label

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

* [ ] `package.json` is up-to-date and `@ecl/[system]-base` is part of the dependencies
* [ ] I have checked the dependencies
* [ ] I have given the fractal status “ready” to my component
* [ ] I have declared `@define mycomponent` in the SCSS file
* [ ] I have specified `margin: 0;` on the CSS component
* [ ] I have provided tests
* [ ] I follow the naming guidelines
* [ ] the component supports composition
* [ ] there are no hardcoded strings (all content come from the context)
* [ ] I have filled the README.md file (at least a few lines)
* [ ] My component is listed in the root README
* [ ] My PR has the right label(s)
