### PR TITLE
fix(breadcrumb): add "expand all" behavior - INNO-1104

### DIFF
--- a/src/generic/generic-component-breadcrumb/generic-component-breadcrumb.js
+++ b/src/generic/generic-component-breadcrumb/generic-component-breadcrumb.js
@@ -114,7 +114,11 @@ export const initBreadcrumb = ({
       ].setAttribute('aria-hidden', 'false');
 
       if (breadcrumbIsTooLarge(breadcrumbContainer)) {
+        // breadcrumb is too large, we hide the last segment
         hideSegment(breadcrumbContainer);
+      } else {
+        // check if there is another segment to be displayed
+        showSegment(breadcrumbContainer);
       }
     }
   }


### PR DESCRIPTION
# PR description

Add missing behavior when expanding the breadcrumb all at once

To test:
- display the breadcrumb collapsed (on small window)
- maximize the window or quickly resize it at maximum
-> breadcrumb is fully expanded

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

* [ ] `package.json` is up-to-date and `@ecl/[system]-base` is part of the dependencies
* [ ] I have checked the dependencies
* [ ] I have given the fractal status “ready” to my component
* [ ] I have declared `@define mycomponent` in the SCSS file
* [ ] I have specified `margin: 0;` on the CSS component
* [ ] I have provided tests
* [ ] I follow the naming guidelines
* [ ] the component supports composition
* [ ] there are no hardcoded strings (all content come from the context)
* [ ] I have filled the README.md file (at least a few lines)
* [ ] My component is listed in the root README
* [ ] My PR has the right label(s)
