### PR TITLE
feat(iframe): showcase iframes - no issue

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,6 @@
   command = "yarn run dist"
   publish = "dist/website"
 
-
 [build.environment]
   NODE_VERSION = "8"
   YARN_VERSION = "1.9.4"

--- a/src/systems/ec/specs/components/hero-banner/docs/code.mdx
+++ b/src/systems/ec/specs/components/hero-banner/docs/code.mdx
@@ -9,7 +9,13 @@ import demoContentAlignLeft from '../demo/data--align-left';
 
 ## Image banner
 
-<Playground playgroundLink="/storybook/ec/index.html?selectedKind=HeroBanner&selectedStory=image&stories=0">
+<Playground
+  system="ec"
+  selectedKind="HeroBanner"
+  selectedStory="image"
+  showFrame
+  frameHeight="480px"
+>
   <HeroBanner {...demoContentImage} />
 </Playground>
 

--- a/src/tools/website-components/Playground.jsx
+++ b/src/tools/website-components/Playground.jsx
@@ -7,25 +7,63 @@ import { html as beautifyHtml } from 'js-beautify';
 
 import styles from './Playground.scss';
 
-const Playground = ({ playgroundLink, children }) => {
+const Playground = ({
+  frameHeight,
+  playgroundLink,
+  system,
+  selectedKind,
+  selectedStory,
+  showFrame,
+  children,
+}) => {
   if (!children) return null;
+
+  const playgroundUrl =
+    playgroundLink ||
+    `/storybook/${system}/index.html?selectedKind=${selectedKind}&selectedStory=${selectedStory}&stories=0`;
+
+  const fullFrameUrl =
+    system && selectedKind && selectedStory
+      ? `/storybook/${system}/iframe.html?selectedKind=${selectedKind}&selectedStory=${selectedStory}`
+      : '';
 
   return (
     <div className={styles.playground}>
-      <div className={styles.showcase}>{children}</div>
+      {showFrame && fullFrameUrl ? (
+        <iframe
+          title="Showcase"
+          src={fullFrameUrl}
+          className={styles.showcase}
+          height={frameHeight}
+        />
+      ) : (
+        <div className={styles.showcase}>{children}</div>
+      )}
       <ul className={styles.links}>
-        <li>
-          {playgroundLink && (
+        {playgroundUrl && (
+          <li className={styles['link-item']}>
             <a
-              href={playgroundLink}
+              href={playgroundUrl}
               className={styles.link}
               target="_blank"
               rel="noopener noreferrer"
             >
               Playground
             </a>
-          )}
-        </li>
+          </li>
+        )}
+        {fullFrameUrl && (
+          <li className={styles['link-item']}>
+            <a
+              href={fullFrameUrl}
+              className={styles.link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Full screen
+            </a>
+          </li>
+        )}
       </ul>
       <div className={styles.code}>
         <pre className={`${styles['code-pre']} language-html`}>
@@ -50,11 +88,21 @@ const Playground = ({ playgroundLink, children }) => {
 
 Playground.propTypes = {
   children: PropTypes.node.isRequired,
+  frameHeight: PropTypes.string,
   playgroundLink: PropTypes.string,
+  showFrame: PropTypes.bool,
+  system: PropTypes.string,
+  selectedKind: PropTypes.string,
+  selectedStory: PropTypes.string,
 };
 
 Playground.defaultProps = {
+  frameHeight: '200px',
   playgroundLink: '',
+  showFrame: false,
+  system: '',
+  selectedKind: '',
+  selectedStory: '',
 };
 
 export default Playground;

--- a/src/tools/website-components/Playground.jsx
+++ b/src/tools/website-components/Playground.jsx
@@ -60,7 +60,7 @@ const Playground = ({
               target="_blank"
               rel="noopener noreferrer"
             >
-              Full screen
+              Fullscreen
             </a>
           </li>
         )}

--- a/src/tools/website-components/Playground.scss
+++ b/src/tools/website-components/Playground.scss
@@ -1,3 +1,5 @@
+@import '@ecl/ec-theme-default/index';
+
 * + .playground {
   margin-top: 1rem;
 }
@@ -5,6 +7,11 @@
 .showcase {
   background-color: #f9f9f9;
   border: 1px solid #ddd;
+  box-sizing: border-box;
+  display: block;
+  margin: 0;
+  padding: 0;
+  width: 100%;
 }
 
 .links {
@@ -21,17 +28,21 @@
   width: 100%;
 }
 
+.link-item + .link-item {
+  margin-left: $ecl-spacing-s;
+}
+
 .link {
   align-items: center;
   box-sizing: border-box;
-  color: #004494;
+  color: $ecl-color-blue-100;
   display: inline-flex;
   margin: 0;
   text-decoration: underline;
 }
 
 .link:focus {
-  outline: 3px solid #ffd617;
+  outline: 3px solid $ecl-color-yellow-100;
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
Display showcase in iframe, reusing storybook's iframe.

Can be seen here: https://deploy-preview-826--europa-component-library.netlify.com/ec/components/hero-banner/showcase/

Pros:
- really easy to implement
- add "Fullscreen" link

Cons:
- doesn't work without JS
- height is not automatically adjusted as it is when it's an actual React component

If we replace all our showcases by iframes, we can get avoid injecting/ejecting the EC/EU CSS -> smaller website, faster to load.

Possible enhancement: display the iframe in a device look https://www.w3schools.com/howto/howto_css_devices.asp

Notes:
-----

- This branch is actually based on `feat/hero-INNO-1233` but in order to run netlify, I had to open a PR based on next-v2. If we merge it, we should merge it into `feat/hero-INNO-1233` first.

- [react-snap](https://github.com/stereobooster/react-snap) messes up with storybook... If we could prevent it from rendering some specific routes, or if storybook used the history API, then we'd be good