### PR TITLE
docs(grid): adding new content

### DIFF
--- a/src/tools/website-components/DisplayTokens.jsx
+++ b/src/tools/website-components/DisplayTokens.jsx
@@ -1,13 +1,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import styles from './DisplayTokens.scss';
 
 class DisplayTokens extends PureComponent {
   render() {
     const { tokens, category, name } = this.props;
 
     return (
-      <ul>
+      <ul className={styles.ul}>
         {Object.keys(tokens.props)
           .filter(
             key =>

--- a/src/tools/website-components/DisplayTokens.scss
+++ b/src/tools/website-components/DisplayTokens.scss
@@ -1,0 +1,10 @@
+@import '@ecl/ec-theme-default/index';
+
+.ul {
+  box-sizing: border-box;
+  color: $ecl-color-grey-75;
+  font: $ecl-font-prolonged-m;
+  margin-bottom: 0;
+  margin-top: $ecl-spacing-s;
+  max-width: 38em;
+}

--- a/src/tools/website-components/DisplayTokens.scss
+++ b/src/tools/website-components/DisplayTokens.scss
@@ -7,4 +7,5 @@
   margin-bottom: 0;
   margin-top: $ecl-spacing-s;
   max-width: 38em;
+  text-transform: lowercase;
 }

--- a/src/website/src/pages/ec/guidelines/grid/index.mdx
+++ b/src/website/src/pages/ec/guidelines/grid/index.mdx
@@ -14,10 +14,19 @@ There's no `container-fluid`.
 
 Moreover, `.ecl-col, .ecl-col-sm, ...` without the number of columns is not allowed. You have to **explicitly specify** the number of columns (out of 12).
 
+
 ## Breakpoints
+
+There are four breakpoints in our responsive grid
 
 <DisplayTokens tokens={tokens} category="breakpoints" />
 
 ## Grid
 
+The ECL grid uses a 12 column as the basic underlying structure for all web pages. The width of the columns is adaptable to the width of the screen size.
+
+Gutters are the gaps between the columns. Our grid contains 11 gutters of 2rems (between each column) and 1 more gutter divided in half between the first and the last column.
+
 <DisplayTokens tokens={tokens} category="grid" />
+
+![An image of a grid](https://inno-ecl.s3.amazonaws.com/media/images/EC/Grid/Grid.svg)


### PR DESCRIPTION
Please check the changes. If you need to correct something, please do. If we can change the text format of the dynamic content of the breakpoints and grid data it will be great. We can remove all caps and make it appear like normal text maybe?