### PR TITLE
fix(templates): add missing commas

### DIFF
--- a/examples/webpack4/src/index.html
+++ b/examples/webpack4/src/index.html
@@ -187,7 +187,7 @@
                     <a class="ecl-link ecl-link--inverted ecl-footer__link" href="https://ec.europa.eu/commission/index_en">Commission and its priorities</a>
                   </li>
                   <li class="ecl-footer__list-item">
-                    <a class="ecl-link ecl-link--inverted ecl-footer__link" href="https://ec.europa.eu/info/index_en">Policies information and services</a>
+                    <a class="ecl-link ecl-link--inverted ecl-footer__link" href="https://ec.europa.eu/info/index_en">Policies, information and services</a>
                   </li>
                 </ul>
               </div>

--- a/src/systems/ec/_partials/_preview-full-page.twig
+++ b/src/systems/ec/_partials/_preview-full-page.twig
@@ -99,7 +99,7 @@
           },
           {
             href: 'https://ec.europa.eu/info/index_en',
-            label: 'Policies information and services',
+            label: 'Policies, information and services',
           },
         ],
       },

--- a/src/systems/ec/ec-component/ec-component-footer/ec-component-footer.config.js
+++ b/src/systems/ec/ec-component/ec-component-footer/ec-component-footer.config.js
@@ -61,7 +61,7 @@ module.exports = {
           },
           {
             href: 'https://ec.europa.eu/info/index_en',
-            label: 'Policies information and services',
+            label: 'Policies, information and services',
           },
         ],
       },

--- a/src/systems/ec/ec-template/ec-template-community/ec-template-community.twig
+++ b/src/systems/ec/ec-template/ec-template-community/ec-template-community.twig
@@ -264,7 +264,7 @@
         },
         {
           href: 'https://ec.europa.eu/info/index_en',
-          label: 'Policies information and services',
+          label: 'Policies, information and services',
         },
       ],
     },

--- a/src/systems/ec/ec-template/ec-template-listing/ec-template-listing.twig
+++ b/src/systems/ec/ec-template/ec-template-listing/ec-template-listing.twig
@@ -558,7 +558,7 @@
         },
         {
           href: 'https://ec.europa.eu/info/index_en',
-          label: 'Policies information and services',
+          label: 'Policies, information and services',
         },
       ],
     },

--- a/src/systems/ec/ec-template/ec-template-page/ec-template-page.twig
+++ b/src/systems/ec/ec-template/ec-template-page/ec-template-page.twig
@@ -52,7 +52,7 @@
         },
         {
           href: 'https://ec.europa.eu/info/index_en',
-          label: 'Policies information and services',
+          label: 'Policies, information and services',
         },
       ],
     },

--- a/tools/fractal-theme/views/partials/footer.nunj
+++ b/tools/fractal-theme/views/partials/footer.nunj
@@ -32,7 +32,7 @@
                 <a class="ecl-link ecl-link--inverted ecl-footer__link" href="https://ec.europa.eu/commission/index_en">Commission and its priorities</a>
               </li>
               <li class="ecl-footer__list-item">
-                <a class="ecl-link ecl-link--inverted ecl-footer__link" href="https://ec.europa.eu/info/index_en">Policies information and services</a>
+                <a class="ecl-link ecl-link--inverted ecl-footer__link" href="https://ec.europa.eu/info/index_en">Policies, information and services</a>
               </li>
             </ul>
           </div>

--- a/website/index.html
+++ b/website/index.html
@@ -149,7 +149,7 @@ cl.add('has-js');
                   <a class="ecl-link ecl-link--inverted ecl-footer__link" href="https://ec.europa.eu/commission/index_en">Commission and its priorities</a>
                 </li>
                 <li class="ecl-footer__list-item">
-                  <a class="ecl-link ecl-link--inverted ecl-footer__link" href="https://ec.europa.eu/info/index_en">Policies information and services</a>
+                  <a class="ecl-link ecl-link--inverted ecl-footer__link" href="https://ec.europa.eu/info/index_en">Policies, information and services</a>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
`Policies information and services`-> `Policies, information and services`