### PR TITLE
chore: setup v2-dev branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,21 +1,6 @@
 branches:
   exclude: [ gh-pages ]
 
-clone:
-  git:
-    image: plugins/git
-    commands:
-      - git init
-      - git config core.ignorecase false
-      - git remote add origin ${DRONE_REMOTE_URL}
-      - git fetch --no-tags origin v2 ${DRONE_COMMIT_REF}
-      - git checkout -qf v2;
-      - if [ "${DRONE_BUILD_EVENT}" == "pull_request" ] || [ "${DRONE_BUILD_EVENT}" == "tag" ] ; then
-          git checkout -qf FETCH_HEAD;
-        else
-          git checkout -qf ${DRONE_COMMIT_BRANCH};
-        fi
-
 matrix:
   TEST:
     - audit

--- a/docs/04-documentation.md
+++ b/docs/04-documentation.md
@@ -155,7 +155,7 @@ Full example:
 ## Step 4: Open a pull request
 
 - Once you made sure you have saved changes on your particular branch, you are
-  ready to proceed on proposing these changes to the main `v2` branch which
+  ready to proceed on proposing these changes to the main `v2-dev` branch which
   is where you see the documentation in production.
 
 - You can simply use the hints which GitHub gives you when you go to the root of
@@ -174,7 +174,7 @@ Full example:
 
 Your pull request will be briefly reviewed by our team, so that there are no
 linting issues and if all checks are green, changes will be integrated with the
-v2 ECL branch in short time.
+v2-dev ECL branch in short time.
 
 Thank you!
 

--- a/docs/06-presets.md
+++ b/docs/06-presets.md
@@ -2,7 +2,7 @@
 
 A preset is a set of components from a specific system (EC or EU) bundled together for distribution.
 
-We currently offer 5 presets for each system:
+We currently offer 2 presets for each system:
 
 ## EC presets
 


### PR DESCRIPTION
This PR removes the custom git clone we needed in v1. It was needed for comparing screenshots between the main branch and the PR branch but since we don't use this feature anymore, we can remove it from the drone configuration.