### PR TITLE
fix: export classes correctly - INNO-1354

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/ec-component-gallery.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/ec-component-gallery.js
@@ -2,7 +2,7 @@ import createFocusTrap from 'focus-trap';
 
 import { queryOne, queryAll } from '@ecl/ec-base/helpers/dom';
 
-class Gallery {
+export class Gallery {
   constructor(
     element,
     {

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-message/ec-component-message.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-message/ec-component-message.js
@@ -1,6 +1,6 @@
 import { queryOne } from '@ecl/ec-base/helpers/dom';
 
-class Message {
+export class Message {
   constructor(
     element,
     {

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.js
@@ -11,7 +11,7 @@ export * from '@ecl/ec-component-file';
 // export * from '@ecl/ec-component-form-file-upload';
 export * from '@ecl/ec-component-gallery';
 // export * from '@ecl/ec-component-lang-select-page';
-// export * from '@ecl/ec-component-message';
+export * from '@ecl/ec-component-message';
 // export * from '@ecl/ec-component-inpage-navigation';
 // export * from '@ecl/ec-component-navigation-menu';
 // export * from '@ecl/ec-component-table';

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/eu-component-gallery.js
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/eu-component-gallery.js
@@ -2,7 +2,7 @@ import createFocusTrap from 'focus-trap';
 
 import { queryOne, queryAll } from '@ecl/eu-base/helpers/dom';
 
-class Gallery {
+export class Gallery {
   constructor(
     element,
     {

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-message/eu-component-message.js
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-message/eu-component-message.js
@@ -1,6 +1,6 @@
 import { queryOne } from '@ecl/eu-base/helpers/dom';
 
-class Message {
+export class Message {
   constructor(
     element,
     {

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-dev/src/eu-preset-dev.js
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-dev/src/eu-preset-dev.js
@@ -11,7 +11,7 @@ export * from '@ecl/eu-component-file';
 // export * from '@ecl/eu-component-form-file-upload';
 export * from '@ecl/eu-component-gallery';
 // export * from '@ecl/eu-component-lang-select-page';
-// export * from '@ecl/eu-component-message';
+export * from '@ecl/eu-component-message';
 // export * from '@ecl/eu-component-inpage-navigation';
 // export * from '@ecl/eu-component-navigation-menu';
 // export * from '@ecl/eu-component-table';


### PR DESCRIPTION
- Add `export` keyword to Message + Gallery
- Add missing export from the presets 

Both EC and EU