### PR TITLE
fix(file): rotate icon on expand/collapse - INNO-1382

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-component-file/ec-component-file.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-file/ec-component-file.scss
@@ -155,7 +155,7 @@
       display: block;
     }
 
-    .ecl-file__translation-toggle .ecl-link__icon {
+    .ecl-file__translation-toggle .ecl-button__icon {
       transform: rotate(0);
     }
   }

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-file/eu-component-file.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-file/eu-component-file.scss
@@ -155,7 +155,7 @@
       display: block;
     }
 
-    .ecl-file__translation-toggle .ecl-link__icon {
+    .ecl-file__translation-toggle .ecl-button__icon {
       transform: rotate(0);
     }
   }


### PR DESCRIPTION
The CSS was still based on the old markup (link instead of button)