### PR TITLE
fix(accordion): fix display issue on IE 11 - INNO-1381

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-component-accordion/ec-component-accordion.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-accordion/ec-component-accordion.scss
@@ -22,6 +22,7 @@
 
   .ecl-accordion__toggle {
     color: $toggle-color;
+    display: block;
     font: $ecl-font-prolonged-l;
     font-weight: bold;
     padding: $ecl-spacing-xs 0;

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-accordion/eu-component-accordion.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-accordion/eu-component-accordion.scss
@@ -22,6 +22,7 @@
 
   .ecl-accordion__toggle {
     color: $toggle-color;
+    display: block;
     font: $ecl-font-prolonged-l;
     font-weight: bold;
     padding: $ecl-spacing-xs 0;


### PR DESCRIPTION
Adding `display: block` on the button removes the extra spacing we have on IE 11.