### PR TITLE
refactor(table): set table-layout to auto - INNO-1425

### DIFF
--- a/src/generic/generic-component-table/_mixins.scss
+++ b/src/generic/generic-component-table/_mixins.scss
@@ -3,7 +3,7 @@
   border-width: 0;
   font-size: map-get($ecl-font-size, 's');
   margin: 0;
-  table-layout: fixed;
+  table-layout: auto;
   width: 100%;
 
   th {


### PR DESCRIPTION
# PR description

To see the issue and the correction:
- Use the preview to decrease width, but do not be in mobile viewport
- Edit cell data with the inspector, put single large string
- Select top-level `ecl-table` element, update CSS property from `table-layout`
- See the difference between `fixed` and `auto`

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

* [ ] `package.json` is up-to-date and `@ecl/[system]-base` is part of the dependencies
* [ ] I have checked the dependencies
* [ ] I have given the fractal status “ready” to my component
* [ ] I have declared `@define mycomponent` in the SCSS file
* [ ] I have specified `margin: 0;` on the CSS component
* [ ] I have provided tests
* [ ] I follow the naming guidelines
* [ ] the component supports composition
* [ ] there are no hardcoded strings (all content come from the context)
* [ ] I have filled the README.md file (at least a few lines)
* [ ] My component is listed in the root README
* [ ] My PR has the right label(s)
