### PR TITLE
fix(gallery): prevent body scroll - INNO-1428

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/ec-component-gallery.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/ec-component-gallery.js
@@ -258,6 +258,10 @@ export class Gallery {
 
     // Focus item
     this.selectedItem.focus();
+
+    // Enable scroll on body
+    document.body.classList.remove('ecl-u-disablescroll');
+    document.body.scroll = 'yes';
   }
 
   handleKeyPressOnItem(e) {
@@ -282,6 +286,10 @@ export class Gallery {
 
     // Trap focus
     this.focusTrap.activate();
+
+    // Disable scroll on body
+    document.body.classList.add('ecl-u-disablescroll');
+    document.body.scroll = 'no';
   }
 
   handleClickOnPreviousButton() {

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/ec-component-gallery.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/ec-component-gallery.js
@@ -261,7 +261,6 @@ export class Gallery {
 
     // Enable scroll on body
     document.body.classList.remove('ecl-u-disablescroll');
-    document.body.scroll = 'yes';
   }
 
   handleKeyPressOnItem(e) {
@@ -273,6 +272,9 @@ export class Gallery {
 
   handleClickOnItem(e) {
     e.preventDefault();
+
+    // Disable scroll on body
+    document.body.classList.add('ecl-u-disablescroll');
 
     // Display overlay
     if (this.isDialogSupported) {
@@ -286,10 +288,6 @@ export class Gallery {
 
     // Trap focus
     this.focusTrap.activate();
-
-    // Disable scroll on body
-    document.body.classList.add('ecl-u-disablescroll');
-    document.body.scroll = 'no';
   }
 
   handleClickOnPreviousButton() {

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/ec-component-gallery.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/ec-component-gallery.scss
@@ -185,6 +185,7 @@
 
   .ecl-gallery__overlay[open] {
     display: flex;
+    overflow: auto;
   }
 
   .ecl-gallery__close {

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-gallery/package.json
@@ -13,7 +13,8 @@
     "focus-trap": "^4.0.2"
   },
   "devDependencies": {
-    "@ecl/ec-specs-gallery": "^2.3.0"
+    "@ecl/ec-specs-gallery": "^2.3.0",
+    "@ecl/ec-utility-disablescroll": "^2.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/eu-component-gallery.js
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/eu-component-gallery.js
@@ -258,6 +258,10 @@ export class Gallery {
 
     // Focus item
     this.selectedItem.focus();
+
+    // Enable scroll on body
+    document.body.classList.remove('ecl-u-disablescroll');
+    document.body.scroll = 'yes';
   }
 
   handleKeyPressOnItem(e) {
@@ -282,6 +286,10 @@ export class Gallery {
 
     // Trap focus
     this.focusTrap.activate();
+
+    // Disable scroll on body
+    document.body.classList.add('ecl-u-disablescroll');
+    document.body.scroll = 'no';
   }
 
   handleClickOnPreviousButton() {

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/eu-component-gallery.js
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/eu-component-gallery.js
@@ -261,7 +261,6 @@ export class Gallery {
 
     // Enable scroll on body
     document.body.classList.remove('ecl-u-disablescroll');
-    document.body.scroll = 'yes';
   }
 
   handleKeyPressOnItem(e) {
@@ -273,6 +272,9 @@ export class Gallery {
 
   handleClickOnItem(e) {
     e.preventDefault();
+
+    // Disable scroll on body
+    document.body.classList.add('ecl-u-disablescroll');
 
     // Display overlay
     if (this.isDialogSupported) {
@@ -286,10 +288,6 @@ export class Gallery {
 
     // Trap focus
     this.focusTrap.activate();
-
-    // Disable scroll on body
-    document.body.classList.add('ecl-u-disablescroll');
-    document.body.scroll = 'no';
   }
 
   handleClickOnPreviousButton() {

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/eu-component-gallery.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/eu-component-gallery.scss
@@ -185,6 +185,7 @@
 
   .ecl-gallery__overlay[open] {
     display: flex;
+    overflow: auto;
   }
 
   .ecl-gallery__close {

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/package.json
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-gallery/package.json
@@ -13,7 +13,8 @@
     "focus-trap": "^4.0.2"
   },
   "devDependencies": {
-    "@ecl/eu-specs-gallery": "^2.3.0"
+    "@ecl/eu-specs-gallery": "^2.3.0",
+    "@ecl/eu-utility-disablescroll": "^2.3.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# PR description

Prevent page body from scrolling when gallery overlay is displayed

To test: 
- reduce window width to have a vertical scrolling on the gallery
- click on a gallery item to open the overlay
- no scrollbar displayed, scrolling with the mouse does not affect the display
- close the overlay; body hasn't scrolled (last selected gallery item is focused)
