### PR TITLE
feat(feedback-form): add template - INNO-1437

### DIFF
--- a/src/systems/ec/implementations/react/templates/feedback-form/examples/Default.jsx
+++ b/src/systems/ec/implementations/react/templates/feedback-form/examples/Default.jsx
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+
+import data from '@ecl/ec-specs-feedback-form/demo/data';
+
+import FeedbackForm from '../src/FeedbackForm';
+
+export default () => {
+  return <FeedbackForm footer={data.footer} />;
+};

--- a/src/systems/ec/implementations/react/templates/feedback-form/examples/Expanded.jsx
+++ b/src/systems/ec/implementations/react/templates/feedback-form/examples/Expanded.jsx
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+
+import data from '@ecl/ec-specs-feedback-form/demo/data';
+
+import FeedbackForm from '../src/FeedbackForm';
+
+export default () => {
+  return <FeedbackForm footer={data.footer} isExpanded="true" />;
+};

--- a/src/systems/ec/implementations/react/templates/feedback-form/examples/Expanded.jsx
+++ b/src/systems/ec/implementations/react/templates/feedback-form/examples/Expanded.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 
 import data from '@ecl/ec-specs-feedback-form/demo/data';
 
-import FeedbackForm from '../src/FeedbackForm';
+import FeedbackFormExpanded from '../src/FeedbackFormExpanded';
 
 export default () => {
-  return <FeedbackForm footer={data.footer} isExpanded="true" />;
+  return <FeedbackFormExpanded footer={data.footer} />;
 };

--- a/src/systems/ec/implementations/react/templates/feedback-form/index.js
+++ b/src/systems/ec/implementations/react/templates/feedback-form/index.js
@@ -1,0 +1,1 @@
+export default from './src/FeedbackForm';

--- a/src/systems/ec/implementations/react/templates/feedback-form/package.json
+++ b/src/systems/ec/implementations/react/templates/feedback-form/package.json
@@ -1,0 +1,32 @@
+{
+  "private": true,
+  "name": "@ecl/ec-react-feedback-form",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "2.3.0",
+  "description": "ECL EC React Feedback Form",
+  "main": "index.js",
+  "module": "index.js",
+  "dependencies": {
+    "@ecl/ec-react-component-button": "^2.3.0",
+    "@ecl/ec-react-component-footer": "^2.3.0",
+    "@ecl/ec-react-component-link": "^2.3.0",
+    "@ecl/ec-react-component-select": "^2.3.0",
+    "@ecl/ec-react-component-text-area": "^2.3.0"
+  },
+  "devDependencies": {
+    "@ecl/ec-layout-grid": "^2.3.0",
+    "@ecl/ec-specs-search-page": "^2.3.0",
+    "@ecl/ec-utility-colorize": "^2.3.0",
+    "@ecl/ec-utility-display": "^2.3.0",
+    "@ecl/ec-utility-flex": "^2.3.0",
+    "@ecl/ec-utility-spacing": "^2.3.0",
+    "@ecl/ec-utility-typography": "^2.3.0"
+  },
+  "peerDependencies": {
+    "classnames": "^2.2.6",
+    "prop-types": "^15.6.2",
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2"
+  }
+}

--- a/src/systems/ec/implementations/react/templates/feedback-form/src/FeedbackForm.jsx
+++ b/src/systems/ec/implementations/react/templates/feedback-form/src/FeedbackForm.jsx
@@ -1,0 +1,74 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+import Button from '@ecl/ec-react-component-button';
+import Footer from '@ecl/ec-react-component-footer';
+import Link from '@ecl/ec-react-component-link';
+import Select from '@ecl/ec-react-component-select';
+import TextArea from '@ecl/ec-react-component-text-area';
+
+const FeedbackForm = ({ footer, isExpanded }) => (
+  <Fragment>
+    <section className="ecl-u-bg-grey-10 ecl-u-type-m">
+      <div className="ecl-container ecl-u-pv-m ecl-u-d-flex ecl-u-flex-wrap ecl-u-align-items-center">
+        <span className="ecl-u-flex-basis-100 ecl-u-flex-basis-md-auto">
+          Was this page useful?
+          <Button className="ecl-u-ml-s" label="Yes" variant="secondary" />
+          <Button className="ecl-u-ml-xs" label="No" variant="secondary" />
+        </span>
+        <span className="ecl-u-ml-md-auto">
+          <Link
+            href="/example"
+            label="Is there an issue with this page?"
+            icon={{
+              shape: 'ui--corner-arrow',
+              transform: 'rotate-180',
+              size: 'fluid',
+            }}
+          />
+        </span>
+      </div>
+
+      <div
+        className="ecl-container ecl-u-pv-xl"
+        {...(!isExpanded ? { hidden: true } : {})}
+      >
+        <Select
+          label="What type of issue would you like to report?"
+          options={[
+            {
+              value: '1',
+              label: 'There is a technical problem with this page',
+            },
+            {
+              value: '2',
+              label: "I can't find the information I am looking for",
+            },
+            {
+              value: '3',
+              label: 'Other',
+            },
+          ]}
+        />
+        <TextArea
+          label="Please describe the issue"
+          placeholder="Please do not include any personal information."
+        />
+        <Button label="Submit" variant="primary" />
+      </div>
+    </section>
+    <Footer {...footer} />
+  </Fragment>
+);
+
+FeedbackForm.propTypes = {
+  footer: PropTypes.shape(Footer.propTypes),
+  isExpanded: PropTypes.bool,
+};
+
+FeedbackForm.defaultProps = {
+  footer: {},
+  isExpanded: false,
+};
+
+export default FeedbackForm;

--- a/src/systems/ec/implementations/react/templates/feedback-form/src/FeedbackFormExpanded.jsx
+++ b/src/systems/ec/implementations/react/templates/feedback-form/src/FeedbackFormExpanded.jsx
@@ -4,28 +4,50 @@ import PropTypes from 'prop-types';
 import Button from '@ecl/ec-react-component-button';
 import Footer from '@ecl/ec-react-component-footer';
 import Link from '@ecl/ec-react-component-link';
+import Select from '@ecl/ec-react-component-select';
+import TextArea from '@ecl/ec-react-component-text-area';
 
 const FeedbackForm = ({ footer }) => (
   <Fragment>
     <section className="ecl-u-bg-grey-10 ecl-u-type-m">
       <div className="ecl-container ecl-u-pv-m ecl-u-d-flex ecl-u-flex-wrap ecl-u-align-items-center">
-        <span className="ecl-u-flex-basis-100 ecl-u-flex-basis-md-auto">
-          Was this page useful?
-          <Button className="ecl-u-ml-s" label="Yes" variant="secondary" />
-          <Button className="ecl-u-ml-xs" label="No" variant="secondary" />
-        </span>
-
         <span className="ecl-u-ml-md-auto">
           <Link
             href="/example"
             label="Is there an issue with this page?"
             icon={{
               shape: 'ui--corner-arrow',
-              transform: 'rotate-180',
               size: 'fluid',
             }}
           />
         </span>
+      </div>
+      <hr />
+      <div className="ecl-container ecl-u-pv-xl">
+        <Select
+          id="feedback-form-type"
+          label="What type of issue would you like to report?"
+          options={[
+            {
+              value: '1',
+              label: 'There is a technical problem with this page',
+            },
+            {
+              value: '2',
+              label: "I can't find the information I am looking for",
+            },
+            {
+              value: '3',
+              label: 'Other',
+            },
+          ]}
+        />
+        <TextArea
+          id="feedback-form-issue"
+          label="Please describe the issue"
+          placeholder="Please do not include any personal information."
+        />
+        <Button className="ecl-u-mt-l" label="Submit" variant="primary" />
       </div>
     </section>
     <Footer {...footer} />

--- a/src/systems/ec/implementations/react/templates/feedback-form/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/feedback-form/stories/Index.jsx
@@ -1,0 +1,8 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { storiesOf } from '@storybook/react';
+import FeedbackFormDefault from '../examples/Default';
+import FeedbackFormExpanded from '../examples/Expanded';
+
+storiesOf('Templates/Feedback form', module)
+  .add('default', FeedbackFormDefault)
+  .add('expanded', FeedbackFormExpanded);

--- a/src/systems/ec/implementations/vanilla/packages/ec-utility-flex/ec-utility-flex.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-utility-flex/ec-utility-flex.scss
@@ -119,6 +119,13 @@
       .ecl-u-flex-grow#{$infix}-1 {
         flex-grow: 1;
       }
+
+      .ecl-u-flex-basis#{$infix}-100 {
+        flex-basis: 100%;
+      }
+      .ecl-u-flex-basis#{$infix}-auto {
+        flex-basis: auto;
+      }
     }
   }
 }

--- a/src/systems/ec/specs/templates/feedback-form/demo/data.js
+++ b/src/systems/ec/specs/templates/feedback-form/demo/data.js
@@ -1,0 +1,6 @@
+/* eslint "import/no-extraneous-dependencies": ["error", { "devDependencies": true } ] */
+const footerContent = require('@ecl/ec-specs-footer/demo/data--corporate');
+
+module.exports = {
+  footer: footerContent,
+};

--- a/src/systems/ec/specs/templates/feedback-form/package.json
+++ b/src/systems/ec/specs/templates/feedback-form/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@ecl/ec-specs-feedback-form",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "2.3.0",
+  "description": "ECL EC Feedback Form Specs",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@ecl/ec-specs-footer": "^2.3.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}

--- a/src/systems/ec/themes/default/aliases/colors-bg.yml
+++ b/src/systems/ec/themes/default/aliases/colors-bg.yml
@@ -24,3 +24,46 @@ props:
     comment: Tertiary background colour
     type: color
     category: background-color
+
+  # Greys
+
+  - name: BG_COLOR_GREY_100
+    value: '{!COLOR_GREY_100}'
+    comment: Grey 100 background colour
+    type: color
+    category: background-color
+  - name: BG_COLOR_GREY_75
+    value: '{!COLOR_GREY_75}'
+    comment: Grey 75 background colour
+    type: color
+    category: background-color
+  - name: BG_COLOR_GREY_50
+    value: '{!COLOR_GREY_50}'
+    comment: Grey 50 background colour
+    type: color
+    category: background-color
+  - name: BG_COLOR_GREY_25
+    value: '{!COLOR_GREY_25}'
+    comment: Grey 25 background colour
+    type: color
+    category: background-color
+  - name: BG_COLOR_GREY_20
+    value: '{!COLOR_GREY_20}'
+    comment: Grey 20 background colour
+    type: color
+    category: background-color
+  - name: BG_COLOR_GREY_15
+    value: '{!COLOR_GREY_15}'
+    comment: Grey 15 background colour
+    type: color
+    category: background-color
+  - name: BG_COLOR_GREY_10
+    value: '{!COLOR_GREY_10}'
+    comment: Grey 10 background colour
+    type: color
+    category: background-color
+  - name: BG_COLOR_GREY_5
+    value: '{!COLOR_GREY_5}'
+    comment: Grey 5 background colour
+    type: color
+    category: background-color

--- a/src/website/src/pages/ec/templates/feedback-form/docs/code.mdx
+++ b/src/website/src/pages/ec/templates/feedback-form/docs/code.mdx
@@ -1,0 +1,24 @@
+---
+title: Showcase
+order: 2
+---
+
+import Playground from '@ecl/website-components/Playground';
+import FeedbackFormDefault from '@ecl/ec-react-feedback-form/examples/Default';
+import FeedbackFormExpanded from '@ecl/ec-react-feedback-form/examples/Expanded';
+
+<Playground
+  system="ec"
+  selectedKind="templates-feedback-form"
+  selectedStory="default"
+>
+  <SearchPageExample />
+</Playground>
+
+<Playground
+  system="ec"
+  selectedKind="templates-feedback-form"
+  selectedStory="expanded"
+>
+  <SearchPageExample />
+</Playground>

--- a/src/website/src/pages/ec/templates/feedback-form/docs/code.mdx
+++ b/src/website/src/pages/ec/templates/feedback-form/docs/code.mdx
@@ -12,7 +12,7 @@ import FeedbackFormExpanded from '@ecl/ec-react-feedback-form/examples/Expanded'
   selectedKind="templates-feedback-form"
   selectedStory="default"
 >
-  <SearchPageExample />
+  <FeedbackFormDefault />
 </Playground>
 
 <Playground
@@ -20,5 +20,5 @@ import FeedbackFormExpanded from '@ecl/ec-react-feedback-form/examples/Expanded'
   selectedKind="templates-feedback-form"
   selectedStory="expanded"
 >
-  <SearchPageExample />
+  <FeedbackFormExpanded />
 </Playground>

--- a/src/website/src/pages/ec/templates/feedback-form/docs/usage.md
+++ b/src/website/src/pages/ec/templates/feedback-form/docs/usage.md
@@ -1,0 +1,6 @@
+---
+title: Usage
+order: 1
+---
+
+(work in progress)

--- a/src/website/src/pages/ec/templates/feedback-form/index.md
+++ b/src/website/src/pages/ec/templates/feedback-form/index.md
@@ -1,0 +1,5 @@
+---
+title: Feedback form
+defaultTab: usage
+status: ready
+---


### PR DESCRIPTION
# PR description

Add template to showcase the feedback form

Note: 
- there is no js behavior here, templates just display the feedback form in two different states
- several design specifications are unclear of missing, so display isn't optimal for now
