### PR TITLE
poc(axe-core): test into website - INNO-728

### DIFF
--- a/src/systems/ec/implementations/react/packages/accordion/src/AccordionItem.jsx
+++ b/src/systems/ec/implementations/react/packages/accordion/src/AccordionItem.jsx
@@ -19,7 +19,7 @@ const AccordionItem = ({ id, toggle, level, children }) => {
             variant="ghost"
             icon={{ shape: toggle.iconShape, size: 's' }}
             iconPosition="before"
-            label={toggle.label}
+            label=""
           />
         </HeadingTag>
       )}

--- a/src/systems/ec/implementations/react/packages/button/src/Button.jsx
+++ b/src/systems/ec/implementations/react/packages/button/src/Button.jsx
@@ -35,9 +35,7 @@ const Button = ({
     <button {...props} type={type} className={classNames} disabled={disabled}>
       <span className="ecl-button__container">
         {iconPosition === 'before' && iconMarkup}
-        <span className="ecl-button__label" data-ecl-label>
-          {label}
-        </span>
+        <span className="ecl-button__label" data-ecl-label />
         {iconPosition === 'after' && iconMarkup}
       </span>
     </button>

--- a/src/tools/website-components/Playground.jsx
+++ b/src/tools/website-components/Playground.jsx
@@ -4,6 +4,7 @@ import ReactDOMServer from 'react-dom/server';
 import PropTypes from 'prop-types';
 import Prism from 'prismjs';
 import { html as beautifyHtml } from 'js-beautify';
+import Axe from 'axe-core';
 
 import iconSprite from '@ecl/ec-resources-icons/dist/sprites/icons.svg';
 import Iframe from './Showcase/Iframe';
@@ -35,6 +36,12 @@ class Playground extends PureComponent {
       );
       this.showcaseCodeRef.current.style.maxHeight = `${this.maxHeight}px`;
     }
+
+    // Axe core test
+    const showcases = document.querySelectorAll('[data-axe]');
+    Axe.run(showcases, function(err, results) {
+      if (results) console.log(results.violations);
+    });
   }
 
   handleClickOnToggle() {

--- a/src/tools/website-components/Playground.jsx
+++ b/src/tools/website-components/Playground.jsx
@@ -83,7 +83,7 @@ class Playground extends PureComponent {
 
     return (
       <div className={styles.playground}>
-        <div className={styles.showcase}>
+        <div className={styles.showcase} data-axe>
           {!hideDemo && (
             <Fragment>
               {showFrame && fullFrameUrl ? (

--- a/src/tools/website-components/package.json
+++ b/src/tools/website-components/package.json
@@ -4,6 +4,7 @@
   "version": "2.3.0",
   "main": "index.js",
   "dependencies": {
+    "axe-core": "3.2.2",
     "clipboard": "2.0.4",
     "js-beautify": "1.9.1",
     "prismjs": "1.16.0",

--- a/src/website/package.json
+++ b/src/website/package.json
@@ -20,6 +20,7 @@
     "@hot-loader/react-dom": "16.8.6",
     "@mdx-js/mdx": "1.0.4",
     "@mdx-js/react": "1.0.2",
+    "axe-core": "3.2.2",
     "classnames": "2.2.6",
     "core-js": "3.0.1",
     "deepmerge": "3.2.0",

--- a/src/website/src/components/DocPage/DocPage.jsx
+++ b/src/website/src/components/DocPage/DocPage.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { /* Route, Redirect, Switch, */ withRouter } from 'react-router-dom';
 import Prism from 'prismjs';
-import Axe from 'axe-core';
 
 import Header from './Header';
 import ScrollToTopOnMount from '../ScrollToTopOnMount/ScrollToTopOnMount';
@@ -15,11 +14,6 @@ import styles from './DocPage.scss';
 class DocPage extends Component {
   componentDidMount() {
     Prism.highlightAllUnder(document.querySelector('#main-content'));
-
-    const showcases = document.querySelectorAll('[data-axe]');
-    Axe.run(showcases, function(err, results) {
-      if (results) console.log(results.violations);
-    });
   }
 
   render() {

--- a/src/website/src/components/DocPage/DocPage.jsx
+++ b/src/website/src/components/DocPage/DocPage.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { /* Route, Redirect, Switch, */ withRouter } from 'react-router-dom';
 import Prism from 'prismjs';
+import Axe from 'axe-core';
 
 import Header from './Header';
 import ScrollToTopOnMount from '../ScrollToTopOnMount/ScrollToTopOnMount';
@@ -14,6 +15,11 @@ import styles from './DocPage.scss';
 class DocPage extends Component {
   componentDidMount() {
     Prism.highlightAllUnder(document.querySelector('#main-content'));
+
+    const showcases = document.querySelectorAll('[data-axe]');
+    Axe.run(showcases, function(err, results) {
+      if (results) console.log(results.violations);
+    });
   }
 
   render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3253,7 +3253,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@^3.1.2:
+axe-core@3.2.2, axe-core@^3.1.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.2.2.tgz#b06d6e9ae4636d706068843272bfaeed3fe97362"
   integrity sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA==


### PR DESCRIPTION
**Important**: This PR is a PoC, and is not intended to be merged as is.

Try to run axe-core tests on each component in the website, to get an accessibility report.
Currenlty report is generated for components integrated directly into the website, but not for iframes.

Buttons and Accordions have been altered to generate errors (no label)

Result can been seen here (check the console):
- https://deploy-preview-1087--europa-component-library.netlify.com/ec/components/button/code/
- https://deploy-preview-1087--europa-component-library.netlify.com/ec/components/accordion/code/

Resources:
- [axe-core API](https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#options-parameter)
- [tests in iframes](https://dequeuniversity.com/rules/axe/3.2/frame-tested)