### PR TITLE
fix(list): change spacing - INNO-1488

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-component-list/ec-component-list.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-list/ec-component-list.scss
@@ -15,9 +15,9 @@
   .ecl-ordered-list {
     color: $text-color;
     font: $ecl-font-prolonged-m;
+    list-style-position: outside;
     margin: 0;
-    // Approximately centered bullet
-    padding-left: calc((#{$ecl-spacing-s} * 2) + 0.3em);
+    padding-left: $ecl-spacing-2-xl;
   }
 
   .ecl-ordered-list .ecl-ordered-list {
@@ -43,9 +43,9 @@
   .ecl-unordered-list {
     color: $text-color;
     font: $ecl-font-prolonged-m;
+    list-style-position: outside;
     margin: 0;
-    // Approximately centered bullet
-    padding-left: calc((#{$ecl-spacing-s} * 2) + 0.3em);
+    padding-left: $ecl-spacing-2-xl;
   }
 
   .ecl-unordered-list .ecl-unordered-list {

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-list/eu-component-list.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-list/eu-component-list.scss
@@ -15,9 +15,9 @@
   .ecl-ordered-list {
     color: $text-color;
     font: $ecl-font-prolonged-m;
+    list-style-position: outside;
     margin: 0;
-    // Approximately centered bullet
-    padding-left: calc((#{$ecl-spacing-s} * 2) + 0.3em);
+    padding-left: $ecl-spacing-2-xl;
   }
 
   .ecl-ordered-list .ecl-ordered-list {
@@ -43,9 +43,9 @@
   .ecl-unordered-list {
     color: $text-color;
     font: $ecl-font-prolonged-m;
+    list-style-position: outside;
     margin: 0;
-    // Approximately centered bullet
-    padding-left: calc((#{$ecl-spacing-s} * 2) + 0.3em);
+    padding-left: $ecl-spacing-2-xl;
   }
 
   .ecl-unordered-list .ecl-unordered-list {


### PR DESCRIPTION
As discussed on the specs https://webgate.ec.europa.eu/CITnet/confluence/display/NEXTEUROPA/Lists+-+Design+specifications?focusedCommentId=881728990#comment-881728990

- `padding-left` is now `2.5rem` (or "2XL")
- `list-style-position: outside;` is now explicit