### PR TITLE
feat(messages) Control the bottom margin

### DIFF
--- a/src/generic/generic-component-message/generic-component-message.scss
+++ b/src/generic/generic-component-message/generic-component-message.scss
@@ -20,7 +20,7 @@
     border: 2px solid map-get($ecl-colors, 'blue-75');
     color: $ecl-color-shade;
     font-size: map-get($ecl-font-size, 's');
-    margin: 0;
+    margin: 0 0 map-get($ecl-spacing, 'm');
     min-height: map-get($ecl-spacing, 'l');
     padding: map-get($ecl-spacing, 'xs') map-get($ecl-spacing, 'xxl') +
       map-get($ecl-spacing, 'xxs') map-get($ecl-spacing, 'xs')


### PR DESCRIPTION
Messages currently are getting too close to other elements that follow below them. In the strategy Bootstrap is using each component controls its space with at-least the element that follows.

# PR description

Install the theme and force Drupal to display a message (create or update a node). A message is displayed but is touches the elements underneath it. 
![2019-05-21_0930](https://user-images.githubusercontent.com/690575/58076657-17c63300-7bab-11e9-9a67-fd281bf284f3.png)

In Bartik, messages control their distance  from top and bottom.
![2019-05-21_0928](https://user-images.githubusercontent.com/690575/58076767-58be4780-7bab-11e9-8b51-aea7c8e7fc3b.png)


## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

* [x] `package.json` is up-to-date and `@ecl/[system]-base` is part of the dependencies
* [x] I have checked the dependencies
* [x] I have given the fractal status “ready” to my component
* [x] I have declared `@define mycomponent` in the SCSS file
* [ ] I have specified `margin: 0;` on the CSS component
* [ ] I have provided tests
* [x] I follow the naming guidelines
* [ ] the component supports composition
* [ ] there are no hardcoded strings (all content come from the context)
* [ ] I have filled the README.md file (at least a few lines)
* [ ] My component is listed in the root README
* [x] My PR has the right label(s)
