### PR TITLE
feat(links): add CTA variant - INNO-1580

### DIFF
--- a/src/systems/ec/implementations/react/components/hero-banner/src/HeroBanner.jsx
+++ b/src/systems/ec/implementations/react/components/hero-banner/src/HeroBanner.jsx
@@ -35,13 +35,7 @@ const HeroBanner = ({
           {description && (
             <p className="ecl-hero-banner__description">{description}</p>
           )}
-          {link && link.label && (
-            <Link
-              {...link}
-              variant="standalone"
-              className="ecl-hero-banner__link"
-            />
-          )}
+          {link && link.label && <Link {...link} variant="cta" />}
           {/* DEPRECATED */}
           {button && button.label && (
             <Button {...button} className="ecl-hero-banner__button" />

--- a/src/systems/ec/implementations/react/components/link/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/link/stories/Index.jsx
@@ -5,6 +5,7 @@ import { withKnobs, text, select } from '@storybook/addon-knobs';
 
 import demoContentDefault from '@ecl/ec-specs-link/demo/data--default';
 import demoContentStandalone from '@ecl/ec-specs-link/demo/data--standalone';
+import demoContentCTA from '@ecl/ec-specs-link/demo/data--cta';
 import uiIcons from '@ecl/ec-resources-icons/dist/lists/ui.json';
 
 import Link from '../src/Link';
@@ -53,6 +54,22 @@ storiesOf('Components|Navigation/Link', module)
         variant="standalone"
         href="/example#standalone-link"
         label={text('Label', demoContentStandalone.label)}
+        icon={linkIcon}
+        iconPosition={select('Icon position', iconPosition, 'after')}
+      />
+    );
+  })
+  .add('call-to-action', () => {
+    const linkIcon = {
+      shape: select('Icon (sample)', icons, ''),
+      size: 'fluid',
+    };
+
+    return (
+      <Link
+        variant={demoContentCTA.variant}
+        href={demoContentCTA.href}
+        label={text('Label', demoContentCTA.label)}
         icon={linkIcon}
         iconPosition={select('Icon position', iconPosition, 'after')}
       />

--- a/src/systems/ec/implementations/react/components/page-banner/src/PageBanner.jsx
+++ b/src/systems/ec/implementations/react/components/page-banner/src/PageBanner.jsx
@@ -36,8 +36,8 @@ const PageBanner = ({
           {link && link.label && (
             <Link
               {...link}
-              variant="standalone"
-              className="ecl-page-banner__link"
+              variant="cta"
+              className="ecl-page-banner__link-cta"
             />
           )}
           {/* DEPRECATED */}

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-hero-banner/ec-component-hero-banner.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-hero-banner/ec-component-hero-banner.scss
@@ -65,6 +65,7 @@
     margin-top: 0;
   }
 
+  /* DEPRECATED */
   .ecl-hero-banner__link {
     font-weight: $ecl-font-weight-bold;
     padding: $ecl-spacing-m $ecl-spacing-s;
@@ -146,6 +147,7 @@
       color: $description-color-primary;
     }
 
+    /* DEPRECATED */
     .ecl-hero-banner__link,
     .ecl-hero-banner__link:hover,
     .ecl-hero-banner__link:focus {
@@ -224,6 +226,7 @@
         color: $description-color-image-shade;
       }
 
+      /* DEPRECATED */
       /* stylelint-disable-next-line no-descending-specificity */
       .ecl-hero-banner__link,
       .ecl-hero-banner__link:hover,

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-link/ec-component-link-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-link/ec-component-link-print.scss
@@ -39,6 +39,11 @@
     font-family: $ecl-font-family-print;
     text-decoration: none;
   }
+
+  .ecl-link--cta {
+    font-family: $ecl-font-family-print;
+    text-decoration: none;
+  }
 }
 
 // Use mixin

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-link/ec-component-link.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-link/ec-component-link.scss
@@ -69,6 +69,34 @@
     }
     /* stylelint-enable */
   }
+
+  .ecl-link--cta {
+    background-color: $ecl-color-yellow-100;
+    box-sizing: border-box;
+    color: $ecl-color-black-100;
+    display: inline-block;
+    font: $ecl-font-m;
+    font-weight: $ecl-font-weight-bold;
+    padding: $ecl-spacing-s $ecl-spacing-m;
+    text-decoration: underline;
+
+    /* stylelint-disable */
+    &.ecl-link--icon {
+      display: inline-flex;
+      text-decoration: none;
+    }
+
+    &:hover,
+    &:active {
+      border: 2px solid $ecl-color-black-100;
+      padding: calc(#{$ecl-spacing-s} - 2px) calc(#{$ecl-spacing-m} - 2px);
+    }
+
+    &:focus {
+      outline: 3px solid $ecl-color-black-100;
+      outline-offset: -3px;
+    }
+  }
 }
 
 // Use mixin

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-link/ec-component-link.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-link/ec-component-link.scss
@@ -74,17 +74,10 @@
     background-color: $ecl-color-yellow-100;
     box-sizing: border-box;
     color: $ecl-color-black-100;
-    display: inline-block;
+    display: inline-flex;
     font: $ecl-font-m;
     font-weight: $ecl-font-weight-bold;
     padding: $ecl-spacing-s $ecl-spacing-m;
-    text-decoration: underline;
-
-    /* stylelint-disable */
-    &.ecl-link--icon {
-      display: inline-flex;
-      text-decoration: none;
-    }
 
     &:hover,
     &:active {
@@ -93,7 +86,7 @@
     }
 
     &:focus {
-      outline: 3px solid $ecl-color-black-100;
+      outline-color: $ecl-color-black-100;
       outline-offset: -3px;
     }
   }

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-page-banner/ec-component-page-banner.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-page-banner/ec-component-page-banner.scss
@@ -65,10 +65,15 @@
     margin-top: $ecl-spacing-m;
   }
 
+  /* DEPRECATED */
   .ecl-page-banner__link {
     font-weight: $ecl-font-weight-bold;
     margin-top: $ecl-spacing-m;
     padding: $ecl-spacing-m $ecl-spacing-s;
+  }
+
+  .ecl-page-banner__link-cta {
+    margin-top: $ecl-spacing-m;
   }
 
   /* stylelint-disable-next-line order/order */
@@ -156,6 +161,7 @@
       color: $baseline-color-primary;
     }
 
+    /* DEPRECATED */
     .ecl-page-banner__link,
     .ecl-page-banner__link:hover,
     .ecl-page-banner__link:focus {
@@ -242,6 +248,7 @@
         color: $baseline-color-image-shade;
       }
 
+      /* DEPRECATED */
       /* stylelint-disable-next-line no-descending-specificity */
       .ecl-page-banner__link,
       .ecl-page-banner__link:hover,

--- a/src/systems/ec/specs/components/link/demo/data--cta-icon.js
+++ b/src/systems/ec/specs/components/link/demo/data--cta-icon.js
@@ -1,0 +1,11 @@
+// Simple content for demo
+module.exports = {
+  variant: 'cta',
+  label: 'Call to action link with icon',
+  href: '/example#link-cta',
+  icon: {
+    shape: 'ui--corner-arrow',
+    transform: 'rotate-90',
+    size: 'fluid',
+  },
+};

--- a/src/systems/ec/specs/components/link/demo/data--cta.js
+++ b/src/systems/ec/specs/components/link/demo/data--cta.js
@@ -1,0 +1,6 @@
+// Simple content for demo
+module.exports = {
+  variant: 'cta',
+  label: 'Call to action link',
+  href: '/example#link-cta',
+};

--- a/src/systems/eu/implementations/react/components/hero-banner/src/HeroBanner.jsx
+++ b/src/systems/eu/implementations/react/components/hero-banner/src/HeroBanner.jsx
@@ -35,13 +35,7 @@ const HeroBanner = ({
           {description && (
             <p className="ecl-hero-banner__description">{description}</p>
           )}
-          {link && link.label && (
-            <Link
-              {...link}
-              variant="standalone"
-              className="ecl-hero-banner__link"
-            />
-          )}
+          {link && link.label && <Link {...link} variant="cta" />}
           {/* DEPRECATED */}
           {button && button.label && (
             <Button {...button} className="ecl-hero-banner__button" />

--- a/src/systems/eu/implementations/react/components/link/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/link/stories/Index.jsx
@@ -5,6 +5,7 @@ import { withKnobs, text, select } from '@storybook/addon-knobs';
 
 import demoContentDefault from '@ecl/eu-specs-link/demo/data--default';
 import demoContentStandalone from '@ecl/eu-specs-link/demo/data--standalone';
+import demoContentCTA from '@ecl/eu-specs-link/demo/data--cta';
 import uiIcons from '@ecl/eu-resources-icons/dist/lists/ui.json';
 
 import Link from '../src/Link';
@@ -53,6 +54,22 @@ storiesOf('Components|Navigation/Link', module)
         variant="standalone"
         href="/example#standalone-link"
         label={text('Label', demoContentStandalone.label)}
+        icon={linkIcon}
+        iconPosition={select('Icon position', iconPosition, 'after')}
+      />
+    );
+  })
+  .add('call-to-action', () => {
+    const linkIcon = {
+      shape: select('Icon (sample)', icons, ''),
+      size: 'fluid',
+    };
+
+    return (
+      <Link
+        variant={demoContentCTA.variant}
+        href={demoContentCTA.href}
+        label={text('Label', demoContentCTA.label)}
         icon={linkIcon}
         iconPosition={select('Icon position', iconPosition, 'after')}
       />

--- a/src/systems/eu/implementations/react/components/page-banner/src/PageBanner.jsx
+++ b/src/systems/eu/implementations/react/components/page-banner/src/PageBanner.jsx
@@ -36,8 +36,8 @@ const PageBanner = ({
           {link && link.label && (
             <Link
               {...link}
-              variant="standalone"
-              className="ecl-page-banner__link"
+              variant="cta"
+              className="ecl-page-banner__link-cta"
             />
           )}
           {/* DEPRECATED */}

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-hero-banner/eu-component-hero-banner.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-hero-banner/eu-component-hero-banner.scss
@@ -65,6 +65,7 @@
     margin-top: 0;
   }
 
+  /* DEPRECATED */
   .ecl-hero-banner__link {
     font-weight: $ecl-font-weight-bold;
     padding: $ecl-spacing-m $ecl-spacing-s;
@@ -146,6 +147,7 @@
       color: $description-color-primary;
     }
 
+    /* DEPRECATED */
     .ecl-hero-banner__link,
     .ecl-hero-banner__link:hover,
     .ecl-hero-banner__link:focus {
@@ -224,6 +226,7 @@
         color: $description-color-image-shade;
       }
 
+      /* DEPRECATED */
       /* stylelint-disable-next-line no-descending-specificity */
       .ecl-hero-banner__link,
       .ecl-hero-banner__link:hover,

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-link/eu-component-link-print.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-link/eu-component-link-print.scss
@@ -39,6 +39,11 @@
     font-family: $ecl-font-family-print;
     text-decoration: none;
   }
+
+  .ecl-link--cta {
+    font-family: $ecl-font-family-print;
+    text-decoration: none;
+  }
 }
 
 // Use mixin

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-link/eu-component-link.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-link/eu-component-link.scss
@@ -69,6 +69,34 @@
     }
     /* stylelint-enable */
   }
+
+  .ecl-link--cta {
+    background-color: $ecl-color-yellow-100;
+    box-sizing: border-box;
+    color: $ecl-color-black-100;
+    display: inline-block;
+    font: $ecl-font-m;
+    font-weight: $ecl-font-weight-bold;
+    padding: $ecl-spacing-s $ecl-spacing-m;
+    text-decoration: underline;
+
+    /* stylelint-disable */
+    &.ecl-link--icon {
+      display: inline-flex;
+      text-decoration: none;
+    }
+
+    &:hover,
+    &:active {
+      border: 2px solid $ecl-color-black-100;
+      padding: calc(#{$ecl-spacing-s} - 2px) calc(#{$ecl-spacing-m} - 2px);
+    }
+
+    &:focus {
+      outline: 3px solid $ecl-color-black-100;
+      outline-offset: -3px;
+    }
+  }
 }
 
 // Use mixin

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-link/eu-component-link.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-link/eu-component-link.scss
@@ -74,17 +74,10 @@
     background-color: $ecl-color-yellow-100;
     box-sizing: border-box;
     color: $ecl-color-black-100;
-    display: inline-block;
+    display: inline-flex;
     font: $ecl-font-m;
     font-weight: $ecl-font-weight-bold;
     padding: $ecl-spacing-s $ecl-spacing-m;
-    text-decoration: underline;
-
-    /* stylelint-disable */
-    &.ecl-link--icon {
-      display: inline-flex;
-      text-decoration: none;
-    }
 
     &:hover,
     &:active {
@@ -93,7 +86,7 @@
     }
 
     &:focus {
-      outline: 3px solid $ecl-color-black-100;
+      outline-color: $ecl-color-black-100;
       outline-offset: -3px;
     }
   }

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-page-banner/eu-component-page-banner.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-page-banner/eu-component-page-banner.scss
@@ -65,10 +65,15 @@
     margin-top: $ecl-spacing-m;
   }
 
+  /* DEPRECATED */
   .ecl-page-banner__link {
     font-weight: $ecl-font-weight-bold;
     margin-top: $ecl-spacing-m;
     padding: $ecl-spacing-m $ecl-spacing-s;
+  }
+
+  .ecl-page-banner__link-cta {
+    margin-top: $ecl-spacing-m;
   }
 
   /* stylelint-disable-next-line order/order */
@@ -156,6 +161,7 @@
       color: $baseline-color-primary;
     }
 
+    /* DEPRECATED */
     .ecl-page-banner__link,
     .ecl-page-banner__link:hover,
     .ecl-page-banner__link:focus {
@@ -242,6 +248,7 @@
         color: $baseline-color-image-shade;
       }
 
+      /* DEPRECATED */
       /* stylelint-disable-next-line no-descending-specificity */
       .ecl-page-banner__link,
       .ecl-page-banner__link:hover,

--- a/src/systems/eu/specs/components/link/demo/data--cta-icon.js
+++ b/src/systems/eu/specs/components/link/demo/data--cta-icon.js
@@ -1,0 +1,11 @@
+// Simple content for demo
+module.exports = {
+  variant: 'cta',
+  label: 'Call to action link with icon',
+  href: '/example#link-cta',
+  icon: {
+    shape: 'ui--corner-arrow',
+    transform: 'rotate-90',
+    size: 'fluid',
+  },
+};

--- a/src/systems/eu/specs/components/link/demo/data--cta.js
+++ b/src/systems/eu/specs/components/link/demo/data--cta.js
@@ -1,0 +1,6 @@
+// Simple content for demo
+module.exports = {
+  variant: 'cta',
+  label: 'Call to action link',
+  href: '/example#link-cta',
+};

--- a/src/website/src/pages/ec/components/navigation/link/docs/code.mdx
+++ b/src/website/src/pages/ec/components/navigation/link/docs/code.mdx
@@ -8,6 +8,8 @@ import Link from '@ecl/ec-react-component-link';
 
 import demoContentDefault from '@ecl/ec-specs-link/demo/data--default';
 import demoContentStandalone from '@ecl/ec-specs-link/demo/data--standalone';
+import demoContentCTA from '@ecl/ec-specs-link/demo/data--cta';
+import demoContentCTAIcon from '@ecl/ec-specs-link/demo/data--cta-icon';
 import demoContentIcon from '@ecl/ec-specs-link/demo/data--icon';
 
 ## Default link
@@ -44,4 +46,22 @@ import demoContentIcon from '@ecl/ec-specs-link/demo/data--icon';
     The European Commission is the executive of <Link {...demoContentIcon} />{' '}
     and promotes its general interest.
   </p>
+</Playground>
+
+## Call-to-actionl link
+
+<Playground
+  system="ec"
+  selectedKind="components-navigation-link"
+  selectedStory="cta"
+>
+  <Link {...demoContentCTA} />
+</Playground>
+
+<Playground
+  system="ec"
+  selectedKind="components-navigation-link"
+  selectedStory="cta"
+>
+  <Link {...demoContentCTAIcon} />
 </Playground>

--- a/src/website/src/pages/eu/components/navigation/link/docs/code.mdx
+++ b/src/website/src/pages/eu/components/navigation/link/docs/code.mdx
@@ -8,6 +8,8 @@ import Link from '@ecl/eu-react-component-link';
 
 import demoContentDefault from '@ecl/eu-specs-link/demo/data--default';
 import demoContentStandalone from '@ecl/eu-specs-link/demo/data--standalone';
+import demoContentCTA from '@ecl/eu-specs-link/demo/data--cta';
+import demoContentCTAIcon from '@ecl/eu-specs-link/demo/data--cta-icon';
 import demoContentIcon from '@ecl/eu-specs-link/demo/data--icon';
 
 ## Default link
@@ -44,4 +46,22 @@ import demoContentIcon from '@ecl/eu-specs-link/demo/data--icon';
     The European Commission is the executive of <Link {...demoContentIcon} />{' '}
     and promotes its general interest.
   </p>
+</Playground>
+
+## Call-to-action link
+
+<Playground
+  system="eu"
+  selectedKind="components-navigation-link"
+  selectedStory="cta"
+>
+  <Link {...demoContentCTA} />
+</Playground>
+
+<Playground
+  system="eu"
+  selectedKind="components-navigation-link"
+  selectedStory="cta"
+>
+  <Link {...demoContentCTAIcon} />
 </Playground>


### PR DESCRIPTION
This PR adds a new variant to the link component: "CTA" (call-to-action). It looks like the CTA button, except that the link is underlined. Both hero and page banners use this new variant.