### PR TITLE
fix(inpage-nav): fix styles - INNO-1609

### DIFF
--- a/src/systems/ec/implementations/react/components/inpage-navigation/examples/Default.jsx
+++ b/src/systems/ec/implementations/react/components/inpage-navigation/examples/Default.jsx
@@ -46,10 +46,10 @@ export default class DefaultExample extends React.Component {
         <PageHeader breadcrumb={breadcrumb} title="A demo page" />
         <div className="ecl-container">
           <div className="ecl-row ecl-u-mt-l">
-            <div className="ecl-col-md-3">
+            <div className="ecl-col-lg-3">
               <InpageNavigation {...demoContent} />
             </div>
-            <div className="ecl-col-md-9">
+            <div className="ecl-col-lg-9">
               <h2 className="ecl-u-type-heading-2" id="inline-nav-1">
                 Heading 1
               </h2>

--- a/src/systems/ec/implementations/react/components/inpage-navigation/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/inpage-navigation/stories/Index.jsx
@@ -115,12 +115,12 @@ storiesOf('Components|Navigation/In page navigation', module)
 
         <div className="ecl-container">
           <div className="ecl-row ecl-u-mt-l">
-            <div className="ecl-col-md-3">
+            <div className="ecl-col-lg-3">
               <div className="inPageDemoSidebar" />
               <InpageNavigation {...inpageProps} />
             </div>
 
-            <div className="ecl-col-md-9">
+            <div className="ecl-col-lg-9">
               <div className="inPageDemoContent" />
               <h2 className="ecl-u-type-heading-2" id="inline-nav-1">
                 Heading 1

--- a/src/systems/ec/implementations/react/components/inpage-navigation/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/inpage-navigation/stories/Index.jsx
@@ -38,9 +38,9 @@ storiesOf('Components|Navigation/In page navigation', module)
       btnMainElement.append(btnMainTag);
     };
     const btnIdHandler = () => {
-      const numParagraphs = document.querySelectorAll('.ecl-col-md-9 p').length;
+      const numParagraphs = document.querySelectorAll('.ecl-col-lg-9 p').length;
       const position = Math.floor(Math.random() * Math.floor(numParagraphs));
-      const btnIdElement = document.querySelectorAll('.ecl-col-md-9 p')[
+      const btnIdElement = document.querySelectorAll('.ecl-col-lg-9 p')[
         position
       ];
       const demoId = Math.random()
@@ -57,9 +57,9 @@ storiesOf('Components|Navigation/In page navigation', module)
       btnIdElement.insertAdjacentHTML('afterend', btnIdTag.outerHTML);
     };
     const btnIdRemoveHandler = () => {
-      const numH2s = document.querySelectorAll('.ecl-col-md-9 h2[id]').length;
+      const numH2s = document.querySelectorAll('.ecl-col-lg-9 h2[id]').length;
       const position = Math.floor(Math.random() * Math.floor(numH2s));
-      const randomH2 = document.querySelectorAll('.ecl-col-md-9 h2[id]')[
+      const randomH2 = document.querySelectorAll('.ecl-col-lg-9 h2[id]')[
         position
       ];
       randomH2.nextSibling.outerHTML = '';

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-inpage-navigation/ec-component-inpage-navigation.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-inpage-navigation/ec-component-inpage-navigation.js
@@ -21,7 +21,7 @@ export class InpageNavigation {
       linksSelector: linksSelector = '[data-ecl-inpage-navigation-link]',
       spyActiveContainer: spyActiveContainer = 'ecl-inpage-navigation--visible',
       spyOffset: spyOffset = 20,
-      spyClass: spyClass = 'ecl-inpage-navigation__link--is-active',
+      spyClass: spyClass = 'ecl-inpage-navigation__item--active',
       spyTrigger: spyTrigger = '[data-ecl-inpage-navigation-trigger-current]',
     } = {}
   ) {

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-inpage-navigation/ec-component-inpage-navigation.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-inpage-navigation/ec-component-inpage-navigation.scss
@@ -13,6 +13,11 @@
     margin: 0;
     position: relative;
     z-index: 1;
+
+    @include ecl-media-breakpoint-up('lg') {
+      position: sticky;
+      top: 0;
+    }
   }
 
   .ecl-inpage-navigation__trigger {
@@ -35,23 +40,27 @@
 
     .ecl-inpage-navigation--visible & {
       display: block;
-    }
 
-    .ecl-inpage-navigation__trigger-current {
-      font: $ecl-font-prolonged-m;
-      font-weight: $ecl-font-weight-bold;
-      margin-right: $ecl-font-size-xl;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      @include ecl-media-breakpoint-up('lg') {
+        display: none;
+      }
     }
+  }
 
-    .ecl-inpage-navigation__trigger-icon {
-      position: absolute;
-      right: 1em;
-    }
+  .ecl-inpage-navigation__trigger-current {
+    font: $ecl-font-prolonged-m;
+    font-weight: $ecl-font-weight-bold;
+    margin-right: $ecl-font-size-xl;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-    &[aria-expanded='true'] .ecl-inpage-navigation__trigger-icon {
+  .ecl-inpage-navigation__trigger-icon {
+    position: absolute;
+    right: 1em;
+
+    .ecl-inpage-navigation__trigger[aria-expanded='true'] & {
       transform: rotate(0deg);
     }
   }
@@ -62,6 +71,11 @@
     font: $ecl-font-m;
     padding: $ecl-spacing-xs calc(#{$ecl-spacing-s} + #{$inpage-link-border});
     text-transform: uppercase;
+
+    @include ecl-media-breakpoint-up('lg') {
+      color: $ecl-color-grey-100;
+      display: block;
+    }
   }
 
   .ecl-inpage-navigation__list {
@@ -69,83 +83,83 @@
     list-style-type: none;
     margin: 0;
     padding: $ecl-spacing-xl $ecl-spacing-m 0;
+
+    @include ecl-media-breakpoint-up('lg') {
+      border-top: 0;
+      display: block;
+      padding: 0;
+    }
   }
 
   .ecl-inpage-navigation__link {
     font: $ecl-font-prolonged-m;
     padding: $ecl-spacing-s;
 
+    @include ecl-media-breakpoint-up('lg') {
+      background: transparent;
+      border: 0;
+      border-left: $inpage-link-border solid transparent;
+      color: $ecl-color-primary;
+      display: block;
+      font-weight: $ecl-font-weight-bold;
+      padding: $ecl-spacing-xs $ecl-spacing-s;
+    }
+
+    &:hover {
+      @include ecl-media-breakpoint-up('lg') {
+        text-decoration: underline;
+      }
+    }
+
     &:focus {
       outline-offset: -2px;
+
+      @include ecl-media-breakpoint-up('lg') {
+        background-color: $ecl-color-yellow-100;
+        outline: none;
+        text-decoration: underline;
+      }
+    }
+
+    .ecl-inpage-navigation--visible & {
+      border-top: 1px solid $ecl-color-blue-120;
+      color: $ecl-color-white-100;
+      display: block;
+
+      @include ecl-media-breakpoint-up('lg') {
+        border-top-width: 0;
+        color: $ecl-color-primary;
+      }
+    }
+
+    .ecl-inpage-navigation__item--active & {
+      @include ecl-media-breakpoint-up('lg') {
+        background-color: $ecl-color-grey-5;
+        border-left-color: $ecl-color-primary;
+        color: $ecl-color-grey-100;
+      }
     }
   }
 
-  .ecl-inpage-navigation--visible {
-    .ecl-inpage-navigation__body {
+  .ecl-inpage-navigation__link--is-active {
+    @include ecl-media-breakpoint-up('lg') {
+      background-color: $ecl-color-grey-5;
+      border-left-color: $ecl-color-primary;
+      color: $ecl-color-grey-100;
+    }
+  }
+
+  .ecl-inpage-navigation__body {
+    .ecl-inpage-navigation--visible & {
       background-color: $ecl-color-primary;
       left: 0;
       position: fixed;
       right: 0;
       top: 0;
-    }
 
-    .ecl-inpage-navigation__link {
-      border-top: 1px solid $ecl-color-blue-120;
-      color: $ecl-color-white-100;
-      display: block;
-    }
-  }
-
-  /* stylelint-disable-next-line order/order */
-  @include ecl-media-breakpoint-up('lg') {
-    .ecl-inpage-navigation {
-      position: sticky;
-      top: 0;
-
-      .ecl-inpage-navigation__title {
-        color: $ecl-color-grey-100;
-        display: block;
-      }
-
-      .ecl-inpage-navigation__body {
+      @include ecl-media-breakpoint-up('lg') {
         background: transparent;
         position: static;
-      }
-
-      .ecl-inpage-navigation__list[hidden] {
-        border-top: 0;
-        display: block;
-        padding: 0;
-      }
-
-      .ecl-inpage-navigation__link {
-        background: transparent;
-        border: 0;
-        border-left: $inpage-link-border solid transparent;
-        color: $ecl-color-primary;
-        display: block;
-        font-weight: $ecl-font-weight-bold;
-        padding: $ecl-spacing-xs $ecl-spacing-s;
-      }
-
-      .ecl-inpage-navigation__link:hover {
-        text-decoration: underline;
-      }
-
-      .ecl-inpage-navigation__link:focus {
-        background-color: $ecl-color-yellow-100;
-        outline: none;
-        text-decoration: underline;
-      }
-
-      .ecl-inpage-navigation__link--is-active {
-        background-color: $ecl-color-grey-5;
-        border-left-color: $ecl-color-primary;
-        color: $ecl-color-grey-100;
-      }
-
-      .ecl-inpage-navigation__trigger {
-        display: none;
       }
     }
   }

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-inpage-navigation/ec-component-inpage-navigation.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-inpage-navigation/ec-component-inpage-navigation.scss
@@ -96,7 +96,7 @@
     padding: $ecl-spacing-s;
 
     @include ecl-media-breakpoint-up('lg') {
-      background: transparent;
+      background-color: transparent;
       border: 0;
       border-left: $inpage-link-border solid transparent;
       color: $ecl-color-primary;

--- a/src/systems/eu/implementations/react/components/inpage-navigation/examples/Default.jsx
+++ b/src/systems/eu/implementations/react/components/inpage-navigation/examples/Default.jsx
@@ -46,10 +46,10 @@ export default class DefaultExample extends React.Component {
         <PageHeader breadcrumb={breadcrumb} title="A demo page" />
         <div className="ecl-container">
           <div className="ecl-row ecl-u-mt-l">
-            <div className="ecl-col-md-3">
+            <div className="ecl-col-lg-3">
               <InpageNavigation {...demoContent} />
             </div>
-            <div className="ecl-col-md-9">
+            <div className="ecl-col-lg-9">
               <h2 className="ecl-u-type-heading-2" id="inline-nav-1">
                 Heading 1
               </h2>

--- a/src/systems/eu/implementations/react/components/inpage-navigation/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/inpage-navigation/stories/Index.jsx
@@ -38,9 +38,9 @@ storiesOf('Components|Navigation/In page navigation', module)
       btnMainElement.append(btnMainTag);
     };
     const btnIdHandler = () => {
-      const numParagraphs = document.querySelectorAll('.ecl-col-md-9 p').length;
+      const numParagraphs = document.querySelectorAll('.ecl-col-lg-9 p').length;
       const position = Math.floor(Math.random() * Math.floor(numParagraphs));
-      const btnIdElement = document.querySelectorAll('.ecl-col-md-9 p')[
+      const btnIdElement = document.querySelectorAll('.ecl-col-lg-9 p')[
         position
       ];
       const demoId = Math.random()
@@ -57,9 +57,9 @@ storiesOf('Components|Navigation/In page navigation', module)
       btnIdElement.insertAdjacentHTML('afterend', btnIdTag.outerHTML);
     };
     const btnIdRemoveHandler = () => {
-      const numH2s = document.querySelectorAll('.ecl-col-md-9 h2[id]').length;
+      const numH2s = document.querySelectorAll('.ecl-col-lg-9 h2[id]').length;
       const position = Math.floor(Math.random() * Math.floor(numH2s));
-      const randomH2 = document.querySelectorAll('.ecl-col-md-9 h2[id]')[
+      const randomH2 = document.querySelectorAll('.ecl-col-lg-9 h2[id]')[
         position
       ];
       randomH2.nextSibling.outerHTML = '';
@@ -115,12 +115,12 @@ storiesOf('Components|Navigation/In page navigation', module)
 
         <div className="ecl-container">
           <div className="ecl-row ecl-u-mt-l">
-            <div className="ecl-col-md-3">
+            <div className="ecl-col-lg-3">
               <div className="inPageDemoSidebar" />
               <InpageNavigation {...inpageProps} />
             </div>
 
-            <div className="ecl-col-md-9">
+            <div className="ecl-col-lg-9">
               <div className="inPageDemoContent" />
               <h2 className="ecl-u-type-heading-2" id="inline-nav-1">
                 Heading 1

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-inpage-navigation/eu-component-inpage-navigation.js
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-inpage-navigation/eu-component-inpage-navigation.js
@@ -21,7 +21,7 @@ export class InpageNavigation {
       linksSelector: linksSelector = '[data-ecl-inpage-navigation-link]',
       spyActiveContainer: spyActiveContainer = 'ecl-inpage-navigation--visible',
       spyOffset: spyOffset = 20,
-      spyClass: spyClass = 'ecl-inpage-navigation__link--is-active',
+      spyClass: spyClass = 'ecl-inpage-navigation__item--active',
       spyTrigger: spyTrigger = '[data-ecl-inpage-navigation-trigger-current]',
     } = {}
   ) {

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-inpage-navigation/eu-component-inpage-navigation.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-inpage-navigation/eu-component-inpage-navigation.scss
@@ -13,6 +13,11 @@
     margin: 0;
     position: relative;
     z-index: 1;
+
+    @include ecl-media-breakpoint-up('lg') {
+      position: sticky;
+      top: 0;
+    }
   }
 
   .ecl-inpage-navigation__trigger {
@@ -35,23 +40,27 @@
 
     .ecl-inpage-navigation--visible & {
       display: block;
-    }
 
-    .ecl-inpage-navigation__trigger-current {
-      font: $ecl-font-prolonged-m;
-      font-weight: $ecl-font-weight-bold;
-      margin-right: $ecl-font-size-xl;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      @include ecl-media-breakpoint-up('lg') {
+        display: none;
+      }
     }
+  }
 
-    .ecl-inpage-navigation__trigger-icon {
-      position: absolute;
-      right: 1em;
-    }
+  .ecl-inpage-navigation__trigger-current {
+    font: $ecl-font-prolonged-m;
+    font-weight: $ecl-font-weight-bold;
+    margin-right: $ecl-font-size-xl;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-    &[aria-expanded='true'] .ecl-inpage-navigation__trigger-icon {
+  .ecl-inpage-navigation__trigger-icon {
+    position: absolute;
+    right: 1em;
+
+    .ecl-inpage-navigation__trigger[aria-expanded='true'] & {
       transform: rotate(0deg);
     }
   }
@@ -62,6 +71,11 @@
     font: $ecl-font-m;
     padding: $ecl-spacing-xs calc(#{$ecl-spacing-s} + #{$inpage-link-border});
     text-transform: uppercase;
+
+    @include ecl-media-breakpoint-up('lg') {
+      color: $ecl-color-grey-100;
+      display: block;
+    }
   }
 
   .ecl-inpage-navigation__list {
@@ -69,83 +83,83 @@
     list-style-type: none;
     margin: 0;
     padding: $ecl-spacing-xl $ecl-spacing-m 0;
+
+    @include ecl-media-breakpoint-up('lg') {
+      border-top: 0;
+      display: block;
+      padding: 0;
+    }
   }
 
   .ecl-inpage-navigation__link {
     font: $ecl-font-prolonged-m;
     padding: $ecl-spacing-s;
 
+    @include ecl-media-breakpoint-up('lg') {
+      background: transparent;
+      border: 0;
+      border-left: $inpage-link-border solid transparent;
+      color: $ecl-color-primary;
+      display: block;
+      font-weight: $ecl-font-weight-bold;
+      padding: $ecl-spacing-xs $ecl-spacing-s;
+    }
+
+    &:hover {
+      @include ecl-media-breakpoint-up('lg') {
+        text-decoration: underline;
+      }
+    }
+
     &:focus {
       outline-offset: -2px;
+
+      @include ecl-media-breakpoint-up('lg') {
+        background-color: $ecl-color-yellow-100;
+        outline: none;
+        text-decoration: underline;
+      }
+    }
+
+    .ecl-inpage-navigation--visible & {
+      border-top: 1px solid $ecl-color-blue-120;
+      color: $ecl-color-white-100;
+      display: block;
+
+      @include ecl-media-breakpoint-up('lg') {
+        border-top-width: 0;
+        color: $ecl-color-primary;
+      }
+    }
+
+    .ecl-inpage-navigation__item--active & {
+      @include ecl-media-breakpoint-up('lg') {
+        background-color: $ecl-color-grey-5;
+        border-left-color: $ecl-color-primary;
+        color: $ecl-color-grey-100;
+      }
     }
   }
 
-  .ecl-inpage-navigation--visible {
-    .ecl-inpage-navigation__body {
+  .ecl-inpage-navigation__link--is-active {
+    @include ecl-media-breakpoint-up('lg') {
+      background-color: $ecl-color-grey-5;
+      border-left-color: $ecl-color-primary;
+      color: $ecl-color-grey-100;
+    }
+  }
+
+  .ecl-inpage-navigation__body {
+    .ecl-inpage-navigation--visible & {
       background-color: $ecl-color-primary;
       left: 0;
       position: fixed;
       right: 0;
       top: 0;
-    }
 
-    .ecl-inpage-navigation__link {
-      border-top: 1px solid $ecl-color-blue-120;
-      color: $ecl-color-white-100;
-      display: block;
-    }
-  }
-
-  /* stylelint-disable-next-line order/order */
-  @include ecl-media-breakpoint-up('lg') {
-    .ecl-inpage-navigation {
-      position: sticky;
-      top: 0;
-
-      .ecl-inpage-navigation__title {
-        color: $ecl-color-grey-100;
-        display: block;
-      }
-
-      .ecl-inpage-navigation__body {
+      @include ecl-media-breakpoint-up('lg') {
         background: transparent;
         position: static;
-      }
-
-      .ecl-inpage-navigation__list[hidden] {
-        border-top: 0;
-        display: block;
-        padding: 0;
-      }
-
-      .ecl-inpage-navigation__link {
-        background: transparent;
-        border: 0;
-        border-left: $inpage-link-border solid transparent;
-        color: $ecl-color-primary;
-        display: block;
-        font-weight: $ecl-font-weight-bold;
-        padding: $ecl-spacing-xs $ecl-spacing-s;
-      }
-
-      .ecl-inpage-navigation__link:hover {
-        text-decoration: underline;
-      }
-
-      .ecl-inpage-navigation__link:focus {
-        background-color: $ecl-color-yellow-100;
-        outline: none;
-        text-decoration: underline;
-      }
-
-      .ecl-inpage-navigation__link--is-active {
-        background-color: $ecl-color-grey-5;
-        border-left-color: $ecl-color-primary;
-        color: $ecl-color-grey-100;
-      }
-
-      .ecl-inpage-navigation__trigger {
-        display: none;
       }
     }
   }

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-inpage-navigation/eu-component-inpage-navigation.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-inpage-navigation/eu-component-inpage-navigation.scss
@@ -96,7 +96,7 @@
     padding: $ecl-spacing-s;
 
     @include ecl-media-breakpoint-up('lg') {
-      background: transparent;
+      background-color: transparent;
       border: 0;
       border-left: $inpage-link-border solid transparent;
       color: $ecl-color-primary;


### PR DESCRIPTION
In a nutshell, `ecl-inpage-navigation__item--active` is now added on the active nav item (instead of `ecl-inpage-navigation__link--is-active`, which was wrong). The styles don't change, I've just taken into the new class `ecl-inpage-navigation__item--active` to add the right styles on the link when the parent item is active.