### PR TITLE
feat(form-group): allow group classname - INNO-1702

### DIFF
--- a/src/systems/ec/implementations/react/components/select/src/Select.jsx
+++ b/src/systems/ec/implementations/react/components/select/src/Select.jsx
@@ -6,6 +6,7 @@ import Icon from '@ecl/ec-react-component-icon';
 
 const Select = ({
   disabled,
+  groupClassName,
   helperText,
   id,
   invalid,
@@ -26,7 +27,12 @@ const Select = ({
   });
 
   return (
-    <div className="ecl-form-group ecl-form-group--select">
+    <div
+      className={classnames(
+        groupClassName,
+        'ecl-form-group ecl-form-group--select'
+      )}
+    >
       {label && (
         <label
           className={classnames(labelClassName, 'ecl-form-label', {
@@ -97,6 +103,7 @@ const Select = ({
 
 Select.propTypes = {
   disabled: PropTypes.bool,
+  groupClassName: PropTypes.string,
   helperText: PropTypes.node,
   id: PropTypes.string.isRequired,
   invalid: PropTypes.bool,
@@ -119,6 +126,7 @@ Select.propTypes = {
 
 Select.defaultProps = {
   disabled: false,
+  groupClassName: '',
   helperText: '',
   invalid: false,
   invalidText: '',

--- a/src/systems/ec/implementations/react/components/text-area/src/TextArea.jsx
+++ b/src/systems/ec/implementations/react/components/text-area/src/TextArea.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 const TextArea = ({
   id,
   disabled,
+  groupClassName,
   helperText,
   invalid,
   invalidText,
@@ -25,7 +26,12 @@ const TextArea = ({
   });
 
   return (
-    <div className="ecl-form-group ecl-form-group--text-area">
+    <div
+      className={classnames(
+        groupClassName,
+        'ecl-form-group ecl-form-group--text-area'
+      )}
+    >
       {label && (
         <label
           className={classnames(labelClassName, 'ecl-form-label', {
@@ -78,6 +84,7 @@ const TextArea = ({
 TextArea.propTypes = {
   id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  groupClassName: PropTypes.string,
   helperText: PropTypes.node,
   invalid: PropTypes.bool,
   invalidText: PropTypes.node,
@@ -94,6 +101,7 @@ TextArea.propTypes = {
 
 TextArea.defaultProps = {
   disabled: false,
+  groupClassName: '',
   helperText: '',
   invalid: false,
   invalidText: '',

--- a/src/systems/ec/implementations/react/components/text-input/src/TextInput.jsx
+++ b/src/systems/ec/implementations/react/components/text-input/src/TextInput.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 const TextInput = ({
   id,
   disabled,
+  groupClassName,
   helperText,
   invalid,
   invalidText,
@@ -25,7 +26,12 @@ const TextInput = ({
   });
 
   return (
-    <div className="ecl-form-group ecl-form-group--text-input">
+    <div
+      className={classnames(
+        groupClassName,
+        'ecl-form-group ecl-form-group--text-input'
+      )}
+    >
       {label && (
         <label
           className={classnames(labelClassName, 'ecl-form-label', {
@@ -79,6 +85,7 @@ const TextInput = ({
 TextInput.propTypes = {
   id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  groupClassName: PropTypes.string,
   helperText: PropTypes.node,
   invalid: PropTypes.bool,
   invalidText: PropTypes.node,
@@ -95,6 +102,7 @@ TextInput.propTypes = {
 
 TextInput.defaultProps = {
   disabled: false,
+  groupClassName: '',
   helperText: '',
   invalid: false,
   invalidText: '',

--- a/src/systems/eu/implementations/react/components/select/src/Select.jsx
+++ b/src/systems/eu/implementations/react/components/select/src/Select.jsx
@@ -6,6 +6,7 @@ import Icon from '@ecl/eu-react-component-icon';
 
 const Select = ({
   disabled,
+  groupClassName,
   helperText,
   id,
   invalid,
@@ -26,7 +27,12 @@ const Select = ({
   });
 
   return (
-    <div className="ecl-form-group ecl-form-group--select">
+    <div
+      className={classnames(
+        groupClassName,
+        'ecl-form-group ecl-form-group--select'
+      )}
+    >
       {label && (
         <label
           className={classnames(labelClassName, 'ecl-form-label', {
@@ -97,6 +103,7 @@ const Select = ({
 
 Select.propTypes = {
   disabled: PropTypes.bool,
+  groupClassName: PropTypes.string,
   helperText: PropTypes.node,
   id: PropTypes.string.isRequired,
   invalid: PropTypes.bool,
@@ -119,6 +126,7 @@ Select.propTypes = {
 
 Select.defaultProps = {
   disabled: false,
+  groupClassName: '',
   helperText: '',
   invalid: false,
   invalidText: '',

--- a/src/systems/eu/implementations/react/components/text-area/src/TextArea.jsx
+++ b/src/systems/eu/implementations/react/components/text-area/src/TextArea.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 const TextArea = ({
   id,
   disabled,
+  groupClassName,
   helperText,
   invalid,
   invalidText,
@@ -25,7 +26,12 @@ const TextArea = ({
   });
 
   return (
-    <div className="ecl-form-group ecl-form-group--text-area">
+    <div
+      className={classnames(
+        groupClassName,
+        'ecl-form-group ecl-form-group--text-area'
+      )}
+    >
       {label && (
         <label
           className={classnames(labelClassName, 'ecl-form-label', {
@@ -78,6 +84,7 @@ const TextArea = ({
 TextArea.propTypes = {
   id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  groupClassName: PropTypes.string,
   helperText: PropTypes.node,
   invalid: PropTypes.bool,
   invalidText: PropTypes.node,
@@ -94,6 +101,7 @@ TextArea.propTypes = {
 
 TextArea.defaultProps = {
   disabled: false,
+  groupClassName: '',
   helperText: '',
   invalid: false,
   invalidText: '',

--- a/src/systems/eu/implementations/react/components/text-input/src/TextInput.jsx
+++ b/src/systems/eu/implementations/react/components/text-input/src/TextInput.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 const TextInput = ({
   id,
   disabled,
+  groupClassName,
   helperText,
   invalid,
   invalidText,
@@ -25,7 +26,12 @@ const TextInput = ({
   });
 
   return (
-    <div className="ecl-form-group ecl-form-group--text-input">
+    <div
+      className={classnames(
+        groupClassName,
+        'ecl-form-group ecl-form-group--text-input'
+      )}
+    >
       {label && (
         <label
           className={classnames(labelClassName, 'ecl-form-label', {
@@ -79,6 +85,7 @@ const TextInput = ({
 TextInput.propTypes = {
   id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
+  groupClassName: PropTypes.string,
   helperText: PropTypes.node,
   invalid: PropTypes.bool,
   invalidText: PropTypes.node,
@@ -95,6 +102,7 @@ TextInput.propTypes = {
 
 TextInput.defaultProps = {
   disabled: false,
+  groupClassName: '',
   helperText: '',
   invalid: false,
   invalidText: '',


### PR DESCRIPTION
# PR description

Add possibility to add custom css classes to form group elements.
Previously, it was only possible to add classes on inner elements.
