### PR TITLE
fix(cards): use aria-label instead of alt - INNO-1727

### DIFF
--- a/src/systems/ec/implementations/react/components/card/src/Card.jsx
+++ b/src/systems/ec/implementations/react/components/card/src/Card.jsx
@@ -27,7 +27,8 @@ const Card = ({
     imageMarkup = (
       <div
         className="ecl-card__image"
-        alt={image.alt}
+        aria-label={image.alt}
+        role="img"
         style={{ backgroundImage: `url(${image.src})` }}
       />
     );
@@ -41,12 +42,15 @@ const Card = ({
 
   // Title
   let titleMarkup = '';
-  const TitleTag = `h${title.level || 1}`;
+
   if (title) {
+    const { level: titleLevel, ...otherTitleProps } = title;
+    const TitleTag = `h${titleLevel || 1}`;
+
     if (title.href) {
       titleMarkup = (
         <TitleTag className="ecl-card__title">
-          <Link {...title} />
+          <Link {...otherTitleProps} />
         </TitleTag>
       );
     } else {
@@ -106,10 +110,10 @@ const Card = ({
         {titleMarkup}
       </header>
 
-      <section className="ecl-card__body">
+      <div className="ecl-card__body">
         {descriptionMarkup}
         {linksMarkup}
-      </section>
+      </div>
 
       <footer className="ecl-card__footer">
         {infosMarkup}

--- a/src/systems/ec/implementations/react/components/media-container/src/MediaContainer.jsx
+++ b/src/systems/ec/implementations/react/components/media-container/src/MediaContainer.jsx
@@ -21,7 +21,6 @@ const MediaContainer = ({
           className="ecl-media-container__media"
           controls="controls"
           poster={image}
-          alt={alt}
         >
           {sources.map(source => (
             <source {...source} key={source.src} />

--- a/src/systems/ec/implementations/react/page-structure/footer/src/Footer.jsx
+++ b/src/systems/ec/implementations/react/page-structure/footer/src/Footer.jsx
@@ -132,7 +132,7 @@ const Footer = ({
     </div>
 
     {/* Common */}
-    <section className="ecl-footer__common">
+    <div className="ecl-footer__common">
       <div className="ecl-container ecl-footer__common-container">
         {common.map(link => (
           <Link
@@ -142,7 +142,7 @@ const Footer = ({
           />
         ))}
       </div>
-    </section>
+    </div>
   </footer>
 );
 

--- a/src/systems/eu/implementations/react/components/card/src/Card.jsx
+++ b/src/systems/eu/implementations/react/components/card/src/Card.jsx
@@ -27,7 +27,8 @@ const Card = ({
     imageMarkup = (
       <div
         className="ecl-card__image"
-        alt={image.alt}
+        aria-label={image.alt}
+        role="img"
         style={{ backgroundImage: `url(${image.src})` }}
       />
     );
@@ -41,12 +42,15 @@ const Card = ({
 
   // Title
   let titleMarkup = '';
-  const TitleTag = `h${title.level || 1}`;
+
   if (title) {
+    const { level: titleLevel, ...otherTitleProps } = title;
+    const TitleTag = `h${titleLevel || 1}`;
+
     if (title.href) {
       titleMarkup = (
         <TitleTag className="ecl-card__title">
-          <Link {...title} />
+          <Link {...otherTitleProps} />
         </TitleTag>
       );
     } else {
@@ -106,10 +110,10 @@ const Card = ({
         {titleMarkup}
       </header>
 
-      <section className="ecl-card__body">
+      <div className="ecl-card__body">
         {descriptionMarkup}
         {linksMarkup}
-      </section>
+      </div>
 
       <footer className="ecl-card__footer">
         {infosMarkup}

--- a/src/systems/eu/implementations/react/components/media-container/src/MediaContainer.jsx
+++ b/src/systems/eu/implementations/react/components/media-container/src/MediaContainer.jsx
@@ -21,7 +21,6 @@ const MediaContainer = ({
           className="ecl-media-container__media"
           controls="controls"
           poster={image}
-          alt={alt}
         >
           {sources.map(source => (
             <source {...source} key={source.src} />

--- a/src/systems/eu/implementations/react/page-structure/footer/src/Footer.jsx
+++ b/src/systems/eu/implementations/react/page-structure/footer/src/Footer.jsx
@@ -171,7 +171,7 @@ const Footer = ({
       </div>
     </div>
     {/* Common */}
-    <section className="ecl-footer__common">
+    <div className="ecl-footer__common">
       <div className="ecl-container ecl-footer__common-container">
         <span className="ecl-footer__common-label">{common.label}</span>
         {common.links.map(link => (
@@ -182,7 +182,7 @@ const Footer = ({
           />
         ))}
       </div>
-    </section>
+    </div>
   </footer>
 );
 


### PR DESCRIPTION
And other fixes:
- `aria-label` and `role="img"` are used on the image `<div>`
- `level` is not propagated to `<Link>` anymore
- `<section>` is replaced by a `<div>` because there's no heading in it
  > Each section should be identified, typically by including a heading (h1-h6 element)as a child of the section element.

  — https://www.w3.org/wiki/HTML/Usage/Headings/Missing#section_element_advice
- remove `alt` on videos (not supported)

tested with https://validator.w3.org/nu/