### PR TITLE
fix(content-item): fix image css - INNO-1761

### DIFF
--- a/src/systems/ec/implementations/react/templates/compositions/content-item/examples/Default.jsx
+++ b/src/systems/ec/implementations/react/templates/compositions/content-item/examples/Default.jsx
@@ -40,8 +40,8 @@ export default () => (
       style={{
         backgroundImage:
           'url("https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg")',
+        backgroundRepeat: 'no-repeat',
         backgroundSize: 'contain',
-        height: '5rem',
         width: '7.5rem',
       }}
     />
@@ -53,8 +53,8 @@ export default () => (
       style={{
         backgroundImage:
           'url("https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg")',
+        backgroundRepeat: 'no-repeat',
         backgroundSize: 'contain',
-        height: '8.75rem',
         width: '13.125rem',
       }}
     />

--- a/src/systems/eu/implementations/react/templates/compositions/content-item/examples/Default.jsx
+++ b/src/systems/eu/implementations/react/templates/compositions/content-item/examples/Default.jsx
@@ -40,8 +40,8 @@ export default () => (
       style={{
         backgroundImage:
           'url("https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg")',
+        backgroundRepeat: 'no-repeat',
         backgroundSize: 'contain',
-        height: '5rem',
         width: '7.5rem',
       }}
     />
@@ -53,8 +53,8 @@ export default () => (
       style={{
         backgroundImage:
           'url("https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg")',
+        backgroundRepeat: 'no-repeat',
         backgroundSize: 'contain',
-        height: '8.75rem',
         width: '13.125rem',
       }}
     />


### PR DESCRIPTION
# PR description

Remove forced height on the images in content-item template, as it already uses a ratio (so width is enough)

Note: utilities will be used instead of inline style when media utilities are fully ready