### PR TITLE
fix(tag): fix markup for removable tags - INNO-1753

### DIFF
--- a/src/systems/ec/implementations/react/components/tag/src/Tag.jsx
+++ b/src/systems/ec/implementations/react/components/tag/src/Tag.jsx
@@ -10,7 +10,12 @@ const Tag = ({ label, variant, href, className, ...props }) => {
     [`ecl-tag--${variant}`]: variant,
   });
 
-  const TagName = href ? 'a' : 'button';
+  let TagName = href ? 'a' : 'button';
+  const TagNameIcon = TagName;
+
+  if (variant === 'removable') {
+    TagName = 'span';
+  }
 
   const tagProps = {
     ...props,
@@ -21,14 +26,14 @@ const Tag = ({ label, variant, href, className, ...props }) => {
     <TagName {...tagProps} className={classNames}>
       {label}
       {!!(variant && variant === 'removable') && (
-        <span className="ecl-tag__icon">
+        <TagNameIcon className="ecl-tag__icon">
           <Icon shape="ui--close" className="ecl-tag__icon-close" size="xs" />
           <Icon
             shape="ui--close-filled"
             className="ecl-tag__icon-close-filled"
             size="xs"
           />
-        </span>
+        </TagNameIcon>
       )}
     </TagName>
   );

--- a/src/systems/ec/implementations/react/components/tag/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/tag/stories/Index.jsx
@@ -14,9 +14,5 @@ storiesOf('Components|Tag', module)
     <Tag label={text('Label', 'Button tag')} type="button" />
   ))
   .add('removable', () => (
-    <Tag
-      label={text('Label', 'Removable tag')}
-      variant="removable"
-      type="button"
-    />
+    <Tag label={text('Label', 'Removable tag')} variant="removable" />
   ));

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-tag/ec-component-tag.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-tag/ec-component-tag.scss
@@ -12,11 +12,11 @@
 @mixin ecl-tag() {
   .ecl-tag {
     align-items: center;
-    background-color: map-get($ecl-colors, 'grey-15');
+    background-color: $ecl-color-grey-15;
     border-radius: (2 * $ecl-spacing-xs + $ecl-line-height-s) / 2;
     border-width: 0;
     box-sizing: border-box;
-    color: $ecl-color-text;
+    color: $ecl-color-grey;
     display: inline-flex;
     font: $ecl-font-s;
     padding: $ecl-spacing-xs $ecl-spacing-s;
@@ -30,7 +30,7 @@
     }
 
     &:focus {
-      box-shadow: inset 0 0 0 3px map-get($ecl-colors, 'yellow-100');
+      box-shadow: inset 0 0 0 3px $ecl-color-yellow;
       outline: none;
     }
   }
@@ -40,20 +40,28 @@
 
     &:hover,
     &:focus {
-      background-color: $ecl-color-text;
-      color: #fff;
+      background-color: $ecl-color-grey;
+      color: $ecl-color-white;
     }
   }
 
   .ecl-tag__icon {
-    fill: currentColor;
+    appearance: none;
+    background: none;
+    border-width: 0;
     height: $ecl-icon-xs;
     margin-left: $ecl-spacing-xs;
+    padding: 0;
     position: relative;
     width: $ecl-icon-xs;
+
+    &:focus {
+      outline: 3px solid $ecl-color-yellow;
+    }
   }
 
   .ecl-tag__icon-close {
+    fill: $ecl-color-grey;
     left: 0;
     opacity: 1;
     position: absolute;
@@ -61,6 +69,7 @@
   }
 
   .ecl-tag__icon-close-filled {
+    fill: $ecl-color-white;
     left: 0;
     opacity: 0;
     position: absolute;

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-tag/ec-component-tag.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-tag/ec-component-tag.scss
@@ -36,6 +36,7 @@
   }
 
   .ecl-tag--removable {
+    pointer-events: none;
     text-decoration: none;
 
     &:hover,
@@ -52,6 +53,7 @@
     height: $ecl-icon-xs;
     margin-left: $ecl-spacing-xs;
     padding: 0;
+    pointer-events: auto;
     position: relative;
     width: $ecl-icon-xs;
 

--- a/src/systems/eu/implementations/react/components/tag/src/Tag.jsx
+++ b/src/systems/eu/implementations/react/components/tag/src/Tag.jsx
@@ -10,7 +10,12 @@ const Tag = ({ label, variant, href, className, ...props }) => {
     [`ecl-tag--${variant}`]: variant,
   });
 
-  const TagName = href ? 'a' : 'button';
+  let TagName = href ? 'a' : 'button';
+  const TagNameIcon = TagName;
+
+  if (variant === 'removable') {
+    TagName = 'span';
+  }
 
   const tagProps = {
     ...props,
@@ -21,14 +26,14 @@ const Tag = ({ label, variant, href, className, ...props }) => {
     <TagName {...tagProps} className={classNames}>
       {label}
       {!!(variant && variant === 'removable') && (
-        <span className="ecl-tag__icon">
+        <TagNameIcon className="ecl-tag__icon">
           <Icon shape="ui--close" className="ecl-tag__icon-close" size="xs" />
           <Icon
             shape="ui--close-filled"
             className="ecl-tag__icon-close-filled"
             size="xs"
           />
-        </span>
+        </TagNameIcon>
       )}
     </TagName>
   );

--- a/src/systems/eu/implementations/react/components/tag/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/tag/stories/Index.jsx
@@ -14,9 +14,5 @@ storiesOf('Components|Tag', module)
     <Tag label={text('Label', 'Button tag')} type="button" />
   ))
   .add('removable', () => (
-    <Tag
-      label={text('Label', 'Removable tag')}
-      variant="removable"
-      type="button"
-    />
+    <Tag label={text('Label', 'Removable tag')} variant="removable" />
   ));

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-tag/eu-component-tag.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-tag/eu-component-tag.scss
@@ -12,11 +12,11 @@
 @mixin ecl-tag() {
   .ecl-tag {
     align-items: center;
-    background-color: map-get($ecl-colors, 'grey-15');
-    border-radius: (2 * $ecl-spacing-xs + $ecl-line-height-s);
+    background-color: $ecl-color-grey-15;
+    border-radius: (2 * $ecl-spacing-xs + $ecl-line-height-s) / 2;
     border-width: 0;
     box-sizing: border-box;
-    color: $ecl-color-text;
+    color: $ecl-color-grey;
     display: inline-flex;
     font: $ecl-font-s;
     padding: $ecl-spacing-xs $ecl-spacing-s;
@@ -30,7 +30,7 @@
     }
 
     &:focus {
-      box-shadow: inset 0 0 0 3px map-get($ecl-colors, 'yellow-100');
+      box-shadow: inset 0 0 0 3px $ecl-color-yellow;
       outline: none;
     }
   }
@@ -40,20 +40,28 @@
 
     &:hover,
     &:focus {
-      background-color: $ecl-color-text;
-      color: #fff;
+      background-color: $ecl-color-grey;
+      color: $ecl-color-white;
     }
   }
 
   .ecl-tag__icon {
-    fill: currentColor;
+    appearance: none;
+    background: none;
+    border-width: 0;
     height: $ecl-icon-xs;
     margin-left: $ecl-spacing-xs;
+    padding: 0;
     position: relative;
     width: $ecl-icon-xs;
+
+    &:focus {
+      outline: 3px solid $ecl-color-yellow;
+    }
   }
 
   .ecl-tag__icon-close {
+    fill: $ecl-color-grey;
     left: 0;
     opacity: 1;
     position: absolute;
@@ -61,6 +69,7 @@
   }
 
   .ecl-tag__icon-close-filled {
+    fill: $ecl-color-white;
     left: 0;
     opacity: 0;
     position: absolute;

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-tag/eu-component-tag.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-tag/eu-component-tag.scss
@@ -36,6 +36,7 @@
   }
 
   .ecl-tag--removable {
+    pointer-events: none;
     text-decoration: none;
 
     &:hover,
@@ -52,6 +53,7 @@
     height: $ecl-icon-xs;
     margin-left: $ecl-spacing-xs;
     padding: 0;
+    pointer-events: auto;
     position: relative;
     width: $ecl-icon-xs;
 


### PR DESCRIPTION
# PR description

Button tag is put on the icon only; the tag itself is now a span.
This fixes a bug on Firefox.
