### PR TITLE
feat(breadcrumb-core): add component - INNO-1808

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -48,7 +48,7 @@
   {
     "path": "dist/packages/ec-preset-website/styles/ecl-ec-preset-website.css",
     "webpack": false,
-    "limit": "21 KB"
+    "limit": "22 KB"
   },
   {
     "path": "dist/packages/ec-preset-website/styles/ecl-ec-preset-website-print.css",

--- a/src/systems/ec/implementations/react/components/breadcrumb-core/index.js
+++ b/src/systems/ec/implementations/react/components/breadcrumb-core/index.js
@@ -1,0 +1,4 @@
+export default from './src/BreadcrumbCore';
+export { BreadcrumbCore } from './src/BreadcrumbCore';
+export { BreadcrumbCoreItem } from './src/BreadcrumbCoreItem';
+export { BreadcrumbCoreEllipsis } from './src/BreadcrumbCoreEllipsis';

--- a/src/systems/ec/implementations/react/components/breadcrumb-core/package.json
+++ b/src/systems/ec/implementations/react/components/breadcrumb-core/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "name": "@ecl/ec-react-component-breadcrumb-core",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "2.12.0",
+  "description": "ECL EC React Breadcrumb Core",
+  "main": "index.js",
+  "module": "index.js",
+  "dependencies": {
+    "@ecl/ec-component-breadcrumb-core": "^2.12.0",
+    "@ecl/ec-react-component-icon": "^2.12.0",
+    "@ecl/ec-react-component-link": "^2.12.0"
+  },
+  "devDependencies": {
+    "@ecl/ec-specs-breadcrumb-core": "^2.12.0"
+  },
+  "peerDependencies": {
+    "classnames": "^2.2.6",
+    "prop-types": "^15.6.2",
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2"
+  }
+}

--- a/src/systems/ec/implementations/react/components/breadcrumb-core/src/BreadcrumbCore.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-core/src/BreadcrumbCore.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import { BreadcrumbCoreEllipsis } from './BreadcrumbCoreEllipsis';
+
+export const BreadcrumbCore = ({
+  label,
+  className,
+  ellipsisLabel,
+  children,
+  minItemsLeft,
+  minItemsRight,
+  ...props
+}) => {
+  if (!children) return null;
+
+  const childrenArray = React.Children.toArray(children);
+  let expanded;
+  let isItemVisible;
+
+  if (childrenArray.length <= minItemsLeft) {
+    expanded = true;
+    isItemVisible = [...children.map(() => true)];
+  } else {
+    expanded = false;
+    isItemVisible = [
+      ...children.slice(0, minItemsLeft).map(() => true),
+      ...children.slice(minItemsLeft, -minItemsRight).map(() => false),
+      ...children.slice(-minItemsRight).map(() => true),
+    ];
+  }
+
+  const classNames = classnames(className, 'ecl-breadcrumb-core');
+
+  const childrenCount = React.Children.count(children);
+
+  const items = [];
+  if (childrenCount <= minItemsLeft + minItemsRight) {
+    items.push(
+      ...childrenArray.map((item, index) =>
+        React.cloneElement(item, {
+          isLastItem: index === childrenArray.length - 1,
+          isVisible: true,
+        })
+      )
+    );
+  } else {
+    // Insert left items
+    const leftItems = childrenArray.slice(0, minItemsLeft);
+    items.push(
+      ...leftItems.map(item => React.cloneElement(item, { isVisible: true }))
+    );
+
+    // Insert Ellipsis
+    items.push(
+      <BreadcrumbCoreEllipsis
+        label={ellipsisLabel}
+        isVisible={!expanded}
+        key="ellipsis"
+      />
+    );
+
+    // Insert "expandable" items
+    const expandableItems = childrenArray.slice(minItemsLeft, -minItemsRight);
+    items.push(
+      ...expandableItems.map((item, index) =>
+        React.cloneElement(item, {
+          isVisible: expanded || isItemVisible[index],
+          isExpandable: true,
+        })
+      )
+    );
+
+    // Insert right items
+    const rightItems = childrenArray.slice(-minItemsRight);
+    items.push(
+      ...rightItems.map((item, index) =>
+        React.cloneElement(item, {
+          isLastItem: index === rightItems.length - 1,
+          isVisible: true,
+        })
+      )
+    );
+  }
+
+  return (
+    <nav
+      {...props}
+      className={classNames}
+      aria-label={label}
+      data-ecl-breadcrumb-core
+    >
+      <ol className="ecl-breadcrumb-core__container">{items}</ol>
+    </nav>
+  );
+};
+
+BreadcrumbCore.propTypes = {
+  label: PropTypes.string.isRequired,
+  ellipsisLabel: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.node,
+  minItemsLeft: PropTypes.number,
+  minItemsRight: PropTypes.number,
+};
+
+BreadcrumbCore.defaultProps = {
+  ellipsisLabel: '',
+  className: '',
+  children: null,
+  minItemsLeft: 1,
+  minItemsRight: 2,
+};
+
+export default BreadcrumbCore;

--- a/src/systems/ec/implementations/react/components/breadcrumb-core/src/BreadcrumbCoreEllipsis.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-core/src/BreadcrumbCoreEllipsis.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '@ecl/ec-react-component-icon';
+
+export const BreadcrumbCoreEllipsis = ({ label, isVisible }) => (
+  <li
+    className="ecl-breadcrumb-core__segment ecl-breadcrumb-core__segment--ellipsis"
+    aria-hidden={!isVisible}
+    data-ecl-breadcrumb-core-ellipsis
+  >
+    <button
+      type="button"
+      className="ecl-breadcrumb-core__ellipsis"
+      aria-label={label}
+      data-ecl-breadcrumb-core-ellipsis-button
+    >
+      …
+    </button>
+    <Icon
+      className="ecl-breadcrumb-core__icon"
+      shape="ui--corner-arrow"
+      transform="rotate-90"
+      size="2xs"
+      role="presentation"
+      aria-hidden
+    />
+  </li>
+);
+
+BreadcrumbCoreEllipsis.propTypes = {
+  label: PropTypes.string,
+  isVisible: PropTypes.bool,
+};
+
+BreadcrumbCoreEllipsis.defaultProps = {
+  label: '',
+  isVisible: true,
+};
+
+export default BreadcrumbCoreEllipsis;

--- a/src/systems/ec/implementations/react/components/breadcrumb-core/src/BreadcrumbCoreItem.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-core/src/BreadcrumbCoreItem.jsx
@@ -1,0 +1,69 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import Icon from '@ecl/ec-react-component-icon';
+import Link from '@ecl/ec-react-component-link';
+
+export const BreadcrumbCoreItem = ({
+  href,
+  label,
+  isLastItem,
+  isVisible,
+  isExpandable,
+  className,
+  children,
+  ...props
+}) => (
+  <li
+    {...props}
+    className={classnames(className, 'ecl-breadcrumb-core__segment', {
+      'ecl-breadcrumb-core__current-page': isLastItem,
+    })}
+    {...(isLastItem && { 'aria-current': 'page' })}
+    data-ecl-breadcrumb-core-item={isExpandable ? 'expandable' : 'static'}
+    aria-hidden={!isVisible}
+  >
+    {!isLastItem ? (
+      <Fragment>
+        <Link
+          href={href}
+          label={label}
+          variant="standalone"
+          {...(isLastItem && { 'aria-current': 'page' })}
+          className="ecl-breadcrumb-core__link"
+        />
+        <Icon
+          className="ecl-breadcrumb-core__icon"
+          shape="ui--corner-arrow"
+          transform="rotate-90"
+          size="2xs"
+          role="presentation"
+          aria-hidden
+        />
+      </Fragment>
+    ) : (
+      <Fragment>{label}</Fragment>
+    )}
+  </li>
+);
+
+BreadcrumbCoreItem.propTypes = {
+  label: PropTypes.string.isRequired,
+  href: PropTypes.string,
+  isLastItem: PropTypes.bool,
+  isVisible: PropTypes.bool,
+  isExpandable: PropTypes.bool,
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+BreadcrumbCoreItem.defaultProps = {
+  href: '',
+  isLastItem: false,
+  isVisible: false,
+  isExpandable: false,
+  className: '',
+  children: null,
+};
+
+export default BreadcrumbCoreItem;

--- a/src/systems/ec/implementations/react/components/breadcrumb-core/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-core/stories/Index.jsx
@@ -1,0 +1,65 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import StoryWrapper from '@ecl/story-wrapper';
+import simpleContent from '@ecl/ec-specs-breadcrumb-core/demo/data-simple';
+import demoContent from '@ecl/ec-specs-breadcrumb-core/demo/data';
+
+import { BreadcrumbCore } from '../src/BreadcrumbCore';
+import { BreadcrumbCoreItem } from '../src/BreadcrumbCoreItem';
+
+storiesOf('Components|Navigation/Breadcrumb core', module)
+  .addDecorator(withKnobs)
+  .addDecorator(story => (
+    <StoryWrapper
+      afterMount={() => {
+        if (!window.ECL) return {};
+
+        const components = window.ECL.autoInit();
+        return { components };
+      }}
+      beforeUnmount={context => {
+        if (context.components) {
+          context.components.forEach(c => c.destroy());
+        }
+      }}
+    >
+      {story()}
+    </StoryWrapper>
+  ))
+  .add('simple', () => {
+    const items = simpleContent.items.map((item, index) => ({
+      label: text(`Item ${index}`, item.label),
+      href: item.href,
+    }));
+
+    return (
+      <BreadcrumbCore
+        label={simpleContent.label}
+        ellipsisLabel="Click to expand"
+      >
+        {items.map(item => (
+          <BreadcrumbCoreItem {...item} key={item.label} />
+        ))}
+      </BreadcrumbCore>
+    );
+  })
+  .add('long', () => {
+    const items = demoContent.items.map((item, index) => ({
+      label: text(`Item ${index}`, item.label),
+      href: item.href,
+    }));
+
+    return (
+      <BreadcrumbCore
+        label={demoContent.label}
+        ellipsisLabel="Click to expand"
+        data-ecl-auto-init="BreadcrumbCore"
+      >
+        {items.map(item => (
+          <BreadcrumbCoreItem {...item} key={item.label} />
+        ))}
+      </BreadcrumbCore>
+    );
+  });

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/README.md
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/README.md
@@ -1,0 +1,3 @@
+# Breadcrumb Core
+
+(Work in progress)

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/ec-component-breadcrumb-core-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/ec-component-breadcrumb-core-print.scss
@@ -1,0 +1,18 @@
+/*
+ * Breadcrumbs Core
+ * @define breadcrumb-core
+ */
+
+// Import base
+@import '@ecl/ec-base/ec-base';
+
+@mixin ecl-breadcrumb-core-print() {
+  .ecl-breadcrumb-core {
+    display: none;
+  }
+}
+
+// Use mixin
+@include exports('ec-component-breadcrumb-core-print') {
+  @include ecl-breadcrumb-core-print();
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/ec-component-breadcrumb-core.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/ec-component-breadcrumb-core.js
@@ -1,0 +1,210 @@
+import { queryOne, queryAll } from '@ecl/ec-base/helpers/dom';
+
+export class BreadcrumbCore {
+  static autoInit(root, { BREADCRUMB_CORE: defaultOptions = {} } = {}) {
+    const breadcrumbCore = new BreadcrumbCore(root, defaultOptions);
+    breadcrumbCore.init();
+    // eslint-disable-next-line no-param-reassign
+    root.ECLBreadcrumbCore = breadcrumbCore;
+    return breadcrumbCore;
+  }
+
+  constructor(
+    element,
+    {
+      ellipsisButtonSelector = '[data-ecl-breadcrumb-core-ellipsis-button]',
+      ellipsisSelector = '[data-ecl-breadcrumb-core-ellipsis]',
+      segmentSelector = '[data-ecl-breadcrumb-core-item]',
+      expandableItemsSelector = '[data-ecl-breadcrumb-core-item="expandable"]',
+      staticItemsSelector = '[data-ecl-breadcrumb-core-item="static"]',
+      onPartialExpand = null,
+      onFullExpand = null,
+      attachClickListener = true,
+    } = {}
+  ) {
+    // Check element
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+      throw new TypeError(
+        'DOM element should be given to initialize this widget.'
+      );
+    }
+
+    this.element = element;
+
+    // Options
+    this.ellipsisButtonSelector = ellipsisButtonSelector;
+    this.ellipsisSelector = ellipsisSelector;
+    this.segmentSelector = segmentSelector;
+    this.expandableItemsSelector = expandableItemsSelector;
+    this.staticItemsSelector = staticItemsSelector;
+    this.onPartialExpand = onPartialExpand;
+    this.onFullExpand = onFullExpand;
+    this.attachClickListener = attachClickListener;
+
+    // Private variables
+    this.ellipsisButton = null;
+    this.itemsElements = null;
+    this.staticElements = null;
+    this.expandableElements = null;
+
+    // Bind `this` for use in callbacks
+    this.handleClickOnEllipsis = this.handleClickOnEllipsis.bind(this);
+  }
+
+  init() {
+    this.ellipsisButton = queryOne(this.ellipsisButtonSelector, this.element);
+
+    // Bind click event on ellipsis
+    if (this.attachClickListener && this.ellipsisButton) {
+      this.ellipsisButton.addEventListener('click', this.handleClickOnEllipsis);
+    }
+
+    this.itemsElements = queryAll(this.segmentSelector, this.element);
+    this.staticElements = queryAll(this.staticItemsSelector, this.element);
+    this.expandableElements = queryAll(
+      this.expandableItemsSelector,
+      this.element
+    );
+
+    this.check();
+  }
+
+  destroy() {
+    if (this.attachClickListener && this.ellipsisButton) {
+      this.ellipsisButton.removeEventListener(
+        'click',
+        this.handleClickOnEllipsis
+      );
+    }
+  }
+
+  handleClickOnEllipsis() {
+    return this.handleFullExpand();
+  }
+
+  check() {
+    const visibilityMap = this.computeVisibilityMap();
+
+    if (!visibilityMap) return;
+
+    if (visibilityMap.expanded === true) {
+      this.handleFullExpand();
+    } else {
+      this.handlePartialExpand(visibilityMap);
+    }
+  }
+
+  hideEllipsis() {
+    // Hide ellipsis
+    const ellipsis = queryOne(this.ellipsisSelector, this.element);
+    if (ellipsis) {
+      ellipsis.setAttribute('aria-hidden', 'true');
+    }
+
+    // Remove event listener
+    if (this.attachClickListener && this.ellipsisButton) {
+      this.ellipsisButton.removeEventListener(
+        'click',
+        this.handleClickOnEllipsis
+      );
+    }
+  }
+
+  showAllItems() {
+    this.expandableElements.forEach(item =>
+      item.setAttribute('aria-hidden', 'false')
+    );
+  }
+
+  handlePartialExpand(visibilityMap) {
+    if (!visibilityMap) return;
+
+    const { isItemVisible } = visibilityMap;
+    if (!isItemVisible || !Array.isArray(isItemVisible)) return;
+
+    if (this.onPartialExpand) {
+      this.onPartialExpand(isItemVisible);
+    } else {
+      this.expandableElements.forEach((item, index) => {
+        item.setAttribute(
+          'aria-hidden',
+          isItemVisible[index] ? 'false' : 'true'
+        );
+      });
+    }
+  }
+
+  handleFullExpand() {
+    if (this.onFullExpand) {
+      this.onFullExpand();
+    } else {
+      this.hideEllipsis();
+      this.showAllItems();
+    }
+  }
+
+  computeVisibilityMap() {
+    // Ignore if there are no expandableElements
+    if (!this.expandableElements || this.expandableElements.length === 0) {
+      return { expanded: true };
+    }
+
+    const wrapperWidth = Math.floor(this.element.getBoundingClientRect().width);
+
+    // Get the sum of all items' width
+    const allItemsWidth = this.itemsElements
+      .map(
+        breadcrumbCoreSegment =>
+          breadcrumbCoreSegment.getBoundingClientRect().width
+      )
+      .reduce((a, b) => a + b);
+
+    if (allItemsWidth <= wrapperWidth) {
+      return { expanded: true };
+    }
+
+    const ellipsisItem = queryOne(this.ellipsisSelector, this.element);
+    const ellipsisItemWidth = ellipsisItem.getBoundingClientRect().width;
+
+    const incompressibleWidth =
+      ellipsisItemWidth +
+      this.staticElements.reduce(
+        (sum, currentItem) => sum + currentItem.getBoundingClientRect().width,
+        0
+      );
+
+    if (incompressibleWidth >= wrapperWidth) {
+      return {
+        expanded: false,
+        isItemVisible: [...this.expandableElements.map(() => false)],
+      };
+    }
+
+    let previousItemsWidth = 0;
+    let isPreviousItemVisible = true;
+
+    // Careful: reverse() is destructive, that's why we make a copy of the array
+    const isItemVisible = [...this.expandableElements]
+      .reverse()
+      .map(otherSegment => {
+        if (!isPreviousItemVisible) return false;
+
+        previousItemsWidth += otherSegment.getBoundingClientRect().width;
+
+        const isVisible =
+          previousItemsWidth + incompressibleWidth <= wrapperWidth;
+
+        if (!isVisible) isPreviousItemVisible = false;
+
+        return isVisible;
+      })
+      .reverse();
+
+    return {
+      expanded: false,
+      isItemVisible,
+    };
+  }
+}
+
+export default BreadcrumbCore;

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/ec-component-breadcrumb-core.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/ec-component-breadcrumb-core.scss
@@ -1,0 +1,121 @@
+/*
+ * Breadcrumbs core
+ * @define breadcrumb-core
+ */
+
+// Import base
+@import '@ecl/ec-base/ec-base';
+
+// Check if overridden dependencies are already loaded, if needed
+@include check-imports(('ec-component-link', 'ec-component-icon'));
+
+@mixin ecl-breadcrumb-core(
+  $background-color: $ecl-color-blue-100,
+  $background-color-hover: $ecl-color-blue-120,
+  $link-color: $ecl-color-white-100,
+  $last-link-color: $ecl-color-blue-25,
+  $border-color: $ecl-color-white-100
+) {
+  .ecl-breadcrumb-core {
+    background-color: $background-color;
+    margin: 0;
+  }
+
+  .ecl-breadcrumb-core__container {
+    border-bottom: 1px solid $border-color;
+    box-sizing: border-box;
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0 0 calc(#{$ecl-spacing-m} - 1px);
+
+    &::after {
+      clear: both;
+      content: '';
+      display: block;
+    }
+  }
+
+  .ecl-breadcrumb-core__segment {
+    align-items: center;
+    display: inline-flex;
+    font: $ecl-font-s;
+    margin-top: $ecl-spacing-m;
+    max-width: 100%;
+
+    &[aria-hidden='true'] {
+      position: absolute;
+      visibility: hidden;
+
+      /* Force display if JS is disabled */
+      /* stylelint-disable-next-line max-nesting-depth */
+      .no-js & {
+        position: static;
+        visibility: visible;
+      }
+    }
+  }
+
+  .ecl-breadcrumb-core__segment--ellipsis {
+    &[aria-hidden='false'] {
+      /* Force hide if JS is disabled */
+      /* stylelint-disable-next-line max-nesting-depth */
+      .no-js & {
+        display: none;
+      }
+    }
+  }
+
+  .ecl-breadcrumb-core__ellipsis {
+    background-color: transparent;
+    border-width: 0;
+    box-sizing: border-box;
+    color: $link-color;
+    font-weight: $ecl-font-weight-bold;
+    margin: 0;
+    padding: 0;
+
+    &:hover {
+      background-color: $background-color-hover;
+    }
+
+    &:focus {
+      outline: 3px solid $ecl-color-yellow-100;
+      outline-offset: 2px;
+    }
+  }
+
+  .ecl-breadcrumb-core__link {
+    color: $link-color;
+    font-weight: $ecl-font-weight-bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &:hover,
+    &:active,
+    &:focus,
+    &:visited {
+      color: $link-color;
+    }
+  }
+
+  .ecl-breadcrumb-core__icon {
+    fill: $link-color;
+    flex-shrink: 0;
+    margin-left: $ecl-spacing-xs;
+    margin-right: $ecl-spacing-xs;
+    vertical-align: text-bottom;
+  }
+
+  .ecl-breadcrumb-core__current-page {
+    color: $last-link-color;
+    font-weight: $ecl-font-weight-bold;
+  }
+}
+
+// Use mixin
+@include exports('ec-component-breadcrumb-core') {
+  @include ecl-breadcrumb-core();
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-core/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@ecl/ec-component-breadcrumb-core",
+  "version": "2.12.0",
+  "description": "ECL EC Breadcrumb Core",
+  "main": "ec-component-breadcrumb-core.js",
+  "module": "ec-component-breadcrumb-core.js",
+  "style": "ec-component-breadcrumb-core.scss",
+  "sass": "ec-component-breadcrumb-core.scss",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "dependencies": {
+    "@ecl/ec-base": "^2.12.0",
+    "@ecl/ec-component-icon": "^2.12.0",
+    "@ecl/ec-component-link": "^2.12.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/package.json
@@ -15,6 +15,7 @@
     "@ecl/ec-component-accordion2": "^2.12.0",
     "@ecl/ec-component-blockquote": "^2.12.0",
     "@ecl/ec-component-breadcrumb": "^2.12.0",
+    "@ecl/ec-component-breadcrumb-core": "^2.12.0",
     "@ecl/ec-component-button": "^2.12.0",
     "@ecl/ec-component-card": "^2.12.0",
     "@ecl/ec-component-contextual-navigation": "^2.12.0",

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev-print.scss
@@ -31,6 +31,7 @@
 @import '@ecl/ec-component-hero-banner/ec-component-hero-banner-print';
 @import '@ecl/ec-component-page-banner/ec-component-page-banner-print';
 @import '@ecl/ec-component-breadcrumb/ec-component-breadcrumb-print';
+@import '@ecl/ec-component-breadcrumb-core/ec-component-breadcrumb-core-print';
 @import '@ecl/ec-component-card/ec-component-card-print';
 @import '@ecl/ec-component-contextual-navigation/ec-component-contextual-navigation-print';
 @import '@ecl/ec-component-expandable/ec-component-expandable-print';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.js
@@ -3,6 +3,7 @@
 export * from '@ecl/ec-auto-init';
 export * from '@ecl/ec-component-accordion2';
 export * from '@ecl/ec-component-breadcrumb';
+export * from '@ecl/ec-component-breadcrumb-core';
 export * from '@ecl/ec-component-contextual-navigation';
 export * from '@ecl/ec-component-expandable';
 export * from '@ecl/ec-component-file';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.scss
@@ -44,6 +44,7 @@
 @import '@ecl/ec-component-hero-banner/ec-component-hero-banner';
 @import '@ecl/ec-component-page-banner/ec-component-page-banner';
 @import '@ecl/ec-component-breadcrumb/ec-component-breadcrumb';
+@import '@ecl/ec-component-breadcrumb-core/ec-component-breadcrumb-core';
 @import '@ecl/ec-component-card/ec-component-card';
 // @import '@ecl/ec-component-carousel/ec-component-carousel';
 // @import '@ecl/ec-component-comment/ec-component-comment';

--- a/src/systems/ec/specs/components/breadcrumb-core/demo/data-simple.js
+++ b/src/systems/ec/specs/components/breadcrumb-core/demo/data-simple.js
@@ -1,0 +1,9 @@
+// Simple content for demo
+module.exports = {
+  items: [
+    { label: 'Home', href: '/example' },
+    { label: 'About the European Commission', href: '/example' },
+    { label: 'News' },
+  ],
+  label: 'You are here:',
+};

--- a/src/systems/ec/specs/components/breadcrumb-core/demo/data.js
+++ b/src/systems/ec/specs/components/breadcrumb-core/demo/data.js
@@ -1,0 +1,11 @@
+// Simple content for demo
+module.exports = {
+  items: [
+    { label: 'Home', href: '/example' },
+    { label: 'About the European Commission', href: '/example' },
+    { label: 'Organisational structure', href: '/example' },
+    { label: 'How the Commission is organised', href: '/example' },
+    { label: 'News' },
+  ],
+  label: 'You are here:',
+};

--- a/src/systems/ec/specs/components/breadcrumb-core/package.json
+++ b/src/systems/ec/specs/components/breadcrumb-core/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ecl/ec-specs-breadcrumb-core",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "2.12.0",
+  "description": "ECL EC Breadcrumb Core Specs",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}


### PR DESCRIPTION
# PR description

specs: https://webgate.ec.europa.eu/CITnet/confluence/display/NEXTEUROPA/Core+Breadcrumb+-+Design+Specifications

playground:
- https://deploy-preview-1338--europa-component-library.netlify.com/playground/ec/?path=/story/components-navigation-breadcrumb-core--simple
- https://deploy-preview-1338--europa-component-library.netlify.com/playground/ec/?path=/story/components-navigation-breadcrumb-core--long

note: the component isn't dipslayed on the website as is, as it will be part of the page header