### PR TITLE
feat(breadcrumb-standardised): add component - INNO-1809

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -48,7 +48,7 @@
   {
     "path": "dist/packages/ec-preset-website/styles/ecl-ec-preset-website.css",
     "webpack": false,
-    "limit": "21 KB"
+    "limit": "22 KB"
   },
   {
     "path": "dist/packages/ec-preset-website/styles/ecl-ec-preset-website-print.css",

--- a/src/systems/ec/implementations/react/components/breadcrumb-standardised/index.js
+++ b/src/systems/ec/implementations/react/components/breadcrumb-standardised/index.js
@@ -1,0 +1,6 @@
+export default from './src/BreadcrumbStandardised';
+export { BreadcrumbStandardised } from './src/BreadcrumbStandardised';
+export { BreadcrumbStandardisedItem } from './src/BreadcrumbStandardisedItem';
+export {
+  BreadcrumbStandardisedEllipsis,
+} from './src/BreadcrumbStandardisedEllipsis';

--- a/src/systems/ec/implementations/react/components/breadcrumb-standardised/package.json
+++ b/src/systems/ec/implementations/react/components/breadcrumb-standardised/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "name": "@ecl/ec-react-component-breadcrumb-standardised",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "2.12.0",
+  "description": "ECL EC React Breadcrumb Standardised",
+  "main": "index.js",
+  "module": "index.js",
+  "dependencies": {
+    "@ecl/ec-component-breadcrumb-standardised": "^2.12.0",
+    "@ecl/ec-react-component-icon": "^2.12.0",
+    "@ecl/ec-react-component-link": "^2.12.0"
+  },
+  "devDependencies": {
+    "@ecl/ec-specs-breadcrumb-standardised": "^2.12.0"
+  },
+  "peerDependencies": {
+    "classnames": "^2.2.6",
+    "prop-types": "^15.6.2",
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2"
+  }
+}

--- a/src/systems/ec/implementations/react/components/breadcrumb-standardised/src/BreadcrumbStandardised.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-standardised/src/BreadcrumbStandardised.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import { BreadcrumbStandardisedEllipsis } from './BreadcrumbStandardisedEllipsis';
+
+export const BreadcrumbStandardised = ({
+  label,
+  className,
+  ellipsisLabel,
+  children,
+  minItemsLeft,
+  minItemsRight,
+  ...props
+}) => {
+  if (!children) return null;
+
+  const childrenArray = React.Children.toArray(children);
+  let expanded;
+  let isItemVisible;
+
+  if (childrenArray.length <= minItemsLeft) {
+    expanded = true;
+    isItemVisible = [...children.map(() => true)];
+  } else {
+    expanded = false;
+    isItemVisible = [
+      ...children.slice(0, minItemsLeft).map(() => true),
+      ...children.slice(minItemsLeft, -minItemsRight).map(() => false),
+      ...children.slice(-minItemsRight).map(() => true),
+    ];
+  }
+
+  const classNames = classnames(className, 'ecl-breadcrumb-standardised');
+
+  const childrenCount = React.Children.count(children);
+
+  const items = [];
+  if (childrenCount <= minItemsLeft + minItemsRight) {
+    items.push(
+      ...childrenArray.map((item, index) =>
+        React.cloneElement(item, {
+          isLastItem: index === childrenArray.length - 1,
+          isVisible: true,
+        })
+      )
+    );
+  } else {
+    // Insert left items
+    const leftItems = childrenArray.slice(0, minItemsLeft);
+    items.push(
+      ...leftItems.map(item => React.cloneElement(item, { isVisible: true }))
+    );
+
+    // Insert Ellipsis
+    items.push(
+      <BreadcrumbStandardisedEllipsis
+        label={ellipsisLabel}
+        isVisible={!expanded}
+        key="ellipsis"
+      />
+    );
+
+    // Insert "expandable" items
+    const expandableItems = childrenArray.slice(minItemsLeft, -minItemsRight);
+    items.push(
+      ...expandableItems.map((item, index) =>
+        React.cloneElement(item, {
+          isVisible: expanded || isItemVisible[index],
+          isExpandable: true,
+        })
+      )
+    );
+
+    // Insert right items
+    const rightItems = childrenArray.slice(-minItemsRight);
+    items.push(
+      ...rightItems.map((item, index) =>
+        React.cloneElement(item, {
+          isLastItem: index === rightItems.length - 1,
+          isVisible: true,
+        })
+      )
+    );
+  }
+
+  return (
+    <nav
+      {...props}
+      className={classNames}
+      aria-label={label}
+      data-ecl-breadcrumb-standardised
+    >
+      <ol className="ecl-breadcrumb-standardised__container">{items}</ol>
+    </nav>
+  );
+};
+
+BreadcrumbStandardised.propTypes = {
+  label: PropTypes.string.isRequired,
+  ellipsisLabel: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.node,
+  minItemsLeft: PropTypes.number,
+  minItemsRight: PropTypes.number,
+};
+
+BreadcrumbStandardised.defaultProps = {
+  ellipsisLabel: '',
+  className: '',
+  children: null,
+  minItemsLeft: 1,
+  minItemsRight: 2,
+};
+
+export default BreadcrumbStandardised;

--- a/src/systems/ec/implementations/react/components/breadcrumb-standardised/src/BreadcrumbStandardisedEllipsis.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-standardised/src/BreadcrumbStandardisedEllipsis.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '@ecl/ec-react-component-icon';
+
+export const BreadcrumbStandardisedEllipsis = ({ label, isVisible }) => (
+  <li
+    className="ecl-breadcrumb-standardised__segment ecl-breadcrumb-standardised__segment--ellipsis"
+    aria-hidden={!isVisible}
+    data-ecl-breadcrumb-standardised-ellipsis
+  >
+    <button
+      type="button"
+      className="ecl-breadcrumb-standardised__ellipsis"
+      aria-label={label}
+      data-ecl-breadcrumb-standardised-ellipsis-button
+    >
+      …
+    </button>
+    <Icon
+      className="ecl-breadcrumb-standardised__icon"
+      shape="ui--corner-arrow"
+      transform="rotate-90"
+      size="2xs"
+      role="presentation"
+      aria-hidden
+    />
+  </li>
+);
+
+BreadcrumbStandardisedEllipsis.propTypes = {
+  label: PropTypes.string,
+  isVisible: PropTypes.bool,
+};
+
+BreadcrumbStandardisedEllipsis.defaultProps = {
+  label: '',
+  isVisible: true,
+};
+
+export default BreadcrumbStandardisedEllipsis;

--- a/src/systems/ec/implementations/react/components/breadcrumb-standardised/src/BreadcrumbStandardisedItem.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-standardised/src/BreadcrumbStandardisedItem.jsx
@@ -1,0 +1,71 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import Icon from '@ecl/ec-react-component-icon';
+import Link from '@ecl/ec-react-component-link';
+
+export const BreadcrumbStandardisedItem = ({
+  href,
+  label,
+  isLastItem,
+  isVisible,
+  isExpandable,
+  className,
+  children,
+  ...props
+}) => (
+  <li
+    {...props}
+    className={classnames(className, 'ecl-breadcrumb-standardised__segment', {
+      'ecl-breadcrumb-standardised__current-page': isLastItem,
+    })}
+    {...(isLastItem && { 'aria-current': 'page' })}
+    data-ecl-breadcrumb-standardised-item={
+      isExpandable ? 'expandable' : 'static'
+    }
+    aria-hidden={!isVisible}
+  >
+    {!isLastItem ? (
+      <Fragment>
+        <Link
+          href={href}
+          label={label}
+          variant="standalone"
+          {...(isLastItem && { 'aria-current': 'page' })}
+          className="ecl-breadcrumb-standardised__link"
+        />
+        <Icon
+          className="ecl-breadcrumb-standardised__icon"
+          shape="ui--corner-arrow"
+          transform="rotate-90"
+          size="2xs"
+          role="presentation"
+          aria-hidden
+        />
+      </Fragment>
+    ) : (
+      <Fragment>{label}</Fragment>
+    )}
+  </li>
+);
+
+BreadcrumbStandardisedItem.propTypes = {
+  label: PropTypes.string.isRequired,
+  href: PropTypes.string,
+  isLastItem: PropTypes.bool,
+  isVisible: PropTypes.bool,
+  isExpandable: PropTypes.bool,
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+BreadcrumbStandardisedItem.defaultProps = {
+  href: '',
+  isLastItem: false,
+  isVisible: false,
+  isExpandable: false,
+  className: '',
+  children: null,
+};
+
+export default BreadcrumbStandardisedItem;

--- a/src/systems/ec/implementations/react/components/breadcrumb-standardised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-standardised/stories/Index.jsx
@@ -1,0 +1,65 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import StoryWrapper from '@ecl/story-wrapper';
+import simpleContent from '@ecl/ec-specs-breadcrumb-standardised/demo/data-simple';
+import demoContent from '@ecl/ec-specs-breadcrumb-standardised/demo/data';
+
+import { BreadcrumbStandardised } from '../src/BreadcrumbStandardised';
+import { BreadcrumbStandardisedItem } from '../src/BreadcrumbStandardisedItem';
+
+storiesOf('Components|Navigation/Breadcrumb standardised', module)
+  .addDecorator(withKnobs)
+  .addDecorator(story => (
+    <StoryWrapper
+      afterMount={() => {
+        if (!window.ECL) return {};
+
+        const components = window.ECL.autoInit();
+        return { components };
+      }}
+      beforeUnmount={context => {
+        if (context.components) {
+          context.components.forEach(c => c.destroy());
+        }
+      }}
+    >
+      {story()}
+    </StoryWrapper>
+  ))
+  .add('simple', () => {
+    const items = simpleContent.items.map((item, index) => ({
+      label: text(`Item ${index}`, item.label),
+      href: item.href,
+    }));
+
+    return (
+      <BreadcrumbStandardised
+        label={simpleContent.label}
+        ellipsisLabel="Click to expand"
+      >
+        {items.map(item => (
+          <BreadcrumbStandardisedItem {...item} key={item.label} />
+        ))}
+      </BreadcrumbStandardised>
+    );
+  })
+  .add('long', () => {
+    const items = demoContent.items.map((item, index) => ({
+      label: text(`Item ${index}`, item.label),
+      href: item.href,
+    }));
+
+    return (
+      <BreadcrumbStandardised
+        label={demoContent.label}
+        ellipsisLabel="Click to expand"
+        data-ecl-auto-init="BreadcrumbStandardised"
+      >
+        {items.map(item => (
+          <BreadcrumbStandardisedItem {...item} key={item.label} />
+        ))}
+      </BreadcrumbStandardised>
+    );
+  });

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/README.md
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/README.md
@@ -1,0 +1,3 @@
+# Breadcrumb Standardised
+
+(Work in progress)

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/ec-component-breadcrumb-standardised-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/ec-component-breadcrumb-standardised-print.scss
@@ -1,0 +1,18 @@
+/*
+ * Breadcrumbs Standardised
+ * @define breadcrumb-standardised
+ */
+
+// Import base
+@import '@ecl/ec-base/ec-base';
+
+@mixin ecl-breadcrumb-standardised-print() {
+  .ecl-breadcrumb-standardised {
+    display: none;
+  }
+}
+
+// Use mixin
+@include exports('ec-component-breadcrumb-standardised-print') {
+  @include ecl-breadcrumb-standardised-print();
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/ec-component-breadcrumb-standardised.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/ec-component-breadcrumb-standardised.js
@@ -1,0 +1,213 @@
+import { queryOne, queryAll } from '@ecl/ec-base/helpers/dom';
+
+export class BreadcrumbStandardised {
+  static autoInit(root, { BREADCRUMB_STANDARDISED: defaultOptions = {} } = {}) {
+    const breadcrumbStandardised = new BreadcrumbStandardised(
+      root,
+      defaultOptions
+    );
+    breadcrumbStandardised.init();
+    // eslint-disable-next-line no-param-reassign
+    root.ECLBreadcrumbStandardised = breadcrumbStandardised;
+    return breadcrumbStandardised;
+  }
+
+  constructor(
+    element,
+    {
+      ellipsisButtonSelector = '[data-ecl-breadcrumb-standardised-ellipsis-button]',
+      ellipsisSelector = '[data-ecl-breadcrumb-standardised-ellipsis]',
+      segmentSelector = '[data-ecl-breadcrumb-standardised-item]',
+      expandableItemsSelector = '[data-ecl-breadcrumb-standardised-item="expandable"]',
+      staticItemsSelector = '[data-ecl-breadcrumb-standardised-item="static"]',
+      onPartialExpand = null,
+      onFullExpand = null,
+      attachClickListener = true,
+    } = {}
+  ) {
+    // Check element
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+      throw new TypeError(
+        'DOM element should be given to initialize this widget.'
+      );
+    }
+
+    this.element = element;
+
+    // Options
+    this.ellipsisButtonSelector = ellipsisButtonSelector;
+    this.ellipsisSelector = ellipsisSelector;
+    this.segmentSelector = segmentSelector;
+    this.expandableItemsSelector = expandableItemsSelector;
+    this.staticItemsSelector = staticItemsSelector;
+    this.onPartialExpand = onPartialExpand;
+    this.onFullExpand = onFullExpand;
+    this.attachClickListener = attachClickListener;
+
+    // Private variables
+    this.ellipsisButton = null;
+    this.itemsElements = null;
+    this.staticElements = null;
+    this.expandableElements = null;
+
+    // Bind `this` for use in callbacks
+    this.handleClickOnEllipsis = this.handleClickOnEllipsis.bind(this);
+  }
+
+  init() {
+    this.ellipsisButton = queryOne(this.ellipsisButtonSelector, this.element);
+
+    // Bind click event on ellipsis
+    if (this.attachClickListener && this.ellipsisButton) {
+      this.ellipsisButton.addEventListener('click', this.handleClickOnEllipsis);
+    }
+
+    this.itemsElements = queryAll(this.segmentSelector, this.element);
+    this.staticElements = queryAll(this.staticItemsSelector, this.element);
+    this.expandableElements = queryAll(
+      this.expandableItemsSelector,
+      this.element
+    );
+
+    this.check();
+  }
+
+  destroy() {
+    if (this.attachClickListener && this.ellipsisButton) {
+      this.ellipsisButton.removeEventListener(
+        'click',
+        this.handleClickOnEllipsis
+      );
+    }
+  }
+
+  handleClickOnEllipsis() {
+    return this.handleFullExpand();
+  }
+
+  check() {
+    const visibilityMap = this.computeVisibilityMap();
+
+    if (!visibilityMap) return;
+
+    if (visibilityMap.expanded === true) {
+      this.handleFullExpand();
+    } else {
+      this.handlePartialExpand(visibilityMap);
+    }
+  }
+
+  hideEllipsis() {
+    // Hide ellipsis
+    const ellipsis = queryOne(this.ellipsisSelector, this.element);
+    if (ellipsis) {
+      ellipsis.setAttribute('aria-hidden', 'true');
+    }
+
+    // Remove event listener
+    if (this.attachClickListener && this.ellipsisButton) {
+      this.ellipsisButton.removeEventListener(
+        'click',
+        this.handleClickOnEllipsis
+      );
+    }
+  }
+
+  showAllItems() {
+    this.expandableElements.forEach(item =>
+      item.setAttribute('aria-hidden', 'false')
+    );
+  }
+
+  handlePartialExpand(visibilityMap) {
+    if (!visibilityMap) return;
+
+    const { isItemVisible } = visibilityMap;
+    if (!isItemVisible || !Array.isArray(isItemVisible)) return;
+
+    if (this.onPartialExpand) {
+      this.onPartialExpand(isItemVisible);
+    } else {
+      this.expandableElements.forEach((item, index) => {
+        item.setAttribute(
+          'aria-hidden',
+          isItemVisible[index] ? 'false' : 'true'
+        );
+      });
+    }
+  }
+
+  handleFullExpand() {
+    if (this.onFullExpand) {
+      this.onFullExpand();
+    } else {
+      this.hideEllipsis();
+      this.showAllItems();
+    }
+  }
+
+  computeVisibilityMap() {
+    // Ignore if there are no expandableElements
+    if (!this.expandableElements || this.expandableElements.length === 0) {
+      return { expanded: true };
+    }
+
+    const wrapperWidth = Math.floor(this.element.getBoundingClientRect().width);
+
+    // Get the sum of all items' width
+    const allItemsWidth = this.itemsElements
+      .map(
+        breadcrumbStandardisedSegment =>
+          breadcrumbStandardisedSegment.getBoundingClientRect().width
+      )
+      .reduce((a, b) => a + b);
+
+    if (allItemsWidth <= wrapperWidth) {
+      return { expanded: true };
+    }
+
+    const ellipsisItem = queryOne(this.ellipsisSelector, this.element);
+    const ellipsisItemWidth = ellipsisItem.getBoundingClientRect().width;
+
+    const incompressibleWidth =
+      ellipsisItemWidth +
+      this.staticElements.reduce(
+        (sum, currentItem) => sum + currentItem.getBoundingClientRect().width,
+        0
+      );
+
+    if (incompressibleWidth >= wrapperWidth) {
+      return {
+        expanded: false,
+        isItemVisible: [...this.expandableElements.map(() => false)],
+      };
+    }
+
+    let previousItemsWidth = 0;
+    let isPreviousItemVisible = true;
+
+    // Careful: reverse() is destructive, that's why we make a copy of the array
+    const isItemVisible = [...this.expandableElements]
+      .reverse()
+      .map(otherSegment => {
+        if (!isPreviousItemVisible) return false;
+
+        previousItemsWidth += otherSegment.getBoundingClientRect().width;
+
+        const isVisible =
+          previousItemsWidth + incompressibleWidth <= wrapperWidth;
+
+        if (!isVisible) isPreviousItemVisible = false;
+
+        return isVisible;
+      })
+      .reverse();
+
+    return {
+      expanded: false,
+      isItemVisible,
+    };
+  }
+}
+
+export default BreadcrumbStandardised;

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/ec-component-breadcrumb-standardised.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/ec-component-breadcrumb-standardised.scss
@@ -1,0 +1,121 @@
+/*
+ * Breadcrumbs standardised
+ * @define breadcrumb-standardised
+ */
+
+// Import base
+@import '@ecl/ec-base/ec-base';
+
+// Check if overridden dependencies are already loaded, if needed
+@include check-imports(('ec-component-link', 'ec-component-icon'));
+
+@mixin ecl-breadcrumb-standardised(
+  $background-color: transparent,
+  $background-color-hover: $ecl-color-blue-5,
+  $link-color: $ecl-color-blue,
+  $last-link-color: $ecl-color-grey-75,
+  $border-color: $ecl-color-blue-25
+) {
+  .ecl-breadcrumb-standardised {
+    background-color: $background-color;
+    margin: 0;
+  }
+
+  .ecl-breadcrumb-standardised__container {
+    border-bottom: 1px solid $border-color;
+    box-sizing: border-box;
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0 0 calc(#{$ecl-spacing-m} - 1px);
+
+    &::after {
+      clear: both;
+      content: '';
+      display: block;
+    }
+  }
+
+  .ecl-breadcrumb-standardised__segment {
+    align-items: center;
+    display: inline-flex;
+    font: $ecl-font-s;
+    margin-top: $ecl-spacing-m;
+    max-width: 100%;
+
+    &[aria-hidden='true'] {
+      position: absolute;
+      visibility: hidden;
+
+      /* Force display if JS is disabled */
+      /* stylelint-disable-next-line max-nesting-depth */
+      .no-js & {
+        position: static;
+        visibility: visible;
+      }
+    }
+  }
+
+  .ecl-breadcrumb-standardised__segment--ellipsis {
+    &[aria-hidden='false'] {
+      /* Force hide if JS is disabled */
+      /* stylelint-disable-next-line max-nesting-depth */
+      .no-js & {
+        display: none;
+      }
+    }
+  }
+
+  .ecl-breadcrumb-standardised__ellipsis {
+    background-color: transparent;
+    border-width: 0;
+    box-sizing: border-box;
+    color: $link-color;
+    font-weight: $ecl-font-weight-bold;
+    margin: 0;
+    padding: 0;
+
+    &:hover {
+      background-color: $background-color-hover;
+    }
+
+    &:focus {
+      outline: 3px solid $ecl-color-yellow-100;
+      outline-offset: 2px;
+    }
+  }
+
+  .ecl-breadcrumb-standardised__link {
+    color: $link-color;
+    font-weight: $ecl-font-weight-bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    &:hover,
+    &:active,
+    &:focus,
+    &:visited {
+      color: $link-color;
+    }
+  }
+
+  .ecl-breadcrumb-standardised__icon {
+    fill: $link-color;
+    flex-shrink: 0;
+    margin-left: $ecl-spacing-xs;
+    margin-right: $ecl-spacing-xs;
+    vertical-align: text-bottom;
+  }
+
+  .ecl-breadcrumb-standardised__current-page {
+    color: $last-link-color;
+    font-weight: $ecl-font-weight-bold;
+  }
+}
+
+// Use mixin
+@include exports('ec-component-breadcrumb-standardised') {
+  @include ecl-breadcrumb-standardised();
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-standardised/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@ecl/ec-component-breadcrumb-standardised",
+  "version": "2.12.0",
+  "description": "ECL EC Breadcrumb Standardised",
+  "main": "ec-component-breadcrumb-standardised.js",
+  "module": "ec-component-breadcrumb-standardised.js",
+  "style": "ec-component-breadcrumb-standardised.scss",
+  "sass": "ec-component-breadcrumb-standardised.scss",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "dependencies": {
+    "@ecl/ec-base": "^2.12.0",
+    "@ecl/ec-component-icon": "^2.12.0",
+    "@ecl/ec-component-link": "^2.12.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/package.json
@@ -15,6 +15,7 @@
     "@ecl/ec-component-accordion2": "^2.12.0",
     "@ecl/ec-component-blockquote": "^2.12.0",
     "@ecl/ec-component-breadcrumb": "^2.12.0",
+    "@ecl/ec-component-breadcrumb-standardised": "^2.12.0",
     "@ecl/ec-component-button": "^2.12.0",
     "@ecl/ec-component-card": "^2.12.0",
     "@ecl/ec-component-contextual-navigation": "^2.12.0",

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev-print.scss
@@ -31,6 +31,7 @@
 @import '@ecl/ec-component-hero-banner/ec-component-hero-banner-print';
 @import '@ecl/ec-component-page-banner/ec-component-page-banner-print';
 @import '@ecl/ec-component-breadcrumb/ec-component-breadcrumb-print';
+@import '@ecl/ec-component-breadcrumb-standardised/ec-component-breadcrumb-standardised-print';
 @import '@ecl/ec-component-card/ec-component-card-print';
 @import '@ecl/ec-component-contextual-navigation/ec-component-contextual-navigation-print';
 @import '@ecl/ec-component-expandable/ec-component-expandable-print';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.js
@@ -3,6 +3,7 @@
 export * from '@ecl/ec-auto-init';
 export * from '@ecl/ec-component-accordion2';
 export * from '@ecl/ec-component-breadcrumb';
+export * from '@ecl/ec-component-breadcrumb-standardised';
 export * from '@ecl/ec-component-contextual-navigation';
 export * from '@ecl/ec-component-expandable';
 export * from '@ecl/ec-component-file';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.scss
@@ -44,6 +44,7 @@
 @import '@ecl/ec-component-hero-banner/ec-component-hero-banner';
 @import '@ecl/ec-component-page-banner/ec-component-page-banner';
 @import '@ecl/ec-component-breadcrumb/ec-component-breadcrumb';
+@import '@ecl/ec-component-breadcrumb-standardised/ec-component-breadcrumb-standardised';
 @import '@ecl/ec-component-card/ec-component-card';
 // @import '@ecl/ec-component-carousel/ec-component-carousel';
 // @import '@ecl/ec-component-comment/ec-component-comment';

--- a/src/systems/ec/specs/components/breadcrumb-standardised/demo/data-simple.js
+++ b/src/systems/ec/specs/components/breadcrumb-standardised/demo/data-simple.js
@@ -1,0 +1,9 @@
+// Simple content for demo
+module.exports = {
+  items: [
+    { label: 'Home', href: '/example' },
+    { label: 'About the European Commission', href: '/example' },
+    { label: 'News' },
+  ],
+  label: 'You are here:',
+};

--- a/src/systems/ec/specs/components/breadcrumb-standardised/demo/data.js
+++ b/src/systems/ec/specs/components/breadcrumb-standardised/demo/data.js
@@ -1,0 +1,11 @@
+// Simple content for demo
+module.exports = {
+  items: [
+    { label: 'Home', href: '/example' },
+    { label: 'About the European Commission', href: '/example' },
+    { label: 'Organisational structure', href: '/example' },
+    { label: 'How the Commission is organised', href: '/example' },
+    { label: 'News' },
+  ],
+  label: 'You are here:',
+};

--- a/src/systems/ec/specs/components/breadcrumb-standardised/package.json
+++ b/src/systems/ec/specs/components/breadcrumb-standardised/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ecl/ec-specs-breadcrumb-standardised",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "2.12.0",
+  "description": "ECL EC Breadcrumb Standardised Specs",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}


### PR DESCRIPTION
# PR description

specs: https://webgate.ec.europa.eu/CITnet/confluence/display/NEXTEUROPA/Standardised+Breadcrumb+-+Design+Specifications

playground:
- https://deploy-preview-1339--europa-component-library.netlify.com/playground/ec/?path=/story/components-navigation-breadcrumb-standardised--simple
- https://deploy-preview-1339--europa-component-library.netlify.com/playground/ec/?path=/story/components-navigation-breadcrumb-standardised--long

note: the component isn't dipslayed on the website as is, as it will be part of the page header