### PR TITLE
feat(breadcrumb-harmonised): add component - INNO-1817

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -34,7 +34,7 @@
   {
     "path": "dist/packages/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website.css",
     "webpack": false,
-    "limit": "23 KB"
+    "limit": "24 KB"
   },
   {
     "path": "dist/packages/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website-print.css",

--- a/src/systems/ec/implementations/react/components/breadcrumb-harmonised/index.js
+++ b/src/systems/ec/implementations/react/components/breadcrumb-harmonised/index.js
@@ -1,0 +1,6 @@
+export default from './src/BreadcrumbHarmonised';
+export { BreadcrumbHarmonised } from './src/BreadcrumbHarmonised';
+export { BreadcrumbHarmonisedItem } from './src/BreadcrumbHarmonisedItem';
+export {
+  BreadcrumbHarmonisedEllipsis,
+} from './src/BreadcrumbHarmonisedEllipsis';

--- a/src/systems/ec/implementations/react/components/breadcrumb-harmonised/package.json
+++ b/src/systems/ec/implementations/react/components/breadcrumb-harmonised/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "name": "@ecl/ec-react-component-breadcrumb-harmonised",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "2.12.0",
+  "description": "ECL EC React Breadcrumb Harmonised",
+  "main": "index.js",
+  "module": "index.js",
+  "dependencies": {
+    "@ecl/ec-component-breadcrumb-harmonised": "^2.12.0",
+    "@ecl/ec-react-component-icon": "^2.12.0",
+    "@ecl/ec-react-component-link": "^2.12.0"
+  },
+  "devDependencies": {
+    "@ecl/ec-specs-breadcrumb-harmonised": "^2.12.0"
+  },
+  "peerDependencies": {
+    "classnames": "^2.2.6",
+    "prop-types": "^15.6.2",
+    "react": "^16.4.2",
+    "react-dom": "^16.4.2"
+  }
+}

--- a/src/systems/ec/implementations/react/components/breadcrumb-harmonised/src/BreadcrumbHarmonised.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-harmonised/src/BreadcrumbHarmonised.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+import { BreadcrumbHarmonisedEllipsis } from './BreadcrumbHarmonisedEllipsis';
+
+export const BreadcrumbHarmonised = ({
+  label,
+  className,
+  ellipsisLabel,
+  children,
+  minItemsLeft,
+  minItemsRight,
+  ...props
+}) => {
+  if (!children) return null;
+
+  const childrenArray = React.Children.toArray(children);
+  let expanded;
+  let isItemVisible;
+
+  if (childrenArray.length <= minItemsLeft) {
+    expanded = true;
+    isItemVisible = [...children.map(() => true)];
+  } else {
+    expanded = false;
+    isItemVisible = [
+      ...children.slice(0, minItemsLeft).map(() => true),
+      ...children.slice(minItemsLeft, -minItemsRight).map(() => false),
+      ...children.slice(-minItemsRight).map(() => true),
+    ];
+  }
+
+  const classNames = classnames(className, 'ecl-breadcrumb-harmonised');
+
+  const childrenCount = React.Children.count(children);
+
+  const items = [];
+  if (childrenCount <= minItemsLeft + minItemsRight) {
+    items.push(
+      ...childrenArray.map((item, index) =>
+        React.cloneElement(item, {
+          isLastItem: index === childrenArray.length - 1,
+          isVisible: true,
+        })
+      )
+    );
+  } else {
+    // Insert left items
+    const leftItems = childrenArray.slice(0, minItemsLeft);
+    items.push(
+      ...leftItems.map(item => React.cloneElement(item, { isVisible: true }))
+    );
+
+    // Insert Ellipsis
+    items.push(
+      <BreadcrumbHarmonisedEllipsis
+        label={ellipsisLabel}
+        isVisible={!expanded}
+        key="ellipsis"
+      />
+    );
+
+    // Insert "expandable" items
+    const expandableItems = childrenArray.slice(minItemsLeft, -minItemsRight);
+    items.push(
+      ...expandableItems.map((item, index) =>
+        React.cloneElement(item, {
+          isVisible: expanded || isItemVisible[index],
+          isExpandable: true,
+        })
+      )
+    );
+
+    // Insert right items
+    const rightItems = childrenArray.slice(-minItemsRight);
+    items.push(
+      ...rightItems.map((item, index) =>
+        React.cloneElement(item, {
+          isLastItem: index === rightItems.length - 1,
+          isVisible: true,
+        })
+      )
+    );
+  }
+
+  return (
+    <nav
+      {...props}
+      className={classNames}
+      aria-label={label}
+      data-ecl-breadcrumb-harmonised
+    >
+      <ol className="ecl-breadcrumb-harmonised__container">{items}</ol>
+    </nav>
+  );
+};
+
+BreadcrumbHarmonised.propTypes = {
+  label: PropTypes.string.isRequired,
+  ellipsisLabel: PropTypes.string,
+  className: PropTypes.string,
+  children: PropTypes.node,
+  minItemsLeft: PropTypes.number,
+  minItemsRight: PropTypes.number,
+};
+
+BreadcrumbHarmonised.defaultProps = {
+  ellipsisLabel: '',
+  className: '',
+  children: null,
+  minItemsLeft: 1,
+  minItemsRight: 2,
+};
+
+export default BreadcrumbHarmonised;

--- a/src/systems/ec/implementations/react/components/breadcrumb-harmonised/src/BreadcrumbHarmonisedEllipsis.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-harmonised/src/BreadcrumbHarmonisedEllipsis.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Icon from '@ecl/ec-react-component-icon';
+
+export const BreadcrumbHarmonisedEllipsis = ({ label, isVisible }) => (
+  <li
+    className="ecl-breadcrumb-harmonised__segment ecl-breadcrumb-harmonised__segment--ellipsis"
+    aria-hidden={!isVisible}
+    data-ecl-breadcrumb-harmonised-ellipsis
+  >
+    <button
+      type="button"
+      className="ecl-breadcrumb-harmonised__ellipsis"
+      aria-label={label}
+      data-ecl-breadcrumb-harmonised-ellipsis-button
+    >
+      …
+    </button>
+    <Icon
+      className="ecl-breadcrumb-harmonised__icon"
+      shape="ui--corner-arrow"
+      transform="rotate-90"
+      size="2xs"
+      role="presentation"
+      aria-hidden
+    />
+  </li>
+);
+
+BreadcrumbHarmonisedEllipsis.propTypes = {
+  label: PropTypes.string,
+  isVisible: PropTypes.bool,
+};
+
+BreadcrumbHarmonisedEllipsis.defaultProps = {
+  label: '',
+  isVisible: true,
+};
+
+export default BreadcrumbHarmonisedEllipsis;

--- a/src/systems/ec/implementations/react/components/breadcrumb-harmonised/src/BreadcrumbHarmonisedItem.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-harmonised/src/BreadcrumbHarmonisedItem.jsx
@@ -1,0 +1,69 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import Icon from '@ecl/ec-react-component-icon';
+import Link from '@ecl/ec-react-component-link';
+
+export const BreadcrumbHarmonisedItem = ({
+  href,
+  label,
+  isLastItem,
+  isVisible,
+  isExpandable,
+  className,
+  children,
+  ...props
+}) => (
+  <li
+    {...props}
+    className={classnames(className, 'ecl-breadcrumb-harmonised__segment', {
+      'ecl-breadcrumb-harmonised__current-page': isLastItem,
+    })}
+    {...(isLastItem && { 'aria-current': 'page' })}
+    data-ecl-breadcrumb-harmonised-item={isExpandable ? 'expandable' : 'static'}
+    aria-hidden={!isVisible}
+  >
+    {!isLastItem ? (
+      <Fragment>
+        <Link
+          href={href}
+          label={label}
+          variant="standalone"
+          {...(isLastItem && { 'aria-current': 'page' })}
+          className="ecl-breadcrumb-harmonised__link"
+        />
+        <Icon
+          className="ecl-breadcrumb-harmonised__icon"
+          shape="ui--corner-arrow"
+          transform="rotate-90"
+          size="2xs"
+          role="presentation"
+          aria-hidden
+        />
+      </Fragment>
+    ) : (
+      <Fragment>{label}</Fragment>
+    )}
+  </li>
+);
+
+BreadcrumbHarmonisedItem.propTypes = {
+  label: PropTypes.string.isRequired,
+  href: PropTypes.string,
+  isLastItem: PropTypes.bool,
+  isVisible: PropTypes.bool,
+  isExpandable: PropTypes.bool,
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+BreadcrumbHarmonisedItem.defaultProps = {
+  href: '',
+  isLastItem: false,
+  isVisible: false,
+  isExpandable: false,
+  className: '',
+  children: null,
+};
+
+export default BreadcrumbHarmonisedItem;

--- a/src/systems/ec/implementations/react/components/breadcrumb-harmonised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-harmonised/stories/Index.jsx
@@ -1,0 +1,48 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import StoryWrapper from '@ecl/story-wrapper';
+import demoContent from '@ecl/ec-specs-breadcrumb-harmonised/demo/data';
+
+import { BreadcrumbHarmonised } from '../src/BreadcrumbHarmonised';
+import { BreadcrumbHarmonisedItem } from '../src/BreadcrumbHarmonisedItem';
+
+storiesOf('Components|Navigation/Breadcrumb harmonised', module)
+  .addDecorator(withKnobs)
+  .addDecorator(story => (
+    <StoryWrapper
+      afterMount={() => {
+        if (!window.ECL) return {};
+
+        const components = window.ECL.autoInit();
+        return { components };
+      }}
+      beforeUnmount={context => {
+        if (context.components) {
+          context.components.forEach(c => c.destroy());
+        }
+      }}
+    >
+      {story()}
+    </StoryWrapper>
+  ))
+  .add('group 1', () => {
+    const items = demoContent.items.map((item, index) => ({
+      label: text(`Item ${index}`, item.label),
+      href: item.href,
+    }));
+
+    return (
+      <BreadcrumbHarmonised
+        label={demoContent.label}
+        ellipsisLabel="Click to expand"
+        data-ecl-auto-init="BreadcrumbHarmonised"
+        className="ecl-breadcrumb-harmonised--group1"
+      >
+        {items.map(item => (
+          <BreadcrumbHarmonisedItem {...item} key={item.label} />
+        ))}
+      </BreadcrumbHarmonised>
+    );
+  });

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/README.md
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/README.md
@@ -1,0 +1,3 @@
+# Breadcrumb Harmonised
+
+(Work in progress)

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/ec-component-breadcrumb-harmonised-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/ec-component-breadcrumb-harmonised-print.scss
@@ -1,0 +1,18 @@
+/*
+ * Breadcrumbs Harmonised
+ * @define breadcrumb-harmonised
+ */
+
+// Import base
+@import '@ecl/ec-base/ec-base';
+
+@mixin ecl-breadcrumb-harmonised-print() {
+  .ecl-breadcrumb-harmonised {
+    display: none;
+  }
+}
+
+// Use mixin
+@include exports('ec-component-breadcrumb-harmonised-print') {
+  @include ecl-breadcrumb-harmonised-print();
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/ec-component-breadcrumb-harmonised.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/ec-component-breadcrumb-harmonised.js
@@ -1,0 +1,210 @@
+import { queryOne, queryAll } from '@ecl/ec-base/helpers/dom';
+
+export class BreadcrumbHarmonised {
+  static autoInit(root, { BREADCRUMB_HARMONISED: defaultOptions = {} } = {}) {
+    const breadcrumbHarmonised = new BreadcrumbHarmonised(root, defaultOptions);
+    breadcrumbHarmonised.init();
+    // eslint-disable-next-line no-param-reassign
+    root.ECLBreadcrumbHarmonised = breadcrumbHarmonised;
+    return breadcrumbHarmonised;
+  }
+
+  constructor(
+    element,
+    {
+      ellipsisButtonSelector = '[data-ecl-breadcrumb-harmonised-ellipsis-button]',
+      ellipsisSelector = '[data-ecl-breadcrumb-harmonised-ellipsis]',
+      segmentSelector = '[data-ecl-breadcrumb-harmonised-item]',
+      expandableItemsSelector = '[data-ecl-breadcrumb-harmonised-item="expandable"]',
+      staticItemsSelector = '[data-ecl-breadcrumb-harmonised-item="static"]',
+      onPartialExpand = null,
+      onFullExpand = null,
+      attachClickListener = true,
+    } = {}
+  ) {
+    // Check element
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+      throw new TypeError(
+        'DOM element should be given to initialize this widget.'
+      );
+    }
+
+    this.element = element;
+
+    // Options
+    this.ellipsisButtonSelector = ellipsisButtonSelector;
+    this.ellipsisSelector = ellipsisSelector;
+    this.segmentSelector = segmentSelector;
+    this.expandableItemsSelector = expandableItemsSelector;
+    this.staticItemsSelector = staticItemsSelector;
+    this.onPartialExpand = onPartialExpand;
+    this.onFullExpand = onFullExpand;
+    this.attachClickListener = attachClickListener;
+
+    // Private variables
+    this.ellipsisButton = null;
+    this.itemsElements = null;
+    this.staticElements = null;
+    this.expandableElements = null;
+
+    // Bind `this` for use in callbacks
+    this.handleClickOnEllipsis = this.handleClickOnEllipsis.bind(this);
+  }
+
+  init() {
+    this.ellipsisButton = queryOne(this.ellipsisButtonSelector, this.element);
+
+    // Bind click event on ellipsis
+    if (this.attachClickListener && this.ellipsisButton) {
+      this.ellipsisButton.addEventListener('click', this.handleClickOnEllipsis);
+    }
+
+    this.itemsElements = queryAll(this.segmentSelector, this.element);
+    this.staticElements = queryAll(this.staticItemsSelector, this.element);
+    this.expandableElements = queryAll(
+      this.expandableItemsSelector,
+      this.element
+    );
+
+    this.check();
+  }
+
+  destroy() {
+    if (this.attachClickListener && this.ellipsisButton) {
+      this.ellipsisButton.removeEventListener(
+        'click',
+        this.handleClickOnEllipsis
+      );
+    }
+  }
+
+  handleClickOnEllipsis() {
+    return this.handleFullExpand();
+  }
+
+  check() {
+    const visibilityMap = this.computeVisibilityMap();
+
+    if (!visibilityMap) return;
+
+    if (visibilityMap.expanded === true) {
+      this.handleFullExpand();
+    } else {
+      this.handlePartialExpand(visibilityMap);
+    }
+  }
+
+  hideEllipsis() {
+    // Hide ellipsis
+    const ellipsis = queryOne(this.ellipsisSelector, this.element);
+    if (ellipsis) {
+      ellipsis.setAttribute('aria-hidden', 'true');
+    }
+
+    // Remove event listener
+    if (this.attachClickListener && this.ellipsisButton) {
+      this.ellipsisButton.removeEventListener(
+        'click',
+        this.handleClickOnEllipsis
+      );
+    }
+  }
+
+  showAllItems() {
+    this.expandableElements.forEach(item =>
+      item.setAttribute('aria-hidden', 'false')
+    );
+  }
+
+  handlePartialExpand(visibilityMap) {
+    if (!visibilityMap) return;
+
+    const { isItemVisible } = visibilityMap;
+    if (!isItemVisible || !Array.isArray(isItemVisible)) return;
+
+    if (this.onPartialExpand) {
+      this.onPartialExpand(isItemVisible);
+    } else {
+      this.expandableElements.forEach((item, index) => {
+        item.setAttribute(
+          'aria-hidden',
+          isItemVisible[index] ? 'false' : 'true'
+        );
+      });
+    }
+  }
+
+  handleFullExpand() {
+    if (this.onFullExpand) {
+      this.onFullExpand();
+    } else {
+      this.hideEllipsis();
+      this.showAllItems();
+    }
+  }
+
+  computeVisibilityMap() {
+    // Ignore if there are no expandableElements
+    if (!this.expandableElements || this.expandableElements.length === 0) {
+      return { expanded: true };
+    }
+
+    const wrapperWidth = Math.floor(this.element.getBoundingClientRect().width);
+
+    // Get the sum of all items' width
+    const allItemsWidth = this.itemsElements
+      .map(
+        breadcrumbHarmonisedSegment =>
+          breadcrumbHarmonisedSegment.getBoundingClientRect().width
+      )
+      .reduce((a, b) => a + b);
+
+    if (allItemsWidth <= wrapperWidth) {
+      return { expanded: true };
+    }
+
+    const ellipsisItem = queryOne(this.ellipsisSelector, this.element);
+    const ellipsisItemWidth = ellipsisItem.getBoundingClientRect().width;
+
+    const incompressibleWidth =
+      ellipsisItemWidth +
+      this.staticElements.reduce(
+        (sum, currentItem) => sum + currentItem.getBoundingClientRect().width,
+        0
+      );
+
+    if (incompressibleWidth >= wrapperWidth) {
+      return {
+        expanded: false,
+        isItemVisible: [...this.expandableElements.map(() => false)],
+      };
+    }
+
+    let previousItemsWidth = 0;
+    let isPreviousItemVisible = true;
+
+    // Careful: reverse() is destructive, that's why we make a copy of the array
+    const isItemVisible = [...this.expandableElements]
+      .reverse()
+      .map(otherSegment => {
+        if (!isPreviousItemVisible) return false;
+
+        previousItemsWidth += otherSegment.getBoundingClientRect().width;
+
+        const isVisible =
+          previousItemsWidth + incompressibleWidth <= wrapperWidth;
+
+        if (!isVisible) isPreviousItemVisible = false;
+
+        return isVisible;
+      })
+      .reverse();
+
+    return {
+      expanded: false,
+      isItemVisible,
+    };
+  }
+}
+
+export default BreadcrumbHarmonised;

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/ec-component-breadcrumb-harmonised.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/ec-component-breadcrumb-harmonised.scss
@@ -1,0 +1,140 @@
+/*
+ * Breadcrumbs harmonised
+ * @define breadcrumb-harmonised
+ */
+
+// Import base
+@import '@ecl/ec-base/ec-base';
+
+// Check if overridden dependencies are already loaded, if needed
+@include check-imports(('ec-component-link', 'ec-component-icon'));
+
+@mixin ecl-breadcrumb-harmonised() {
+  .ecl-breadcrumb-harmonised {
+    margin: 0;
+  }
+
+  .ecl-breadcrumb-harmonised__container {
+    box-sizing: border-box;
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0 0 calc(#{$ecl-spacing-m} - 1px);
+
+    &::after {
+      clear: both;
+      content: '';
+      display: block;
+    }
+  }
+
+  .ecl-breadcrumb-harmonised__segment {
+    align-items: center;
+    display: inline-flex;
+    font: $ecl-font-s;
+    margin-top: $ecl-spacing-m;
+    max-width: 100%;
+
+    &[aria-hidden='true'] {
+      position: absolute;
+      visibility: hidden;
+
+      /* Force display if JS is disabled */
+      /* stylelint-disable-next-line max-nesting-depth */
+      .no-js & {
+        position: static;
+        visibility: visible;
+      }
+    }
+  }
+
+  .ecl-breadcrumb-harmonised__segment--ellipsis {
+    &[aria-hidden='false'] {
+      /* Force hide if JS is disabled */
+      /* stylelint-disable-next-line max-nesting-depth */
+      .no-js & {
+        display: none;
+      }
+    }
+  }
+
+  .ecl-breadcrumb-harmonised__ellipsis {
+    background-color: transparent;
+    border-width: 0;
+    box-sizing: border-box;
+    font-weight: $ecl-font-weight-bold;
+    margin: 0;
+    padding: 0;
+
+    &:focus {
+      outline: 3px solid $ecl-color-yellow-100;
+      outline-offset: 2px;
+    }
+  }
+
+  .ecl-breadcrumb-harmonised__link {
+    font-weight: $ecl-font-weight-bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .ecl-breadcrumb-harmonised__icon {
+    flex-shrink: 0;
+    margin-left: $ecl-spacing-xs;
+    margin-right: $ecl-spacing-xs;
+    vertical-align: text-bottom;
+  }
+
+  .ecl-breadcrumb-harmonised__current-page {
+    font-weight: $ecl-font-weight-bold;
+  }
+}
+
+/* Group 1 */
+@mixin ecl-breadcrumb-harmonised-group1(
+  $background-color: transparent,
+  $background-color-hover: $ecl-color-blue-5,
+  $link-color: $ecl-color-blue,
+  $last-link-color: $ecl-color-grey-75,
+  $border-color: $ecl-color-blue-25
+) {
+  .ecl-breadcrumb-harmonised--group1 {
+    background-color: $background-color;
+
+    .ecl-breadcrumb-harmonised__container {
+      border-bottom: 1px solid $border-color;
+    }
+
+    .ecl-breadcrumb-harmonised__ellipsis {
+      color: $link-color;
+    }
+
+    .ecl-breadcrumb-harmonised__ellipsis:hover {
+      background-color: $background-color-hover;
+    }
+
+    .ecl-breadcrumb-harmonised__link,
+    .ecl-breadcrumb-harmonised__link:hover,
+    .ecl-breadcrumb-harmonised__link:focus,
+    .ecl-breadcrumb-harmonised__link:active,
+    .ecl-breadcrumb-harmonised__link:visited {
+      color: $link-color;
+    }
+
+    .ecl-breadcrumb-harmonised__icon {
+      fill: $link-color;
+    }
+
+    .ecl-breadcrumb-harmonised__current-page {
+      color: $last-link-color;
+    }
+  }
+}
+
+// Use mixin
+@include exports('ec-component-breadcrumb-harmonised') {
+  @include ecl-breadcrumb-harmonised();
+  @include ecl-breadcrumb-harmonised-group1();
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-breadcrumb-harmonised/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@ecl/ec-component-breadcrumb-harmonised",
+  "version": "2.12.0",
+  "description": "ECL EC Breadcrumb Harmonised",
+  "main": "ec-component-breadcrumb-harmonised.js",
+  "module": "ec-component-breadcrumb-harmonised.js",
+  "style": "ec-component-breadcrumb-harmonised.scss",
+  "sass": "ec-component-breadcrumb-harmonised.scss",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "dependencies": {
+    "@ecl/ec-base": "^2.12.0",
+    "@ecl/ec-component-icon": "^2.12.0",
+    "@ecl/ec-component-link": "^2.12.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/package.json
@@ -15,6 +15,7 @@
     "@ecl/ec-component-accordion2": "^2.12.0",
     "@ecl/ec-component-blockquote": "^2.12.0",
     "@ecl/ec-component-breadcrumb": "^2.12.0",
+    "@ecl/ec-component-breadcrumb-harmonised": "^2.12.0",
     "@ecl/ec-component-button": "^2.12.0",
     "@ecl/ec-component-card": "^2.12.0",
     "@ecl/ec-component-contextual-navigation": "^2.12.0",

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev-print.scss
@@ -31,6 +31,7 @@
 @import '@ecl/ec-component-hero-banner/ec-component-hero-banner-print';
 @import '@ecl/ec-component-page-banner/ec-component-page-banner-print';
 @import '@ecl/ec-component-breadcrumb/ec-component-breadcrumb-print';
+@import '@ecl/ec-component-breadcrumb-harmonised/ec-component-breadcrumb-harmonised-print';
 @import '@ecl/ec-component-card/ec-component-card-print';
 @import '@ecl/ec-component-contextual-navigation/ec-component-contextual-navigation-print';
 @import '@ecl/ec-component-expandable/ec-component-expandable-print';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.js
@@ -3,6 +3,7 @@
 export * from '@ecl/ec-auto-init';
 export * from '@ecl/ec-component-accordion2';
 export * from '@ecl/ec-component-breadcrumb';
+export * from '@ecl/ec-component-breadcrumb-harmonised';
 export * from '@ecl/ec-component-contextual-navigation';
 export * from '@ecl/ec-component-expandable';
 export * from '@ecl/ec-component-file';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.scss
@@ -44,6 +44,7 @@
 @import '@ecl/ec-component-hero-banner/ec-component-hero-banner';
 @import '@ecl/ec-component-page-banner/ec-component-page-banner';
 @import '@ecl/ec-component-breadcrumb/ec-component-breadcrumb';
+@import '@ecl/ec-component-breadcrumb-harmonised/ec-component-breadcrumb-harmonised';
 @import '@ecl/ec-component-card/ec-component-card';
 // @import '@ecl/ec-component-carousel/ec-component-carousel';
 // @import '@ecl/ec-component-comment/ec-component-comment';

--- a/src/systems/ec/specs/components/breadcrumb-harmonised/demo/data-simple.js
+++ b/src/systems/ec/specs/components/breadcrumb-harmonised/demo/data-simple.js
@@ -1,0 +1,9 @@
+// Simple content for demo
+module.exports = {
+  items: [
+    { label: 'Home', href: '/example' },
+    { label: 'About the European Commission', href: '/example' },
+    { label: 'News' },
+  ],
+  label: 'You are here:',
+};

--- a/src/systems/ec/specs/components/breadcrumb-harmonised/demo/data.js
+++ b/src/systems/ec/specs/components/breadcrumb-harmonised/demo/data.js
@@ -1,0 +1,11 @@
+// Simple content for demo
+module.exports = {
+  items: [
+    { label: 'Home', href: '/example' },
+    { label: 'About the European Commission', href: '/example' },
+    { label: 'Organisational structure', href: '/example' },
+    { label: 'How the Commission is organised', href: '/example' },
+    { label: 'News' },
+  ],
+  label: 'You are here:',
+};

--- a/src/systems/ec/specs/components/breadcrumb-harmonised/package.json
+++ b/src/systems/ec/specs/components/breadcrumb-harmonised/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ecl/ec-specs-breadcrumb-harmonised",
+  "author": "European Commission",
+  "license": "EUPL-1.1",
+  "version": "2.12.0",
+  "description": "ECL EC Breadcrumb Harmonised Specs",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}


### PR DESCRIPTION
# PR description

specs: https://webgate.ec.europa.eu/CITnet/confluence/display/NEXTEUROPA/Harmonised+Breadcrumb+-+Design+Specifications

playground: https://deploy-preview-1340--europa-component-library.netlify.com/playground/ec/?path=/story/components-navigation-breadcrumb-harmonised--group-1

note: the component isn't dipslayed on the website as is, as it will be part of the page header
