### PR TITLE
fix(inpage-nav): remove sticky nav when out of viewport - INNO-1948

### DIFF
--- a/src/systems/ec/implementations/react/components/inpage-navigation/examples/Default.jsx
+++ b/src/systems/ec/implementations/react/components/inpage-navigation/examples/Default.jsx
@@ -45,7 +45,10 @@ export default class DefaultExample extends React.Component {
         <SiteHeader {...demoContentEn} />
         <PageHeader breadcrumb={breadcrumb} title="A demo page" />
         <div className="ecl-container">
-          <div className="ecl-row ecl-u-mt-l">
+          <div
+            className="ecl-row ecl-u-mt-l"
+            data-ecl-inpage-navigation-container
+          >
             <div className="ecl-col-lg-3">
               <InpageNavigation {...demoContent} />
             </div>

--- a/src/systems/ec/implementations/react/templates/pages/content-page/src/ContentPage.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/content-page/src/ContentPage.jsx
@@ -12,7 +12,7 @@ const ContentPage = ({ siteHeader, pageHeader, footer, inpageNavigation }) => (
     <SiteHeader {...siteHeader} data-ecl-auto-init="SiteHeader" />
     <PageHeader {...pageHeader} />
     <div className="ecl-container">
-      <div className="ecl-row ecl-u-mt-l">
+      <div className="ecl-row ecl-u-mt-l" data-ecl-inpage-navigation-container>
         <div className="ecl-col-md-3">
           <InpageNavigation
             {...inpageNavigation}

--- a/src/systems/ec/implementations/react/templates/pages/funding-programme/src/FundingProgrammePage.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/funding-programme/src/FundingProgrammePage.jsx
@@ -143,7 +143,7 @@ const FundingProgrammePage = ({ siteHeader, footer, template }) => (
 
     <div className="ecl-u-pv-3xl ecl-u-pv-lg-4xl">
       <div className="ecl-container">
-        <div className="ecl-row">
+        <div className="ecl-row" data-ecl-inpage-navigation-container>
           <div className="ecl-col-12 ecl-col-lg-3">
             <aside className="ecl-u-height-100">
               <InpageNavigation

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-inpage-navigation/ec-component-inpage-navigation.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-inpage-navigation/ec-component-inpage-navigation.js
@@ -24,6 +24,7 @@ export class InpageNavigation {
     {
       attachClickListener = true,
       stickySelector = '[data-ecl-inpage-navigation]',
+      containerSelector = '[data-ecl-inpage-navigation-container]',
       inPageList = '[data-ecl-inpage-navigation-list]',
       spySelector = '[data-ecl-inpage-navigation-link]',
       toggleSelector = '[data-ecl-inpage-navigation-trigger]',
@@ -44,6 +45,7 @@ export class InpageNavigation {
     this.element = element;
     this.attachClickListener = attachClickListener;
     this.stickySelector = stickySelector;
+    this.containerSelector = containerSelector;
     this.toggleSelector = toggleSelector;
     this.linksSelector = linksSelector;
     this.inPageList = inPageList;
@@ -53,6 +55,8 @@ export class InpageNavigation {
     this.spyClass = spyClass;
     this.spyTrigger = spyTrigger;
     this.gumshoe = null;
+    this.observer = null;
+    this.stickyObserver = null;
 
     // Bind `this` for use in callbacks
     this.handleClickOnToggler = this.handleClickOnToggler.bind(this);
@@ -87,29 +91,78 @@ export class InpageNavigation {
       this.deactivateScrollSpy,
       false
     );
+
+    if ('IntersectionObserver' in window) {
+      const navigationContainer = queryOne(this.containerSelector);
+
+      if (navigationContainer) {
+        let previousY = 0;
+        let previousRatio = 0;
+        let initialized = false;
+
+        this.stickyObserver = new IntersectionObserver(
+          entries => {
+            if (entries && entries[0]) {
+              const entry = entries[0];
+              const currentY = entry.boundingClientRect.y;
+              const currentRatio = entry.intersectionRatio;
+              const { isIntersecting } = entry;
+
+              if (!initialized) {
+                initialized = true;
+                previousY = currentY;
+                previousRatio = currentRatio;
+                return;
+              }
+
+              if (currentY < previousY) {
+                if (!(currentRatio > previousRatio && isIntersecting)) {
+                  // Scrolling down leave
+                  this.element.classList.remove(this.spyActiveContainer);
+                }
+              } else if (currentY > previousY && isIntersecting) {
+                if (currentRatio > previousRatio) {
+                  // Scrolling up enter
+                  this.element.classList.add(this.spyActiveContainer);
+                }
+              }
+
+              previousY = currentY;
+              previousRatio = currentRatio;
+            }
+          },
+          { root: null }
+        );
+
+        // observing a target element
+        this.stickyObserver.observe(navigationContainer);
+      }
+    }
   }
 
   activateScrollSpy(event) {
-    const toggleClass = this.spyActiveContainer;
     const navigationTitle = queryOne(this.spyTrigger);
 
-    this.element.classList.add(toggleClass);
+    this.element.classList.add(this.spyActiveContainer);
     navigationTitle.textContent = event.detail.content.textContent;
   }
 
   deactivateScrollSpy() {
-    const toggleClass = this.spyActiveContainer;
     const navigationTitle = queryOne(this.spyTrigger);
     const currentList = queryOne(this.inPageList, this.element);
     const togglerElement = queryOne(this.toggleSelector, this.element);
 
-    this.element.classList.remove(toggleClass);
+    this.element.classList.remove(this.spyActiveContainer);
     navigationTitle.innerHTML = '';
     currentList.hidden = true;
     togglerElement.setAttribute('aria-expanded', 'false');
   }
 
   destroyScrollSpy() {
+    if (this.stickyObserver) {
+      this.stickyObserver.disconnect();
+    }
+
     document.removeEventListener(
       'gumshoeActivate',
       this.activateScrollSpy,
@@ -124,66 +177,64 @@ export class InpageNavigation {
   }
 
   initObserver() {
-    const self = this;
-    this.observer = new MutationObserver(function observe(mutationsList) {
-      const body = queryOne('.ecl-col-lg-9');
-      const currentInpage = queryOne('[data-ecl-inpage-navigation-list]');
+    if ('MutationObserver' in window) {
+      const self = this;
+      this.observer = new MutationObserver(function observe(mutationsList) {
+        const body = queryOne('.ecl-col-lg-9');
+        const currentInpage = queryOne('[data-ecl-inpage-navigation-list]');
 
-      mutationsList.forEach(mutation => {
-        // Exclude the changes we perform.
-        if (
-          mutation &&
-          mutation.target &&
-          mutation.target.classList &&
-          !mutation.target.classList.contains(
-            'ecl-inpage-navigation__trigger-current'
-          )
-        ) {
-          // Added nodes.
-          if (mutation.addedNodes.length > 0) {
-            [].slice.call(mutation.addedNodes).forEach(addedNode => {
-              if (addedNode.tagName === 'H2' && addedNode.id) {
-                const H2s = queryAll('h2[id]', body);
-                const addedNodeIndex = H2s.findIndex(
-                  H2 => H2.id === addedNode.id
-                );
-                const element = currentInpage.childNodes[
-                  addedNodeIndex - 1
-                ].cloneNode(true);
-                element.childNodes[0].textContent = addedNode.textContent;
-                element.childNodes[0].href = `#${addedNode.id}`;
-                currentInpage.childNodes[addedNodeIndex - 1].after(element);
-              }
-            });
-          }
-          // Removed nodes.
-          if (mutation.removedNodes.length > 0) {
-            [].slice.call(mutation.removedNodes).forEach(removedNode => {
-              if (removedNode.tagName === 'H2' && removedNode.id) {
-                currentInpage.childNodes.forEach(item => {
-                  if (item.childNodes[0].href.indexOf(removedNode.id) !== -1) {
-                    // Remove the element from the inpage.
-                    currentInpage.removeChild(item);
-                  }
-                });
-              }
-            });
-          }
+        mutationsList.forEach(mutation => {
+          // Exclude the changes we perform.
+          if (
+            mutation &&
+            mutation.target &&
+            mutation.target.classList &&
+            !mutation.target.classList.contains(
+              'ecl-inpage-navigation__trigger-current'
+            )
+          ) {
+            // Added nodes.
+            if (mutation.addedNodes.length > 0) {
+              [].slice.call(mutation.addedNodes).forEach(addedNode => {
+                if (addedNode.tagName === 'H2' && addedNode.id) {
+                  const H2s = queryAll('h2[id]', body);
+                  const addedNodeIndex = H2s.findIndex(
+                    H2 => H2.id === addedNode.id
+                  );
+                  const element = currentInpage.childNodes[
+                    addedNodeIndex - 1
+                  ].cloneNode(true);
+                  element.childNodes[0].textContent = addedNode.textContent;
+                  element.childNodes[0].href = `#${addedNode.id}`;
+                  currentInpage.childNodes[addedNodeIndex - 1].after(element);
+                }
+              });
+            }
+            // Removed nodes.
+            if (mutation.removedNodes.length > 0) {
+              [].slice.call(mutation.removedNodes).forEach(removedNode => {
+                if (removedNode.tagName === 'H2' && removedNode.id) {
+                  currentInpage.childNodes.forEach(item => {
+                    if (
+                      item.childNodes[0].href.indexOf(removedNode.id) !== -1
+                    ) {
+                      // Remove the element from the inpage.
+                      currentInpage.removeChild(item);
+                    }
+                  });
+                }
+              });
+            }
 
-          self.update();
-        }
+            self.update();
+          }
+        });
       });
-    });
 
-    this.observer.observe(document, {
-      subtree: true,
-      childList: true,
-    });
-  }
-
-  destroyObserver() {
-    if (this.observer) {
-      this.observer.disconnect();
+      this.observer.observe(document, {
+        subtree: true,
+        childList: true,
+      });
     }
   }
 

--- a/src/systems/eu/implementations/react/components/inpage-navigation/examples/Default.jsx
+++ b/src/systems/eu/implementations/react/components/inpage-navigation/examples/Default.jsx
@@ -45,7 +45,10 @@ export default class DefaultExample extends React.Component {
         <SiteHeader {...demoContentEn} />
         <PageHeader breadcrumb={breadcrumb} title="A demo page" />
         <div className="ecl-container">
-          <div className="ecl-row ecl-u-mt-l">
+          <div
+            className="ecl-row ecl-u-mt-l"
+            data-ecl-inpage-navigation-container
+          >
             <div className="ecl-col-lg-3">
               <InpageNavigation {...demoContent} />
             </div>

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-inpage-navigation/eu-component-inpage-navigation.js
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-inpage-navigation/eu-component-inpage-navigation.js
@@ -24,6 +24,7 @@ export class InpageNavigation {
     {
       attachClickListener = true,
       stickySelector = '[data-ecl-inpage-navigation]',
+      containerSelector = '[data-ecl-inpage-navigation-container]',
       inPageList = '[data-ecl-inpage-navigation-list]',
       spySelector = '[data-ecl-inpage-navigation-link]',
       toggleSelector = '[data-ecl-inpage-navigation-trigger]',
@@ -44,6 +45,7 @@ export class InpageNavigation {
     this.element = element;
     this.attachClickListener = attachClickListener;
     this.stickySelector = stickySelector;
+    this.containerSelector = containerSelector;
     this.toggleSelector = toggleSelector;
     this.linksSelector = linksSelector;
     this.inPageList = inPageList;
@@ -53,6 +55,8 @@ export class InpageNavigation {
     this.spyClass = spyClass;
     this.spyTrigger = spyTrigger;
     this.gumshoe = null;
+    this.observer = null;
+    this.stickyObserver = null;
 
     // Bind `this` for use in callbacks
     this.handleClickOnToggler = this.handleClickOnToggler.bind(this);
@@ -87,29 +91,78 @@ export class InpageNavigation {
       this.deactivateScrollSpy,
       false
     );
+
+    if ('IntersectionObserver' in window) {
+      const navigationContainer = queryOne(this.containerSelector);
+
+      if (navigationContainer) {
+        let previousY = 0;
+        let previousRatio = 0;
+        let initialized = false;
+
+        this.stickyObserver = new IntersectionObserver(
+          entries => {
+            if (entries && entries[0]) {
+              const entry = entries[0];
+              const currentY = entry.boundingClientRect.y;
+              const currentRatio = entry.intersectionRatio;
+              const { isIntersecting } = entry;
+
+              if (!initialized) {
+                initialized = true;
+                previousY = currentY;
+                previousRatio = currentRatio;
+                return;
+              }
+
+              if (currentY < previousY) {
+                if (!(currentRatio > previousRatio && isIntersecting)) {
+                  // Scrolling down leave
+                  this.element.classList.remove(this.spyActiveContainer);
+                }
+              } else if (currentY > previousY && isIntersecting) {
+                if (currentRatio > previousRatio) {
+                  // Scrolling up enter
+                  this.element.classList.add(this.spyActiveContainer);
+                }
+              }
+
+              previousY = currentY;
+              previousRatio = currentRatio;
+            }
+          },
+          { root: null }
+        );
+
+        // observing a target element
+        this.stickyObserver.observe(navigationContainer);
+      }
+    }
   }
 
   activateScrollSpy(event) {
-    const toggleClass = this.spyActiveContainer;
     const navigationTitle = queryOne(this.spyTrigger);
 
-    this.element.classList.add(toggleClass);
+    this.element.classList.add(this.spyActiveContainer);
     navigationTitle.textContent = event.detail.content.textContent;
   }
 
   deactivateScrollSpy() {
-    const toggleClass = this.spyActiveContainer;
     const navigationTitle = queryOne(this.spyTrigger);
     const currentList = queryOne(this.inPageList, this.element);
     const togglerElement = queryOne(this.toggleSelector, this.element);
 
-    this.element.classList.remove(toggleClass);
+    this.element.classList.remove(this.spyActiveContainer);
     navigationTitle.innerHTML = '';
     currentList.hidden = true;
     togglerElement.setAttribute('aria-expanded', 'false');
   }
 
   destroyScrollSpy() {
+    if (this.stickyObserver) {
+      this.stickyObserver.disconnect();
+    }
+
     document.removeEventListener(
       'gumshoeActivate',
       this.activateScrollSpy,
@@ -124,66 +177,64 @@ export class InpageNavigation {
   }
 
   initObserver() {
-    const self = this;
-    this.observer = new MutationObserver(function observe(mutationsList) {
-      const body = queryOne('.ecl-col-lg-9');
-      const currentInpage = queryOne('[data-ecl-inpage-navigation-list]');
+    if ('MutationObserver' in window) {
+      const self = this;
+      this.observer = new MutationObserver(function observe(mutationsList) {
+        const body = queryOne('.ecl-col-lg-9');
+        const currentInpage = queryOne('[data-ecl-inpage-navigation-list]');
 
-      mutationsList.forEach(mutation => {
-        // Exclude the changes we perform.
-        if (
-          mutation &&
-          mutation.target &&
-          mutation.target.classList &&
-          !mutation.target.classList.contains(
-            'ecl-inpage-navigation__trigger-current'
-          )
-        ) {
-          // Added nodes.
-          if (mutation.addedNodes.length > 0) {
-            [].slice.call(mutation.addedNodes).forEach(addedNode => {
-              if (addedNode.tagName === 'H2' && addedNode.id) {
-                const H2s = queryAll('h2[id]', body);
-                const addedNodeIndex = H2s.findIndex(
-                  H2 => H2.id === addedNode.id
-                );
-                const element = currentInpage.childNodes[
-                  addedNodeIndex - 1
-                ].cloneNode(true);
-                element.childNodes[0].textContent = addedNode.textContent;
-                element.childNodes[0].href = `#${addedNode.id}`;
-                currentInpage.childNodes[addedNodeIndex - 1].after(element);
-              }
-            });
-          }
-          // Removed nodes.
-          if (mutation.removedNodes.length > 0) {
-            [].slice.call(mutation.removedNodes).forEach(removedNode => {
-              if (removedNode.tagName === 'H2' && removedNode.id) {
-                currentInpage.childNodes.forEach(item => {
-                  if (item.childNodes[0].href.indexOf(removedNode.id) !== -1) {
-                    // Remove the element from the inpage.
-                    currentInpage.removeChild(item);
-                  }
-                });
-              }
-            });
-          }
+        mutationsList.forEach(mutation => {
+          // Exclude the changes we perform.
+          if (
+            mutation &&
+            mutation.target &&
+            mutation.target.classList &&
+            !mutation.target.classList.contains(
+              'ecl-inpage-navigation__trigger-current'
+            )
+          ) {
+            // Added nodes.
+            if (mutation.addedNodes.length > 0) {
+              [].slice.call(mutation.addedNodes).forEach(addedNode => {
+                if (addedNode.tagName === 'H2' && addedNode.id) {
+                  const H2s = queryAll('h2[id]', body);
+                  const addedNodeIndex = H2s.findIndex(
+                    H2 => H2.id === addedNode.id
+                  );
+                  const element = currentInpage.childNodes[
+                    addedNodeIndex - 1
+                  ].cloneNode(true);
+                  element.childNodes[0].textContent = addedNode.textContent;
+                  element.childNodes[0].href = `#${addedNode.id}`;
+                  currentInpage.childNodes[addedNodeIndex - 1].after(element);
+                }
+              });
+            }
+            // Removed nodes.
+            if (mutation.removedNodes.length > 0) {
+              [].slice.call(mutation.removedNodes).forEach(removedNode => {
+                if (removedNode.tagName === 'H2' && removedNode.id) {
+                  currentInpage.childNodes.forEach(item => {
+                    if (
+                      item.childNodes[0].href.indexOf(removedNode.id) !== -1
+                    ) {
+                      // Remove the element from the inpage.
+                      currentInpage.removeChild(item);
+                    }
+                  });
+                }
+              });
+            }
 
-          self.update();
-        }
+            self.update();
+          }
+        });
       });
-    });
 
-    this.observer.observe(document, {
-      subtree: true,
-      childList: true,
-    });
-  }
-
-  destroyObserver() {
-    if (this.observer) {
-      this.observer.disconnect();
+      this.observer.observe(document, {
+        subtree: true,
+        childList: true,
+      });
     }
   }
 

--- a/src/website/src/pages/ec/components/navigation/inpage-navigation/docs/code.mdx
+++ b/src/website/src/pages/ec/components/navigation/inpage-navigation/docs/code.mdx
@@ -16,6 +16,17 @@ import InpageNavigationExample from '@ecl/ec-react-component-inpage-navigation/e
 
 ## JS behaviour
 
+## Data attributes
+
+In order to make the component work correctly, these are the data attributes that we use:
+
+- `data-ecl-inpage-navigation-container`: on the content container, e.g. the row that contains both the inpage navigation and the content
+- `data-ecl-inpage-navigation`: on the `<nav>` itself
+- `data-ecl-inpage-navigation-trigger`: on the dropdown button that appears on mobile
+- `data-ecl-inpage-navigation-trigger-current`: on the `<span>` within the button ; we use it to inject the title of the currently active section
+- `data-ecl-inpage-navigation-list`: to be applied on the list of links
+- `data-ecl-inpage-navigation-link`: to be applied on each link in the inpage navigation
+
 ### Auto initialisation
 
 In order to automatically initalise the JS behaviour, add `data-ecl-auto-init="InpageNavigation"` to your component's markup:


### PR DESCRIPTION
Solution based on IntersectionObserver.

To make use of it, simply add `data-ecl-inpage-navigation-container` to the "real" container of the nav (e.g. the ".ecl-row" parent, and not simply its direct parent), and that's it