### PR TITLE
fix(site-header): add separator - INNO-1965

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-component-site-header-harmonised/ec-component-site-header-harmonised.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-site-header-harmonised/ec-component-site-header-harmonised.scss
@@ -329,6 +329,13 @@
       width: 31.5rem;
     }
   }
+
+  /*
+   * Group 2
+   */
+  .ecl-site-header-harmonised--group2 {
+    box-shadow: 0 2px 5px 0 rgba(0, 47, 103, 0.2);
+  }
 }
 
 // Use mixin


### PR DESCRIPTION
# PR description

Add separator for site header harmonised group 2, as reported here: https://webgate.ec.europa.eu/CITnet/confluence/display/NEXTEUROPA/Harmonised+Site+header+-+Design+Specifications