### PR TITLE
fix(site-headers): fix logo size on IE11

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-component-site-header-core/ec-component-site-header-core.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-site-header-core/ec-component-site-header-core.scss
@@ -11,9 +11,13 @@
 
 @mixin ecl-site-header-core(
   $logo-height-xs: 1.75rem,
-  $logo-height-s: 3rem,
-  $logo-height-m: 3.75rem,
-  $logo-height-l: 4.5rem,
+  $logo-width-xs: 10.1rem,
+  $logo-height-sm: 3rem,
+  $logo-width-sm: 12.1rem,
+  $logo-height-lg: 3.75rem,
+  $logo-width-lg: 15.1rem,
+  $logo-height-xl: 4.5rem,
+  $logo-width-xl: 18.1rem,
   $search-width-l: 25rem,
   $search-width-xl: 31.5rem
 ) {
@@ -43,7 +47,7 @@
   .ecl-site-header-core__logo-image {
     display: block;
     max-height: $logo-height-xs;
-    max-width: 10.1rem; // hack to allow logo to be resized dynamically
+    max-width: $logo-width-xs; // hack to allow logo to be resized dynamically
   }
 
   .ecl-site-header-core__action {
@@ -146,9 +150,10 @@
     }
 
     .ecl-site-header-core__logo-image {
-      height: $logo-height-s;
+      height: $logo-height-sm;
       max-height: 100%;
       max-width: 100%;
+      width: $logo-width-sm;
     }
   }
 
@@ -173,7 +178,8 @@
     }
 
     .ecl-site-header-core__logo-image {
-      height: $logo-height-m;
+      height: $logo-height-lg;
+      width: $logo-width-lg;
     }
 
     .ecl-site-header-core__login-box {
@@ -237,7 +243,8 @@
 
   @include ecl-media-breakpoint-up(xl) {
     .ecl-site-header-core__logo-image {
-      height: $logo-height-l;
+      height: $logo-height-xl;
+      width: $logo-width-xl;
     }
 
     .ecl-site-header-core__search {

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-site-header-harmonised/ec-component-site-header-harmonised.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-site-header-harmonised/ec-component-site-header-harmonised.scss
@@ -11,9 +11,13 @@
 
 @mixin ecl-site-header-harmonised(
   $logo-height-xs: 1.75rem,
+  $logo-width-xs: 7rem,
   $logo-height-xs-g2: 2.5rem,
-  $logo-height-s: 3rem,
-  $logo-height-m: 3.75rem
+  $logo-width-xs-g2: 10.1rem,
+  $logo-height-sm: 3rem,
+  $logo-width-sm: 12.1rem,
+  $logo-height-lg: 3.75rem,
+  $logo-width-lg: 15.1rem
 ) {
   .ecl-site-header-harmonised {
     background-color: $ecl-color-white-100;
@@ -41,7 +45,7 @@
   .ecl-site-header-harmonised__logo-image {
     display: block;
     max-height: $logo-height-xs;
-    max-width: 7rem; // hack to allow logo to be resized dynamically
+    max-width: $logo-width-xs; // hack to allow logo to be resized dynamically
   }
 
   .ecl-site-header-harmonised__action {
@@ -183,9 +187,10 @@
     }
 
     .ecl-site-header-harmonised__logo-image {
-      height: $logo-height-s;
+      height: $logo-height-sm;
       max-height: 100%;
       max-width: 100%;
+      width: $logo-width-sm;
     }
   }
 
@@ -206,7 +211,8 @@
     }
 
     .ecl-site-header-harmonised__logo-image {
-      height: $logo-height-m;
+      height: $logo-height-lg;
+      width: $logo-width-lg;
     }
 
     .ecl-site-header-harmonised__login-box {
@@ -340,7 +346,27 @@
 
     .ecl-site-header-harmonised__logo-image {
       max-height: $logo-height-xs-g2;
-      max-width: 10.1rem; // hack to allow logo to be resized dynamically
+      max-width: $logo-width-xs-g2; // hack to allow logo to be resized dynamically
+    }
+  }
+
+  /* stylelint-disable-next-line order/order */
+  @include ecl-media-breakpoint-up(sm) {
+    .ecl-site-header-harmonised--group2
+      .ecl-site-header-harmonised__logo-image {
+      height: $logo-height-sm;
+      max-height: 100%;
+      max-width: 100%;
+      width: $logo-width-sm;
+    }
+  }
+
+  /* stylelint-disable-next-line order/order */
+  @include ecl-media-breakpoint-up(lg) {
+    .ecl-site-header-harmonised--group2
+      .ecl-site-header-harmonised__logo-image {
+      height: $logo-height-lg;
+      width: $logo-width-lg;
     }
   }
 }

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-site-header-standardised/ec-component-site-header-standardised.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-site-header-standardised/ec-component-site-header-standardised.scss
@@ -11,8 +11,11 @@
 
 @mixin ecl-site-header-standardised(
   $logo-height-xs: 1.75rem,
-  $logo-height-s: 3rem,
-  $logo-height-m: 3.75rem,
+  $logo-width-xs: 10.1rem,
+  $logo-height-sm: 3rem,
+  $logo-width-sm: 12.1rem,
+  $logo-height-lg: 3.75rem,
+  $logo-width-lg: 15.1rem,
   $search-width-l: 25rem,
   $search-width-xl: 31.5rem
 ) {
@@ -42,7 +45,7 @@
   .ecl-site-header-standardised__logo-image {
     display: block;
     max-height: $logo-height-xs;
-    max-width: 10.1rem; // hack to allow logo to be resized dynamically
+    max-width: $logo-width-xs; // hack to allow logo to be resized dynamically
   }
 
   .ecl-site-header-standardised__action {
@@ -183,9 +186,10 @@
     }
 
     .ecl-site-header-standardised__logo-image {
-      height: $logo-height-s;
+      height: $logo-height-sm;
       max-height: 100%;
       max-width: 100%;
+      width: $logo-width-sm;
     }
   }
 
@@ -206,7 +210,8 @@
     }
 
     .ecl-site-header-standardised__logo-image {
-      height: $logo-height-m;
+      height: $logo-height-lg;
+      width: $logo-width-lg;
     }
 
     .ecl-site-header-standardised__login-box {


### PR DESCRIPTION
# PR description

Fix display of logo on site headers (core, harmonised and standardised). The image was partially hidden.
