### PR TITLE
fix(ie11): fix js error - INNO-1988

### DIFF
--- a/src/systems/ec/implementations/react/components/fact-figures/src/FactFigures.jsx
+++ b/src/systems/ec/implementations/react/components/fact-figures/src/FactFigures.jsx
@@ -24,7 +24,7 @@ export const FactFigures = ({
           items.map(item => <FactFiguresItem key={item.title} {...item} />)}
       </div>
 
-      {!!(viewAll && Object.values(viewAll).length >= 1) && (
+      {!!(viewAll && Object.keys(viewAll).length >= 1) && (
         <div className="ecl-fact-figures__view-all">
           <Link
             className={classnames(

--- a/src/systems/ec/implementations/react/components/fact-figures/src/FactFiguresItem.jsx
+++ b/src/systems/ec/implementations/react/components/fact-figures/src/FactFiguresItem.jsx
@@ -13,7 +13,7 @@ export const FactFiguresItem = ({
   ...props
 }) => (
   <div {...props} className={classnames(className, 'ecl-fact-figures__item')}>
-    {!!(icon && Object.values(icon).length >= 1) && (
+    {!!(icon && Object.keys(icon).length >= 1) && (
       <Icon className="ecl-fact-figures__icon" {...icon} />
     )}
     {value && <div className="ecl-fact-figures__value">{value}</div>}

--- a/src/systems/ec/implementations/react/components/site-header-core/src/SiteHeaderCore.jsx
+++ b/src/systems/ec/implementations/react/components/site-header-core/src/SiteHeaderCore.jsx
@@ -58,7 +58,7 @@ const SiteHeaderCore = ({
           <div className="ecl-site-header-core__action">
             {!!(
               loginToggle &&
-              Object.values(loginToggle).length >= 1 &&
+              Object.keys(loginToggle).length >= 1 &&
               loginBox
             ) && (
               <div className="ecl-site-header-core__login-container">
@@ -108,7 +108,7 @@ const SiteHeaderCore = ({
               </div>
             )}
             {!!(
-              languageSelector && Object.values(languageSelector).length >= 1
+              languageSelector && Object.keys(languageSelector).length >= 1
             ) && (
               <a
                 className="ecl-link ecl-link--standalone ecl-site-header-core__language-selector"
@@ -130,7 +130,7 @@ const SiteHeaderCore = ({
             )}
             {!!(
               searchToggle &&
-              Object.values(searchToggle).length >= 1 &&
+              Object.keys(searchToggle).length >= 1 &&
               searchForm
             ) && (
               <div className="ecl-site-header-core__search-container">

--- a/src/systems/ec/implementations/react/components/site-header-harmonised/src/SiteHeaderHarmonised.jsx
+++ b/src/systems/ec/implementations/react/components/site-header-harmonised/src/SiteHeaderHarmonised.jsx
@@ -61,7 +61,7 @@ const SiteHeaderHarmonised = ({
           <div className="ecl-site-header-harmonised__action">
             {!!(
               loginToggle &&
-              Object.values(loginToggle).length >= 1 &&
+              Object.keys(loginToggle).length >= 1 &&
               loginBox
             ) && (
               <div className="ecl-site-header-harmonised__login-container">
@@ -111,7 +111,7 @@ const SiteHeaderHarmonised = ({
               </div>
             )}
             {!!(
-              languageSelector && Object.values(languageSelector).length >= 1
+              languageSelector && Object.keys(languageSelector).length >= 1
             ) && (
               <a
                 className="ecl-link ecl-link--standalone ecl-site-header-harmonised__language-selector"
@@ -133,7 +133,7 @@ const SiteHeaderHarmonised = ({
             )}
             {!!(
               searchToggle &&
-              Object.values(searchToggle).length >= 1 &&
+              Object.keys(searchToggle).length >= 1 &&
               searchForm
             ) && (
               <div className="ecl-site-header-harmonised__search-container">

--- a/src/systems/ec/implementations/react/components/site-header-standardised/src/SiteHeaderStandardised.jsx
+++ b/src/systems/ec/implementations/react/components/site-header-standardised/src/SiteHeaderStandardised.jsx
@@ -61,7 +61,7 @@ const SiteHeaderStandardised = ({
           <div className="ecl-site-header-standardised__action">
             {!!(
               loginToggle &&
-              Object.values(loginToggle).length >= 1 &&
+              Object.keys(loginToggle).length >= 1 &&
               loginBox
             ) && (
               <div className="ecl-site-header-standardised__login-container">
@@ -111,7 +111,7 @@ const SiteHeaderStandardised = ({
               </div>
             )}
             {!!(
-              languageSelector && Object.values(languageSelector).length >= 1
+              languageSelector && Object.keys(languageSelector).length >= 1
             ) && (
               <a
                 className="ecl-link ecl-link--standalone ecl-site-header-standardised__language-selector"
@@ -133,7 +133,7 @@ const SiteHeaderStandardised = ({
             )}
             {!!(
               searchToggle &&
-              Object.values(searchToggle).length >= 1 &&
+              Object.keys(searchToggle).length >= 1 &&
               searchForm
             ) && (
               <div className="ecl-site-header-standardised__search-container">


### PR DESCRIPTION
# PR description

Fix javascript error on some component, on IE11 (it was only visible on the website).  
Error message: Object doesn't support property or method 'values'  
Components: 
- fact and figures
- site header core
- site header harmonised
- site header standardised
