### PR TITLE
fix(menu): Remove top margin for site-header-harmonised group 2 - INNO-2021

### DIFF
--- a/src/systems/ec/implementations/react/components/menu/src/Menu.jsx
+++ b/src/systems/ec/implementations/react/components/menu/src/Menu.jsx
@@ -34,7 +34,7 @@ export const Menu = ({
             {toggleLabelClose}
           </div>
         </a>
-        <div className="ecl-menu__site-name">{siteName}</div>
+        {siteName && <div className="ecl-menu__site-name">{siteName}</div>}
         <ul className="ecl-menu__list" data-ecl-menu-list>
           {items.map(item => (
             <MenuItem {...item} key={item.label} />

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-menu/ec-component-menu.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-menu/ec-component-menu.scss
@@ -31,6 +31,7 @@
 
     .ecl-menu__site-name {
       font: $ecl-font-3-xl;
+      margin-bottom: $ecl-spacing-l;
     }
   }
 
@@ -95,7 +96,7 @@
     flex-grow: 1;
     list-style: none;
     margin-bottom: 0;
-    margin-top: $ecl-spacing-m;
+    margin-top: 0;
     padding-left: 0;
     padding-top: 1px; // Used to display separator
     position: relative;
@@ -180,7 +181,6 @@
     .ecl-menu__list {
       display: flex;
       flex-direction: row;
-      margin-top: $ecl-spacing-l;
 
       &::before {
         display: none;


### PR DESCRIPTION
# PR description

The margin between top header and navigation is way too big for desktop in site-header-harmonised group2. To fix this, I removed top margin on navigation container and added bottom margin to siteName container instead. I also added a condition to avoid empty siteName container when there is no Label passed to menu component.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] `package.json` is up-to-date and `@ecl/[system]-base` is part of the dependencies
- [ ] I have checked the dependencies
- [ ] I have given the fractal status “ready” to my component
- [ ] I have declared `@define mycomponent` in the SCSS file
- [ ] I have specified `margin: 0;` on the CSS component
- [ ] I have provided tests
- [ ] I follow the naming guidelines
- [ ] the component supports composition
- [ ] there are no hardcoded strings (all content come from the context)
- [ ] I have filled the README.md file (at least a few lines)
- [ ] My component is listed in the root README
- [ ] My PR has the right label(s)
- [ ] The redirects in `src/website/src/routes/Redirects.jsx` are up-to-date
