### PR TITLE
fix(list): add max-width - FRONT-471

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-component-description-list/ec-component-description-list.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-description-list/ec-component-description-list.scss
@@ -16,6 +16,7 @@
     font: $ecl-font-prolonged-xl;
     font-weight: $ecl-font-weight-bold;
     margin-top: $ecl-spacing-l;
+    max-width: calc(80ch - #{$ecl-spacing-2-xl});
 
     &:first-child {
       margin-top: 0;
@@ -31,6 +32,7 @@
     font: $ecl-font-prolonged-m;
     margin-left: 0;
     margin-top: $ecl-spacing-m;
+    max-width: calc(80ch - #{$ecl-spacing-2-xl});
     padding-left: $ecl-spacing-s;
   }
 

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-ordered-list/ec-component-ordered-list.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-ordered-list/ec-component-ordered-list.scss
@@ -24,6 +24,7 @@
 
   .ecl-ordered-list__item {
     margin-top: $ecl-spacing-xs;
+    max-width: calc(80ch - #{$ecl-spacing-2-xl});
 
     &:first-child {
       margin-top: 0;

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-unordered-list/ec-component-unordered-list.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-unordered-list/ec-component-unordered-list.scss
@@ -24,6 +24,7 @@
 
   .ecl-unordered-list__item {
     margin-top: $ecl-spacing-xs;
+    max-width: calc(80ch - #{$ecl-spacing-2-xl});
 
     &:first-child {
       margin-top: 0;

--- a/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--list.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--list.scss
@@ -23,7 +23,7 @@
 
     li {
       margin-top: $ecl-spacing-xs;
-      max-width: 80ch;
+      max-width: calc(80ch - #{$ecl-spacing-2-xl});
 
       &:first-child {
         margin-top: 0;
@@ -49,7 +49,7 @@
 
     li {
       margin-top: $ecl-spacing-xs;
-      max-width: 80ch;
+      max-width: calc(80ch - #{$ecl-spacing-2-xl});
 
       &:first-child {
         margin-top: 0;
@@ -68,7 +68,7 @@
     font: $ecl-font-prolonged-xl;
     font-weight: $ecl-font-weight-bold;
     margin-top: $ecl-spacing-l;
-    max-width: 80ch;
+    max-width: calc(80ch - #{$ecl-spacing-2-xl});
 
     + dt {
       margin-top: $ecl-spacing-2-xs;
@@ -84,7 +84,7 @@
     font: $ecl-font-prolonged-m;
     margin-left: 0;
     margin-top: $ecl-spacing-m;
-    max-width: 80ch;
+    max-width: calc(80ch - #{$ecl-spacing-2-xl});
     padding-left: $ecl-spacing-s;
 
     + dd {


### PR DESCRIPTION
# PR description

Add max-width to list items, so that they are aligned with paragraphs

See example from research-area-spoke content type:
![image](https://user-images.githubusercontent.com/25579221/73852449-76ae0400-482f-11ea-9642-c281dd72ecfc.png)

