### PR TITLE
refactor(storybook): migrate to slash separator - FRONT-495

### DIFF
--- a/src/systems/ec/implementations/react/components/accordion2/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/accordion2/stories/Index.jsx
@@ -8,7 +8,7 @@ import { Accordion2 } from '../src/Accordion2';
 import { Accordion2Item } from '../src/Accordion2Item';
 
 export default {
-  title: 'Components|Accordion',
+  title: 'Components/Accordion',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/blockquote/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/blockquote/stories/Index.jsx
@@ -6,7 +6,7 @@ import demoContent from '@ecl/ec-specs-blockquote/demo/data';
 import Blockquote from '../src/Blockquote';
 
 export default {
-  title: 'Components|Blockquote',
+  title: 'Components/Blockquote',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/breadcrumb-core/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-core/stories/Index.jsx
@@ -9,7 +9,7 @@ import { BreadcrumbCore } from '../src/BreadcrumbCore';
 import { BreadcrumbCoreItem } from '../src/BreadcrumbCoreItem';
 
 export default {
-  title: 'Components|Navigation/Breadcrumb core',
+  title: 'Components/Navigation/Breadcrumb core',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/breadcrumb-harmonised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-harmonised/stories/Index.jsx
@@ -9,7 +9,7 @@ import { BreadcrumbHarmonised } from '../src/BreadcrumbHarmonised';
 import { BreadcrumbHarmonisedItem } from '../src/BreadcrumbHarmonisedItem';
 
 export default {
-  title: 'Components|Navigation/Breadcrumb harmonised',
+  title: 'Components/Navigation/Breadcrumb harmonised',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/breadcrumb-standardised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb-standardised/stories/Index.jsx
@@ -9,7 +9,7 @@ import { BreadcrumbStandardised } from '../src/BreadcrumbStandardised';
 import { BreadcrumbStandardisedItem } from '../src/BreadcrumbStandardisedItem';
 
 export default {
-  title: 'Components|Navigation/Breadcrumb standardised',
+  title: 'Components/Navigation/Breadcrumb standardised',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/breadcrumb/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/breadcrumb/stories/Index.jsx
@@ -9,7 +9,7 @@ import { Breadcrumb } from '../src/Breadcrumb';
 import { BreadcrumbItem } from '../src/BreadcrumbItem';
 
 export default {
-  title: 'Components|Navigation/Breadcrumb',
+  title: 'Components/Navigation/Breadcrumb',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/button/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/button/stories/Index.jsx
@@ -22,7 +22,7 @@ const iconPosition = {
 };
 
 export default {
-  title: 'Components|Button',
+  title: 'Components/Button',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/card/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/card/stories/Index.jsx
@@ -10,7 +10,7 @@ import { Template as template } from './Template';
 import Card from '../src/Card';
 
 export default {
-  title: 'Components|Card',
+  title: 'Components/Card',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/checkbox/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/checkbox/stories/Index.jsx
@@ -6,7 +6,7 @@ import demoContentDefault from '@ecl/ec-specs-checkbox/demo/data--default';
 import CheckboxGroup from '../src/CheckboxGroup';
 
 export default {
-  title: 'Components|Forms/Checkbox',
+  title: 'Components/Forms/Checkbox',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/contextual-navigation/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/contextual-navigation/stories/Index.jsx
@@ -11,7 +11,7 @@ import VanillaContextualNavigation from '@ecl/ec-component-contextual-navigation
 
 import ContextualNavigation from '../src/ContextualNavigation';
 
-storiesOf('Components|Navigation/Contextual Navigation', module)
+storiesOf('Components/Navigation/Contextual Navigation', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/ec/implementations/react/components/date-block/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/date-block/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-date-block/demo/data';
 import DateBlock from '../src/DateBlock';
 
 export default {
-  title: 'Components|Date Block',
+  title: 'Components/Date Block',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/datepicker/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/datepicker/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContent from '@ecl/ec-specs-datepicker/demo/data';
 import Datepicker from '../src/Datepicker';
 
 export default {
-  title: 'Components|Forms/Datepicker',
+  title: 'Components/Forms/Datepicker',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/description-list/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/description-list/stories/Index.jsx
@@ -4,7 +4,7 @@ import Description from '../examples/Description';
 import DescriptionHorizontal from '../examples/DescriptionHorizontal';
 
 export default {
-  title: 'Components|List',
+  title: 'Components/List',
 };
 
 export const _Description = Description;

--- a/src/systems/ec/implementations/react/components/dropdown-legacy/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/dropdown-legacy/stories/Index.jsx
@@ -6,7 +6,7 @@ import StoryWrapper from '@ecl/story-wrapper';
 import DropdownExample from '../examples/Default';
 
 export default {
-  title: 'Components|Dropdown Legacy',
+  title: 'Components/Dropdown Legacy',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/expandable/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/expandable/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-expandable/demo/data';
 import { Expandable } from '../src/Expandable';
 
 export default {
-  title: 'Components|Expandables',
+  title: 'Components/Expandables',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/fact-figures/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/fact-figures/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContent4Col from '@ecl/ec-specs-fact-figures/demo/data--4-col';
 import { FactFigures } from '../src/FactFigures';
 
 export default {
-  title: 'Components|Fact figures',
+  title: 'Components/Fact figures',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/file-upload/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/file-upload/stories/Index.jsx
@@ -10,7 +10,7 @@ import demoContentMultiple from '@ecl/ec-specs-file-upload/demo/data--multiple';
 import FileUpload from '../src/FileUpload';
 
 export default {
-  title: 'Components|Forms/File upload',
+  title: 'Components/Forms/File upload',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/file/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/file/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContentTranslation from '@ecl/ec-specs-file/demo/data--with-translati
 import { FileDownload } from '../src/FileDownload';
 
 export default {
-  title: 'Components|File',
+  title: 'Components/File',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/footer-core/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/footer-core/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-footer-core/demo/data';
 import { FooterCore } from '../src/FooterCore';
 
 export default {
-  title: 'Components|Footers/Core',
+  title: 'Components/Footers/Core',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/footer-harmonised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/footer-harmonised/stories/Index.jsx
@@ -11,7 +11,7 @@ import { FooterHarmonisedG2 } from '../src/FooterHarmonisedG2';
 import { FooterHarmonisedG3 } from '../src/FooterHarmonisedG3';
 
 export default {
-  title: 'Components|Footers/Harmonised',
+  title: 'Components/Footers/Harmonised',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/footer-standardised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/footer-standardised/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-footer-standardised/demo/data';
 import { FooterStandardised } from '../src/FooterStandardised';
 
 export default {
-  title: 'Components|Footers/Standardised',
+  title: 'Components/Footers/Standardised',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-gallery/demo/data';
 import { Gallery } from '../src/Gallery';
 
 export default {
-  title: 'Components|Gallery',
+  title: 'Components/Gallery',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/hero-banner/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/hero-banner/stories/Index.jsx
@@ -11,7 +11,7 @@ import demoContentAlignLeft from '@ecl/ec-specs-hero-banner/demo/data--align-lef
 import HeroBanner from '../src/HeroBanner';
 
 export default {
-  title: 'Components|Banners/Hero Banner',
+  title: 'Components/Banners/Hero Banner',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/icon/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/icon/stories/Index.jsx
@@ -40,7 +40,7 @@ const transforms = {
 const defaultTransform = '';
 
 export default {
-  title: 'Components|Icon',
+  title: 'Components/Icon',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/inpage-navigation/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/inpage-navigation/stories/Index.jsx
@@ -14,7 +14,7 @@ const btnIdRemoveHandler = () => {
 };
 
 export default {
-  title: 'Components|Navigation/In page navigation',
+  title: 'Components/Navigation/In page navigation',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/link/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/link/stories/Index.jsx
@@ -25,7 +25,7 @@ const iconPosition = {
 };
 
 export default {
-  title: 'Components|Navigation/Link',
+  title: 'Components/Navigation/Link',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/media-container/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/media-container/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContentVideo from '@ecl/ec-specs-media-container/demo/data--video';
 import MediaContainer from '../src/MediaContainer';
 
 export default {
-  title: 'Components|MediaContainer',
+  title: 'Components/MediaContainer',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/menu/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/menu/stories/Index.jsx
@@ -6,7 +6,7 @@ import demoContent from '@ecl/ec-specs-menu/demo/data--en';
 import { Menu } from '../src/Menu';
 
 export default {
-  title: 'Components|Navigation/Menu',
+  title: 'Components/Navigation/Menu',
 
   decorators: [
     story => (

--- a/src/systems/ec/implementations/react/components/message/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/message/stories/Index.jsx
@@ -10,7 +10,7 @@ import demoContentError from '@ecl/ec-specs-message/demo/data--error';
 import { Message } from '../src/Message';
 
 export default {
-  title: 'Components|Messages',
+  title: 'Components/Messages',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/ordered-list/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/ordered-list/stories/Index.jsx
@@ -3,7 +3,7 @@
 import Ordered from '../examples/Ordered';
 
 export default {
-  title: 'Components|List',
+  title: 'Components/List',
 };
 
 export const _Ordered = Ordered;

--- a/src/systems/ec/implementations/react/components/page-banner/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/page-banner/stories/Index.jsx
@@ -11,7 +11,7 @@ import demoContentAlignLeft from '@ecl/ec-specs-page-banner/demo/data--align-lef
 import PageBanner from '../src/PageBanner';
 
 export default {
-  title: 'Components|Banners/Page Banner',
+  title: 'Components/Banners/Page Banner',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/page-header-core/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/page-header-core/stories/Index.jsx
@@ -24,7 +24,7 @@ const breadcrumb = (
 );
 
 export default {
-  title: 'Components|Page Headers/Core',
+  title: 'Components/Page Headers/Core',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/page-header-harmonised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/page-header-harmonised/stories/Index.jsx
@@ -27,7 +27,7 @@ const breadcrumb = (
 );
 
 export default {
-  title: 'Components|Page Headers/Harmonised',
+  title: 'Components/Page Headers/Harmonised',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/page-header-standardised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/page-header-standardised/stories/Index.jsx
@@ -27,7 +27,7 @@ const breadcrumb = (
 );
 
 export default {
-  title: 'Components|Page Headers/Standardised',
+  title: 'Components/Page Headers/Standardised',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/pagination/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/pagination/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-pagination/demo/data';
 import Pagination from '../src/Pagination';
 
 export default {
-  title: 'Components|Navigation/Pagination',
+  title: 'Components/Navigation/Pagination',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/radio/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/radio/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContentBinary from '@ecl/ec-specs-radio/demo/data--binary';
 import RadioGroup from '../src/RadioGroup';
 
 export default {
-  title: 'Components|Forms/Radio',
+  title: 'Components/Forms/Radio',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/search-form/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/search-form/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-search-form/demo/data';
 import SearchForm from '../src/SearchForm';
 
 export default {
-  title: 'Components|Forms/SearchForm',
+  title: 'Components/Forms/SearchForm',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/select/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/select/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-select/demo/data';
 import Select from '../src/Select';
 
 export default {
-  title: 'Components|Forms/Select',
+  title: 'Components/Forms/Select',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/site-header-core/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/site-header-core/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContentFr from '@ecl/ec-specs-site-header-core/demo/data--fr';
 import SiteHeaderCore from '../src/SiteHeaderCore';
 
 export default {
-  title: 'Components|Site Headers/Core',
+  title: 'Components/Site Headers/Core',
 
   decorators: [
     story => (

--- a/src/systems/ec/implementations/react/components/site-header-harmonised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/site-header-harmonised/stories/Index.jsx
@@ -15,7 +15,7 @@ demoMenuGroup2['data-ecl-auto-init'] = 'Menu';
 demoMenuGroup2.className = 'ecl-menu--group2';
 
 export default {
-  title: 'Components|Site Headers/Harmonised',
+  title: 'Components/Site Headers/Harmonised',
 
   decorators: [
     story => (

--- a/src/systems/ec/implementations/react/components/site-header-standardised/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/site-header-standardised/stories/Index.jsx
@@ -12,7 +12,7 @@ demoMenuEn['data-ecl-auto-init'] = 'Menu';
 demoMenuFr['data-ecl-auto-init'] = 'Menu';
 
 export default {
-  title: 'Components|Site Headers/Standardised',
+  title: 'Components/Site Headers/Standardised',
 
   decorators: [
     story => (

--- a/src/systems/ec/implementations/react/components/skip-link/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/skip-link/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoData from '@ecl/ec-specs-skip-link/demo/data';
 import { SkipLink } from '../src/SkipLink';
 
 export default {
-  title: 'Components|Navigation/Skip link',
+  title: 'Components/Navigation/Skip link',
   decorators: [withKnobs, withCssResources],
 
   parameters: {

--- a/src/systems/ec/implementations/react/components/social-media-follow/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/social-media-follow/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-social-media-follow/demo/data';
 import SocialMediaFollow from '../src/SocialMediaFollow';
 
 export default {
-  title: 'Components|SocialMediaFollow',
+  title: 'Components/SocialMediaFollow',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/social-media-share/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/social-media-share/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/ec-specs-social-media-share/demo/data';
 import SocialMediaShare from '../src/SocialMediaShare';
 
 export default {
-  title: 'Components|SocialMediaShare',
+  title: 'Components/SocialMediaShare',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/table/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/table/stories/Index.jsx
@@ -3,7 +3,7 @@ import TableZebra from '../examples/TableZebra';
 import TableMulti from '../examples/TableMulti';
 
 export default {
-  title: 'Components|Table',
+  title: 'Components/Table',
 };
 
 export const Default = Table;

--- a/src/systems/ec/implementations/react/components/tag/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/tag/stories/Index.jsx
@@ -9,7 +9,7 @@ import demoDataRemovable from '@ecl/ec-specs-tag/demo/data--removable';
 import Tag from '../src/Tag';
 
 export default {
-  title: 'Components|Tag',
+  title: 'Components/Tag',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/text-area/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/text-area/stories/Index.jsx
@@ -13,7 +13,7 @@ import demoContentDefault from '@ecl/ec-specs-text-area/demo/data--default';
 import TextArea from '../src/TextArea';
 
 export default {
-  title: 'Components|Forms/TextArea',
+  title: 'Components/Forms/TextArea',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/text-input/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/text-input/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContentDefault from '@ecl/ec-specs-text-input/demo/data--default';
 import TextInput from '../src/TextInput';
 
 export default {
-  title: 'Components|Forms/Text field',
+  title: 'Components/Forms/Text field',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/components/timeline2/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/timeline2/stories/Index.jsx
@@ -29,7 +29,7 @@ const btnAddContent = () => {
 };
 
 export default {
-  title: 'Components|Timeline',
+  title: 'Components/Timeline',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/components/unordered-list/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/unordered-list/stories/Index.jsx
@@ -5,7 +5,7 @@ import UnorderedWithoutBullet from '../examples/UnorderedWithoutBullet';
 import UnorderedWithDivider from '../examples/UnorderedWithDivider';
 
 export default {
-  title: 'Components|List',
+  title: 'Components/List',
 };
 
 export const _Unordered = Unordered;

--- a/src/systems/ec/implementations/react/deprecated/accordion/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/deprecated/accordion/stories/Index.jsx
@@ -9,7 +9,7 @@ import { Accordion } from '../src/Accordion';
 import { AccordionItem } from '../src/AccordionItem';
 
 export default {
-  title: 'Deprecated|Accordion (ECL<2-6-0)',
+  title: 'Deprecated/Accordion (ECL<2-6-0)',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/deprecated/content-page/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/deprecated/content-page/stories/Index.jsx
@@ -4,7 +4,7 @@ import StoryWrapper from '@ecl/story-wrapper';
 import ContentPageExample from '../examples/Default';
 
 export default {
-  title: 'Deprecated|Templates',
+  title: 'Deprecated/Templates',
 
   decorators: [
     story => (

--- a/src/systems/ec/implementations/react/deprecated/footer/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/deprecated/footer/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContentCustom from '@ecl/ec-specs-footer/demo/data--custom';
 import Footer from '../src/Footer';
 
 export default {
-  title: 'Deprecated|Footer (ECL<2-12-0)',
+  title: 'Deprecated/Footer (ECL<2-12-0)',
 
   parameters: {
     a11y: {

--- a/src/systems/ec/implementations/react/deprecated/menu-legacy/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/deprecated/menu-legacy/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContent from '@ecl/ec-specs-menu-legacy/demo/data';
 import { MenuLegacy } from '../src/MenuLegacy';
 
 export default {
-  title: 'Deprecated|Menu (legacy)',
+  title: 'Deprecated/Menu (legacy)',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/deprecated/page-header/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/deprecated/page-header/stories/Index.jsx
@@ -23,7 +23,7 @@ const breadcrumb = (
 );
 
 export default {
-  title: 'Deprecated|Page Header (ECL<2-14-0)',
+  title: 'Deprecated/Page Header (ECL<2-14-0)',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/deprecated/site-header/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/deprecated/site-header/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContentFr from '@ecl/ec-specs-site-header/demo/data--fr';
 import SiteHeader from '../src/SiteHeader';
 
 export default {
-  title: 'Deprecated|Site Header (ECL<2-12-0)',
+  title: 'Deprecated/Site Header (ECL<2-12-0)',
 
   decorators: [
     story => (

--- a/src/systems/ec/implementations/react/deprecated/standard/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/deprecated/standard/stories/Index.jsx
@@ -4,7 +4,7 @@ import StoryWrapper from '@ecl/story-wrapper';
 import StandardPageExample from '../examples/Default';
 
 export default {
-  title: 'Deprecated|Templates',
+  title: 'Deprecated/Templates',
 
   decorators: [
     story => (

--- a/src/systems/ec/implementations/react/deprecated/timeline/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/deprecated/timeline/stories/Index.jsx
@@ -29,7 +29,7 @@ const btnAddContent = () => {
 };
 
 export default {
-  title: 'Deprecated|Timeline (ECL<2-5-0)',
+  title: 'Deprecated/Timeline (ECL<2-5-0)',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/layout/grid/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/layout/grid/stories/Index.jsx
@@ -55,7 +55,7 @@ const Background = () => (
 );
 
 export default {
-  title: 'Layout|Grid',
+  title: 'Layout/Grid',
   decorators: [withKnobs],
 
   parameters: {

--- a/src/systems/ec/implementations/react/layout/stacks/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/layout/stacks/stories/Index.jsx
@@ -24,7 +24,7 @@ const Box = ({ width, shrink, grow, ...props }) => (
 );
 
 export default {
-  title: 'Layout|Stacks',
+  title: 'Layout/Stacks',
   decorators: [withKnobs],
 
   parameters: {

--- a/src/systems/ec/implementations/react/page-structure/language-list/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/page-structure/language-list/stories/Index.jsx
@@ -8,7 +8,7 @@ import LanguageListSplash from '../src/LanguageListSplash';
 import LanguageListOverlay from '../src/LanguageListOverlay';
 
 export default {
-  title: 'Page structure|LanguageList',
+  title: 'Page structure/LanguageList',
 };
 
 export const Splash = () => <LanguageListSplash {...demoContentSplash} />;

--- a/src/systems/ec/implementations/react/page-structure/site-switcher/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/page-structure/site-switcher/stories/Index.jsx
@@ -14,7 +14,7 @@ const variant = {
   footer: 'footer',
 };
 
-storiesOf('Page structure|SiteSwitcher', module)
+storiesOf('Page structure/SiteSwitcher', module)
   .addDecorator(withKnobs)
   .add('default', () => (
     <SiteSwitcher

--- a/src/systems/ec/implementations/react/storybook/.storybook/main.js
+++ b/src/systems/ec/implementations/react/storybook/.storybook/main.js
@@ -10,7 +10,6 @@ const stories = [
 ];
 
 const addons = [
-  '@storybook/addon-options',
   '@storybook/addon-knobs',
   '@storybook/addon-viewport',
   '@storybook/addon-a11y',

--- a/src/systems/ec/implementations/react/storybook/.storybook/manager.js
+++ b/src/systems/ec/implementations/react/storybook/.storybook/manager.js
@@ -11,26 +11,8 @@ const theme = create({
   brandImage: null,
 });
 
-const storySort = (a, b) => {
-  const aParentKind = a[1].kind.split('|').shift();
-  const aKind = a[1].kind
-    .split('|')
-    .slice(1)
-    .join('|');
-  const bParentKind = b[1].kind.split('|').shift();
-  const bKind = b[1].kind
-    .split('|')
-    .slice(1)
-    .join('|');
-
-  return aParentKind !== bParentKind
-    ? 0
-    : aKind.localeCompare(bKind, { numeric: true });
-};
-
 addons.setConfig({
   theme,
-  storySort,
   sidebarAnimations: false,
   panelPosition: 'right',
 });

--- a/src/systems/ec/implementations/react/storybook/.storybook/preview.js
+++ b/src/systems/ec/implementations/react/storybook/.storybook/preview.js
@@ -83,4 +83,7 @@ html {
       },
     },
   },
+  options: {
+    showRoots: true,
+  },
 });

--- a/src/systems/ec/implementations/react/storybook/package.json
+++ b/src/systems/ec/implementations/react/storybook/package.json
@@ -18,7 +18,6 @@
     "@storybook/addon-a11y": "5.3.12",
     "@storybook/addon-cssresources": "5.3.12",
     "@storybook/addon-knobs": "5.3.12",
-    "@storybook/addon-options": "5.3.12",
     "@storybook/addon-viewport": "5.3.12",
     "@storybook/addons": "5.3.12",
     "@storybook/react": "5.3.12",

--- a/src/systems/ec/implementations/react/templates/compositions/content-item/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/compositions/content-item/stories/Index.jsx
@@ -9,7 +9,7 @@ import ContentItemExampleDate from '../examples/Date';
 import ContentItemExampleCustom from '../examples/Custom';
 
 export default {
-  title: 'Templates|Compositions/Content items',
+  title: 'Templates/Compositions/Content items',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/compositions/login-bar/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/compositions/login-bar/stories/Index.jsx
@@ -6,7 +6,7 @@ import { LoggedOut } from '../examples/LoggedOut';
 import { LoggedIn } from '../examples/LoggedIn';
 
 export default {
-  title: 'Templates|Compositions/Login bar',
+  title: 'Templates/Compositions/Login bar',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/compositions/navigation-lists/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/compositions/navigation-lists/stories/Index.jsx
@@ -1,7 +1,7 @@
 import NavigationListExample from '../examples/Default';
 
 export default {
-  title: 'Templates|Compositions',
+  title: 'Templates/Compositions',
 };
 
 export const NavigationLists = NavigationListExample;

--- a/src/systems/ec/implementations/react/templates/pages/call-proposals/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/call-proposals/stories/Index.jsx
@@ -8,7 +8,7 @@ import CallProposalsHarmonisedG1 from '../examples/CallProposalsHarmonisedG1';
 import CallProposalsHarmonisedG2 from '../examples/CallProposalsHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/call-tenders/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/call-tenders/stories/Index.jsx
@@ -8,7 +8,7 @@ import CallTendersHarmonisedG1 from '../examples/CallTendersHarmonisedG1';
 import CallTendersHarmonisedG2 from '../examples/CallTendersHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/campaign/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/campaign/stories/Index.jsx
@@ -8,7 +8,7 @@ import defaultData from '@ecl/ec-specs-campaign-page/demo/data';
 import CampaignPage from '../src/CampaignPage';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
 
   decorators: [
     withKnobs,

--- a/src/systems/ec/implementations/react/templates/pages/commemorative-coin/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/commemorative-coin/stories/Index.jsx
@@ -8,7 +8,7 @@ import CommemorativeCoinHarmonisedG1 from '../examples/CommemorativeCoinHarmonis
 import CommemorativeCoinHarmonisedG2 from '../examples/CommemorativeCoinHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/department/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/department/stories/Index.jsx
@@ -8,7 +8,7 @@ import DepartmentHarmonisedG1 from '../examples/DepartmentHarmonisedG1';
 import DepartmentHarmonisedG2 from '../examples/DepartmentHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/event-agenda/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/event-agenda/stories/Index.jsx
@@ -8,7 +8,7 @@ import EventAgendaHarmonisedG1 from '../examples/EventAgendaHarmonisedG1';
 import EventAgendaHarmonisedG2 from '../examples/EventAgendaHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/event-detail/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/event-detail/stories/Index.jsx
@@ -8,7 +8,7 @@ import EventDetailHarmonisedG1 from '../examples/EventDetailHarmonisedG1';
 import EventDetailHarmonisedG2 from '../examples/EventDetailHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/event-speaker/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/event-speaker/stories/Index.jsx
@@ -8,7 +8,7 @@ import EventSpeakerHarmonisedG1 from '../examples/EventSpeakerHarmonisedG1';
 import EventSpeakerHarmonisedG2 from '../examples/EventSpeakerHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/funding-programme/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/funding-programme/stories/Index.jsx
@@ -8,7 +8,7 @@ import FundingProgrammeHarmonisedG1 from '../examples/FundingProgrammeHarmonised
 import FundingProgrammeHarmonisedG2 from '../examples/FundingProgrammeHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/job-person-biography/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/job-person-biography/stories/Index.jsx
@@ -8,7 +8,7 @@ import PersonHarmonisedG1 from '../examples/PersonHarmonisedG1';
 import PersonHarmonisedG2 from '../examples/PersonHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/job-person-list/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/job-person-list/stories/Index.jsx
@@ -8,7 +8,7 @@ import PersonListHarmonisedG1 from '../examples/PersonListHarmonisedG1';
 import PersonListHarmonisedG2 from '../examples/PersonListHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/main-policy-awareness/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/main-policy-awareness/stories/Index.jsx
@@ -8,7 +8,7 @@ import MainPolicyAwarenessHarmonisedG1 from '../examples/MainPolicyAwarenessHarm
 import MainPolicyAwarenessHarmonisedG2 from '../examples/MainPolicyAwarenessHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/main-policy-background/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/main-policy-background/stories/Index.jsx
@@ -8,7 +8,7 @@ import MainPolicyBackgroundHarmonisedG1 from '../examples/MainPolicyBackgroundHa
 import MainPolicyBackgroundHarmonisedG2 from '../examples/MainPolicyBackgroundHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/main-policy-evaluation/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/main-policy-evaluation/stories/Index.jsx
@@ -8,7 +8,7 @@ import MainPolicyEvaluationHarmonisedG1 from '../examples/MainPolicyEvaluationHa
 import MainPolicyEvaluationHarmonisedG2 from '../examples/MainPolicyEvaluationHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/main-policy-hub/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/main-policy-hub/stories/Index.jsx
@@ -8,7 +8,7 @@ import MainPolicyHubHarmonisedG1 from '../examples/MainPolicyHubHarmonisedG1';
 import MainPolicyHubHarmonisedG2 from '../examples/MainPolicyHubHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/main-policy-legislation/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/main-policy-legislation/stories/Index.jsx
@@ -8,7 +8,7 @@ import MainPolicyLegislationHarmonisedG1 from '../examples/MainPolicyLegislation
 import MainPolicyLegislationHarmonisedG2 from '../examples/MainPolicyLegislationHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/main-policy-resources/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/main-policy-resources/stories/Index.jsx
@@ -8,7 +8,7 @@ import MainPolicyResourcesHarmonisedG1 from '../examples/MainPolicyResourcesHarm
 import MainPolicyResourcesHarmonisedG2 from '../examples/MainPolicyResourcesHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/research-area-hub/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/research-area-hub/stories/Index.jsx
@@ -8,7 +8,7 @@ import ResearchAreaHubHarmonisedG1 from '../examples/ResearchAreaHubHarmonisedG1
 import ResearchAreaHubHarmonisedG2 from '../examples/ResearchAreaHubHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/research-area-spoke/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/research-area-spoke/stories/Index.jsx
@@ -8,7 +8,7 @@ import ResearchAreaSpokeHarmonisedG1 from '../examples/ResearchAreaSpokeHarmonis
 import ResearchAreaSpokeHarmonisedG2 from '../examples/ResearchAreaSpokeHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/templates/pages/search/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/search/stories/Index.jsx
@@ -8,7 +8,7 @@ import SearchHarmonisedG1 from '../examples/SearchHarmonisedG1';
 import SearchHarmonisedG2 from '../examples/SearchHarmonisedG2';
 
 export default {
-  title: 'Templates|Pages',
+  title: 'Templates/Pages',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/utilities/background/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/background/stories/Index.jsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { withKnobs, select } from '@storybook/addon-knobs';
 
 export default {
-  title: 'Utilities|Background',
+  title: 'Utilities/Background',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/utilities/border/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/border/stories/Index.jsx
@@ -15,7 +15,7 @@ const styleBox = {
 };
 
 export default {
-  title: 'Utilities|Border',
+  title: 'Utilities/Border',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/utilities/dimension/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/dimension/stories/Index.jsx
@@ -18,7 +18,7 @@ const styleBox = {
 };
 
 export default {
-  title: 'Utilities|Display',
+  title: 'Utilities/Display',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/utilities/display/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/display/stories/Index.jsx
@@ -17,7 +17,7 @@ const styleBox = {
 };
 
 export default {
-  title: 'Utilities|Dimension',
+  title: 'Utilities/Dimension',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/utilities/editor/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/editor/stories/Index.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
 
 export default {
-  title: 'Utilities|Editor',
+  title: 'Utilities/Editor',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/utilities/media/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/media/stories/Index.jsx
@@ -97,7 +97,7 @@ const MediaBg = (bgPosition, bgOrigin, bgRepeat, bgSize) => (
 );
 
 export default {
-  title: 'Utilities|Media',
+  title: 'Utilities/Media',
   decorators: [withKnobs],
 };
 

--- a/src/systems/ec/implementations/react/utilities/spacing/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/spacing/stories/Index.jsx
@@ -42,7 +42,7 @@ const Spacing = (type, token) => (
 );
 
 export default {
-  title: 'Utilities|Spacing',
+  title: 'Utilities/Spacing',
   decorators: [withKnobs],
 
   parameters: {

--- a/src/systems/ec/implementations/react/utilities/typography/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/typography/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContentHeading from '@ecl/ec-specs-typography/demo/data--heading';
 import demoContentParagraph from '@ecl/ec-specs-typography/demo/data--paragraph';
 
 export default {
-  title: 'Utilities|Typography',
+  title: 'Utilities/Typography',
   decorators: [withKnobs],
 };
 

--- a/src/systems/eu/implementations/react/components/accordion/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/accordion/stories/Index.jsx
@@ -9,7 +9,7 @@ import demoContent from '@ecl/eu-specs-accordion/demo/data';
 import { Accordion } from '../src/Accordion';
 import { AccordionItem } from '../src/AccordionItem';
 
-storiesOf('Components|Accordion', module)
+storiesOf('Components/Accordion', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/accordion2/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/accordion2/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContent from '@ecl/eu-specs-accordion2/demo/data';
 import { Accordion2 } from '../src/Accordion2';
 import { Accordion2Item } from '../src/Accordion2Item';
 
-storiesOf('Components|Accordion', module)
+storiesOf('Components/Accordion', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/blockquote/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/blockquote/stories/Index.jsx
@@ -6,7 +6,7 @@ import demoContent from '@ecl/eu-specs-blockquote/demo/data';
 
 import Blockquote from '../src/Blockquote';
 
-storiesOf('Components|Blockquote', module)
+storiesOf('Components/Blockquote', module)
   .addDecorator(withKnobs)
   .add('default', () => (
     <Blockquote

--- a/src/systems/eu/implementations/react/components/breadcrumb/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/breadcrumb/stories/Index.jsx
@@ -9,7 +9,7 @@ import demoContent from '@ecl/eu-specs-breadcrumb/demo/data';
 import { Breadcrumb } from '../src/Breadcrumb';
 import { BreadcrumbItem } from '../src/BreadcrumbItem';
 
-storiesOf('Components|Navigation/Breadcrumb', module)
+storiesOf('Components/Navigation/Breadcrumb', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <div style={{ backgroundColor: '#004494' }}>{story()}</div>

--- a/src/systems/eu/implementations/react/components/button/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/button/stories/Index.jsx
@@ -22,7 +22,7 @@ const iconPosition = {
   after: 'after',
 };
 
-storiesOf('Components|Button', module)
+storiesOf('Components/Button', module)
   .addDecorator(withKnobs)
   .add('primary', () => {
     const buttonIcon = {

--- a/src/systems/eu/implementations/react/components/card/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/card/stories/Index.jsx
@@ -10,7 +10,7 @@ import { Template as template } from './Template';
 
 import Card from '../src/Card';
 
-storiesOf('Components|Card', module)
+storiesOf('Components/Card', module)
   .addDecorator(withKnobs)
   .add('card', () => {
     // Image

--- a/src/systems/eu/implementations/react/components/checkbox/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/checkbox/stories/Index.jsx
@@ -6,7 +6,7 @@ import demoContentDefault from '@ecl/eu-specs-checkbox/demo/data--default';
 
 import CheckboxGroup from '../src/CheckboxGroup';
 
-storiesOf('Components|Forms/Checkbox', module)
+storiesOf('Components/Forms/Checkbox', module)
   .addDecorator(withKnobs)
   .add('default', () => (
     <CheckboxGroup

--- a/src/systems/eu/implementations/react/components/contextual-navigation/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/contextual-navigation/stories/Index.jsx
@@ -11,7 +11,7 @@ import VanillaContextualNavigation from '@ecl/eu-component-contextual-navigation
 
 import ContextualNavigation from '../src/ContextualNavigation';
 
-storiesOf('Components|Navigation/Contextual Navigation', module)
+storiesOf('Components/Navigation/Contextual Navigation', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/date-block/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/date-block/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/eu-specs-date-block/demo/data';
 
 import DateBlock from '../src/DateBlock';
 
-storiesOf('Components|Date Block', module)
+storiesOf('Components/Date Block', module)
   .addDecorator(withKnobs)
   .add('default', () => (
     <DateBlock

--- a/src/systems/eu/implementations/react/components/description-list/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/description-list/stories/Index.jsx
@@ -4,6 +4,6 @@ import { storiesOf } from '@storybook/react';
 import Description from '../examples/Description';
 import DescriptionHorizontal from '../examples/DescriptionHorizontal';
 
-storiesOf('Components|List', module)
+storiesOf('Components/List', module)
   .add('description', Description)
   .add('description (horizontal)', DescriptionHorizontal);

--- a/src/systems/eu/implementations/react/components/dropdown-legacy/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/dropdown-legacy/stories/Index.jsx
@@ -6,7 +6,7 @@ import { withCssResources } from '@storybook/addon-cssresources';
 import StoryWrapper from '@ecl/story-wrapper';
 import DropdownExample from '../examples/Default';
 
-storiesOf('Components|Dropdown Legacy', module)
+storiesOf('Components/Dropdown Legacy', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/expandable/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/expandable/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/eu-specs-expandable/demo/data';
 
 import { Expandable } from '../src/Expandable';
 
-storiesOf('Components|Expandables', module)
+storiesOf('Components/Expandables', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/file-upload/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/file-upload/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContentDefault from '@ecl/eu-specs-file-upload/demo/data--default';
 
 import FileUpload from '../src/FileUpload';
 
-storiesOf('Components|Forms/File upload', module)
+storiesOf('Components/Forms/File upload', module)
   .addDecorator(withKnobs)
   .add(
     'default',

--- a/src/systems/eu/implementations/react/components/file/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/file/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContentTranslation from '@ecl/eu-specs-file/demo/data--with-translati
 
 import { FileDownload } from '../src/FileDownload';
 
-storiesOf('Components|File', module)
+storiesOf('Components/File', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/gallery/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/gallery/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/eu-specs-gallery/demo/data';
 
 import { Gallery } from '../src/Gallery';
 
-storiesOf('Components|Gallery', module)
+storiesOf('Components/Gallery', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/hero-banner/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/hero-banner/stories/Index.jsx
@@ -11,7 +11,7 @@ import demoContentAlignLeft from '@ecl/eu-specs-hero-banner/demo/data--align-lef
 
 import HeroBanner from '../src/HeroBanner';
 
-storiesOf('Components|Banners/Hero Banner', module)
+storiesOf('Components/Banners/Hero Banner', module)
   .addDecorator(withKnobs)
   .add('image', () => {
     const link = {

--- a/src/systems/eu/implementations/react/components/icon/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/icon/stories/Index.jsx
@@ -40,7 +40,7 @@ const transforms = {
 
 const defaultTransform = '';
 
-storiesOf('Components|Icon', module)
+storiesOf('Components/Icon', module)
   .addDecorator(withKnobs)
   .add('branded', () => {
     const shape = select('Icon', brandedIcons, brandedIcons[0]);

--- a/src/systems/eu/implementations/react/components/inpage-navigation/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/inpage-navigation/stories/Index.jsx
@@ -14,7 +14,7 @@ const btnIdRemoveHandler = () => {
   randomH2.outerHTML = '';
 };
 
-storiesOf('Components|Navigation/In page navigation', module)
+storiesOf('Components/Navigation/In page navigation', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/link/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/link/stories/Index.jsx
@@ -25,7 +25,7 @@ const iconPosition = {
   after: 'after',
 };
 
-storiesOf('Components|Navigation/Link', module)
+storiesOf('Components/Navigation/Link', module)
   .addDecorator(withKnobs)
   .add('default', () => {
     const linkIcon = {

--- a/src/systems/eu/implementations/react/components/media-container/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/media-container/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContentVideo from '@ecl/eu-specs-media-container/demo/data--video';
 
 import MediaContainer from '../src/MediaContainer';
 
-storiesOf('Components|MediaContainer', module)
+storiesOf('Components/MediaContainer', module)
   .addDecorator(withKnobs)
   .add('video', () => (
     <MediaContainer

--- a/src/systems/eu/implementations/react/components/menu-legacy/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/menu-legacy/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContent from '@ecl/eu-specs-menu-legacy/demo/data';
 
 import { MenuLegacy } from '../src/MenuLegacy';
 
-storiesOf('Components|Navigation/Menu (legacy)', module)
+storiesOf('Components/Navigation/Menu (legacy)', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/message/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/message/stories/Index.jsx
@@ -10,7 +10,7 @@ import demoContentError from '@ecl/eu-specs-message/demo/data--error';
 
 import { Message } from '../src/Message';
 
-storiesOf('Components|Messages', module)
+storiesOf('Components/Messages', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/ordered-list/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/ordered-list/stories/Index.jsx
@@ -3,4 +3,4 @@ import { storiesOf } from '@storybook/react';
 
 import Ordered from '../examples/Ordered';
 
-storiesOf('Components|List', module).add('ordered', Ordered);
+storiesOf('Components/List', module).add('ordered', Ordered);

--- a/src/systems/eu/implementations/react/components/page-banner/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/page-banner/stories/Index.jsx
@@ -11,7 +11,7 @@ import demoContentAlignLeft from '@ecl/eu-specs-page-banner/demo/data--align-lef
 
 import PageBanner from '../src/PageBanner';
 
-storiesOf('Components|Banners/Page Banner', module)
+storiesOf('Components/Banners/Page Banner', module)
   .addDecorator(withKnobs)
   .add('image', () => {
     const link = {

--- a/src/systems/eu/implementations/react/components/pagination/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/pagination/stories/Index.jsx
@@ -7,6 +7,6 @@ import demoContent from '@ecl/eu-specs-pagination/demo/data';
 
 import Pagination from '../src/Pagination';
 
-storiesOf('Components|Navigation/Pagination', module)
+storiesOf('Components/Navigation/Pagination', module)
   .addDecorator(withKnobs)
   .add('default', () => <Pagination {...demoContent} />);

--- a/src/systems/eu/implementations/react/components/radio/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/radio/stories/Index.jsx
@@ -8,7 +8,7 @@ import demoContentBinary from '@ecl/eu-specs-radio/demo/data--binary';
 
 import RadioGroup from '../src/RadioGroup';
 
-storiesOf('Components|Forms/Radio', module)
+storiesOf('Components/Forms/Radio', module)
   .addDecorator(withKnobs)
   .add(
     'default',

--- a/src/systems/eu/implementations/react/components/search-form/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/search-form/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/eu-specs-search-form/demo/data';
 
 import SearchForm from '../src/SearchForm';
 
-storiesOf('Components|Forms/SearchForm', module)
+storiesOf('Components/Forms/SearchForm', module)
   .addDecorator(withKnobs)
   .add('default', () => (
     <SearchForm

--- a/src/systems/eu/implementations/react/components/select/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/select/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/eu-specs-select/demo/data';
 
 import Select from '../src/Select';
 
-storiesOf('Components|Forms/Select', module)
+storiesOf('Components/Forms/Select', module)
   // Example of how to disable an axe-core rule
   /*
   .addParameters({

--- a/src/systems/eu/implementations/react/components/skip-link/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/skip-link/stories/Index.jsx
@@ -7,7 +7,7 @@ import { withCssResources } from '@storybook/addon-cssresources';
 import demoData from '@ecl/eu-specs-skip-link/demo/data';
 import { SkipLink } from '../src/SkipLink';
 
-storiesOf('Components|Navigation/Skip link', module)
+storiesOf('Components/Navigation/Skip link', module)
   .addDecorator(withKnobs)
   .addDecorator(withCssResources)
   .addParameters({

--- a/src/systems/eu/implementations/react/components/social-media-follow/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/social-media-follow/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/eu-specs-social-media-follow/demo/data';
 
 import SocialMediaFollow from '../src/SocialMediaFollow';
 
-storiesOf('Components|SocialMediaFollow', module)
+storiesOf('Components/SocialMediaFollow', module)
   .addDecorator(withKnobs)
   .add('horizontal', () => (
     <SocialMediaFollow

--- a/src/systems/eu/implementations/react/components/social-media-share/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/social-media-share/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContent from '@ecl/eu-specs-social-media-share/demo/data';
 
 import SocialMediaShare from '../src/SocialMediaShare';
 
-storiesOf('Components|SocialMediaShare', module)
+storiesOf('Components/SocialMediaShare', module)
   .addDecorator(withKnobs)
   .add('default', () => (
     <SocialMediaShare

--- a/src/systems/eu/implementations/react/components/table/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/table/stories/Index.jsx
@@ -5,7 +5,7 @@ import Table from '../examples/Table';
 import TableZebra from '../examples/TableZebra';
 import TableMulti from '../examples/TableMulti';
 
-storiesOf('Components|Table', module)
+storiesOf('Components/Table', module)
   .add('default', Table)
   .add('zebra', TableZebra)
   .add('multi header', TableMulti);

--- a/src/systems/eu/implementations/react/components/tag/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/tag/stories/Index.jsx
@@ -9,7 +9,7 @@ import demoDataRemovable from '@ecl/eu-specs-tag/demo/data--removable';
 
 import Tag from '../src/Tag';
 
-storiesOf('Components|Tag', module)
+storiesOf('Components/Tag', module)
   .addDecorator(withKnobs)
   .add('as a link', () => (
     <Tag

--- a/src/systems/eu/implementations/react/components/text-area/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/text-area/stories/Index.jsx
@@ -13,7 +13,7 @@ import demoContentDefault from '@ecl/eu-specs-text-area/demo/data--default';
 
 import TextArea from '../src/TextArea';
 
-storiesOf('Components|Forms/TextArea', module)
+storiesOf('Components/Forms/TextArea', module)
   .addDecorator(withKnobs)
   .add(
     'default',

--- a/src/systems/eu/implementations/react/components/text-input/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/text-input/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContentDefault from '@ecl/eu-specs-text-input/demo/data--default';
 
 import TextInput from '../src/TextInput';
 
-storiesOf('Components|Forms/Text field', module)
+storiesOf('Components/Forms/Text field', module)
   .addDecorator(withKnobs)
   .add(
     'default',

--- a/src/systems/eu/implementations/react/components/timeline/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/timeline/stories/Index.jsx
@@ -30,7 +30,7 @@ const btnAddContent = () => {
   }
 };
 
-storiesOf('Components|Timeline', module)
+storiesOf('Components/Timeline', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/timeline2/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/timeline2/stories/Index.jsx
@@ -29,7 +29,7 @@ const btnAddContent = () => {
   }
 };
 
-storiesOf('Components|Timeline', module)
+storiesOf('Components/Timeline', module)
   .addDecorator(withKnobs)
   .addDecorator(story => (
     <StoryWrapper

--- a/src/systems/eu/implementations/react/components/unordered-list/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/unordered-list/stories/Index.jsx
@@ -5,7 +5,7 @@ import Unordered from '../examples/Unordered';
 import UnorderedWithoutBullet from '../examples/UnorderedWithoutBullet';
 import UnorderedWithDivider from '../examples/UnorderedWithDivider';
 
-storiesOf('Components|List', module)
+storiesOf('Components/List', module)
   .add('unordered', Unordered)
   .add('without bullet', UnorderedWithoutBullet)
   .add('with divider', UnorderedWithDivider);

--- a/src/systems/eu/implementations/react/layout/grid/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/layout/grid/stories/Index.jsx
@@ -56,7 +56,7 @@ const Background = () => (
   </div>
 );
 
-storiesOf('Layout|Grid', module)
+storiesOf('Layout/Grid', module)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive',

--- a/src/systems/eu/implementations/react/layout/stacks/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/layout/stacks/stories/Index.jsx
@@ -24,7 +24,7 @@ const Box = ({ width, shrink, grow, ...props }) => (
   />
 );
 
-storiesOf('Layout|Stacks', module)
+storiesOf('Layout/Stacks', module)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive',

--- a/src/systems/eu/implementations/react/page-structure/footer/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/page-structure/footer/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContentCustom from '@ecl/eu-specs-footer/demo/data--custom';
 
 import Footer from '../src/Footer';
 
-storiesOf('Page structure|Footer', module)
+storiesOf('Page Structure/Footer', module)
   .addParameters({
     a11y: {
       options: {

--- a/src/systems/eu/implementations/react/page-structure/language-list/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/page-structure/language-list/stories/Index.jsx
@@ -8,6 +8,6 @@ import demoContentOverlay from '@ecl/eu-specs-language-list/demo/data--overlay';
 import LanguageListSplash from '../src/LanguageListSplash';
 import LanguageListOverlay from '../src/LanguageListOverlay';
 
-storiesOf('Page structure|LanguageList', module)
+storiesOf('Page Structure/LanguageList', module)
   .add('splash', () => <LanguageListSplash {...demoContentSplash} />)
   .add('overlay', () => <LanguageListOverlay {...demoContentOverlay} />);

--- a/src/systems/eu/implementations/react/page-structure/page-header/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/page-structure/page-header/stories/Index.jsx
@@ -24,7 +24,7 @@ const breadcrumb = (
   </Breadcrumb>
 );
 
-storiesOf('Page structure|PageHeader', module)
+storiesOf('Page Structure/PageHeader', module)
   .addDecorator(withKnobs)
   .add('basic', () => (
     <PageHeader

--- a/src/systems/eu/implementations/react/page-structure/site-header/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/page-structure/site-header/stories/Index.jsx
@@ -7,7 +7,7 @@ import demoContentFr from '@ecl/eu-specs-site-header/demo/data--fr';
 
 import SiteHeader from '../src/SiteHeader';
 
-storiesOf('Page structure|SiteHeader', module)
+storiesOf('Page Structure/SiteHeader', module)
   .addDecorator(story => (
     <StoryWrapper
       afterMount={() => {

--- a/src/systems/eu/implementations/react/storybook/.storybook/main.js
+++ b/src/systems/eu/implementations/react/storybook/.storybook/main.js
@@ -9,7 +9,6 @@ const stories = [
 ];
 
 const addons = [
-  '@storybook/addon-options',
   '@storybook/addon-knobs',
   '@storybook/addon-viewport',
   '@storybook/addon-a11y',

--- a/src/systems/eu/implementations/react/storybook/.storybook/manager.js
+++ b/src/systems/eu/implementations/react/storybook/.storybook/manager.js
@@ -11,26 +11,8 @@ const theme = create({
   brandImage: null,
 });
 
-const storySort = (a, b) => {
-  const aParentKind = a[1].kind.split('|').shift();
-  const aKind = a[1].kind
-    .split('|')
-    .slice(1)
-    .join('|');
-  const bParentKind = b[1].kind.split('|').shift();
-  const bKind = b[1].kind
-    .split('|')
-    .slice(1)
-    .join('|');
-
-  return aParentKind !== bParentKind
-    ? 0
-    : aKind.localeCompare(bKind, { numeric: true });
-};
-
 addons.setConfig({
   theme,
-  storySort,
   sidebarAnimations: false,
   panelPosition: 'right',
 });

--- a/src/systems/eu/implementations/react/storybook/.storybook/preview.js
+++ b/src/systems/eu/implementations/react/storybook/.storybook/preview.js
@@ -83,4 +83,7 @@ html {
       },
     },
   },
+  options: {
+    showRoots: true,
+  },
 });

--- a/src/systems/eu/implementations/react/storybook/package.json
+++ b/src/systems/eu/implementations/react/storybook/package.json
@@ -18,7 +18,6 @@
     "@storybook/addon-a11y": "5.3.12",
     "@storybook/addon-cssresources": "5.3.12",
     "@storybook/addon-knobs": "5.3.12",
-    "@storybook/addon-options": "5.3.12",
     "@storybook/addon-viewport": "5.3.12",
     "@storybook/addons": "5.3.12",
     "@storybook/react": "5.3.12",

--- a/src/systems/eu/implementations/react/templates/compositions/content-item/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/templates/compositions/content-item/stories/Index.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import ContentItemExample from '../examples/Default';
 
-storiesOf('Templates|Compositions', module).add(
+storiesOf('Templates/Compositions', module).add(
   'Content items',
   ContentItemExample
 );

--- a/src/systems/eu/implementations/react/templates/compositions/login-bar/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/templates/compositions/login-bar/stories/Index.jsx
@@ -5,7 +5,7 @@ import { withKnobs, text } from '@storybook/addon-knobs';
 import { LoggedOut } from '../examples/LoggedOut';
 import { LoggedIn } from '../examples/LoggedIn';
 
-storiesOf('Templates|Compositions/Login bar', module)
+storiesOf('Templates/Compositions/Login bar', module)
   .addDecorator(withKnobs)
   .add('Logged out', LoggedOut)
   .add(

--- a/src/systems/eu/implementations/react/templates/compositions/navigation-lists/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/templates/compositions/navigation-lists/stories/Index.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import NavigationListExample from '../examples/Default';
 
-storiesOf('Templates|Compositions', module).add(
+storiesOf('Templates/Compositions', module).add(
   'Navigation lists',
   NavigationListExample
 );

--- a/src/systems/eu/implementations/react/templates/pages/campaign/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/templates/pages/campaign/stories/Index.jsx
@@ -5,7 +5,7 @@ import StoryWrapper from '@ecl/story-wrapper';
 
 import CampaignPageExample from '../examples/Default';
 
-storiesOf('Templates|Pages', module)
+storiesOf('Templates/Pages', module)
   .addDecorator(story => (
     <StoryWrapper
       afterMount={() => {

--- a/src/systems/eu/implementations/react/templates/pages/event-agenda/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/templates/pages/event-agenda/stories/Index.jsx
@@ -6,7 +6,7 @@ import StoryWrapper from '@ecl/story-wrapper';
 
 import EventAgendaPageExample from '../examples/Default';
 
-storiesOf('Templates|Pages', module)
+storiesOf('Templates/Pages', module)
   .addDecorator(story => (
     <StoryWrapper
       afterMount={() => {

--- a/src/systems/eu/implementations/react/templates/pages/event-detail/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/templates/pages/event-detail/stories/Index.jsx
@@ -5,7 +5,7 @@ import StoryWrapper from '@ecl/story-wrapper';
 
 import EventDetailPageExample from '../examples/Default';
 
-storiesOf('Templates|Pages', module)
+storiesOf('Templates/Pages', module)
   .addDecorator(story => (
     <StoryWrapper
       afterMount={() => {

--- a/src/systems/eu/implementations/react/templates/pages/event-speaker/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/templates/pages/event-speaker/stories/Index.jsx
@@ -5,7 +5,7 @@ import StoryWrapper from '@ecl/story-wrapper';
 
 import EventSpeakerPageExample from '../examples/Default';
 
-storiesOf('Templates|Pages', module)
+storiesOf('Templates/Pages', module)
   .addDecorator(story => (
     <StoryWrapper
       afterMount={() => {

--- a/src/systems/eu/implementations/react/templates/pages/standard/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/templates/pages/standard/stories/Index.jsx
@@ -5,7 +5,7 @@ import StoryWrapper from '@ecl/story-wrapper';
 
 import StandardPageExample from '../examples/Default';
 
-storiesOf('Templates|Pages', module)
+storiesOf('Templates/Pages', module)
   .addDecorator(story => (
     <StoryWrapper
       afterMount={() => {

--- a/src/systems/eu/implementations/react/utilities/background/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/utilities/background/stories/Index.jsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select } from '@storybook/addon-knobs';
 
-storiesOf('Utilities|Background', module)
+storiesOf('Utilities/Background', module)
   .addDecorator(withKnobs)
   .add('custom', () => {
     const background = select(

--- a/src/systems/eu/implementations/react/utilities/border/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/utilities/border/stories/Index.jsx
@@ -15,7 +15,7 @@ const styleBox = {
   width: '10rem',
 };
 
-storiesOf('Utilities|Border', module)
+storiesOf('Utilities/Border', module)
   .addDecorator(withKnobs)
   .add('custom', () => {
     const color = select(

--- a/src/systems/eu/implementations/react/utilities/media/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/utilities/media/stories/Index.jsx
@@ -97,7 +97,7 @@ const MediaBg = (bgPosition, bgOrigin, bgRepeat, bgSize) => (
   />
 );
 
-storiesOf('Utilities|Media', module)
+storiesOf('Utilities/Media', module)
   .addDecorator(withKnobs)
   .add('custom', () => {
     const direction = select(

--- a/src/systems/eu/implementations/react/utilities/spacing/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/utilities/spacing/stories/Index.jsx
@@ -42,7 +42,7 @@ const Spacing = (type, token) => (
   </div>
 );
 
-storiesOf('Utilities|Spacing', module)
+storiesOf('Utilities/Spacing', module)
   .addParameters({
     viewport: {
       defaultViewport: 'responsive',

--- a/src/systems/eu/implementations/react/utilities/typography/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/utilities/typography/stories/Index.jsx
@@ -7,7 +7,7 @@ import { withKnobs, text, select, boolean } from '@storybook/addon-knobs';
 import demoContentHeading from '@ecl/eu-specs-typography/demo/data--heading';
 import demoContentParagraph from '@ecl/eu-specs-typography/demo/data--paragraph';
 
-storiesOf('Utilities|Typography', module)
+storiesOf('Utilities/Typography', module)
   .addDecorator(withKnobs)
   .add('paragraph', () => {
     const content = text('Content', demoContentParagraph.content);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3350,15 +3350,6 @@
     react-lifecycles-compat "^3.0.4"
     react-select "^3.0.8"
 
-"@storybook/addon-options@5.3.12":
-  version "5.3.12"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-options/-/addon-options-5.3.12.tgz#33c7cf92bcc19189d979629cdf18f483621fba72"
-  integrity sha512-rGh5FSe4rA3prnZYbihQR27oE47KwdI8GvKC+F2ZakYCtQnSbx0IyMhvhYjr41Vsdx5uMsm1/M87EzxlB6bxYw==
-  dependencies:
-    "@storybook/addons" "5.3.12"
-    core-js "^3.0.1"
-    util-deprecate "^1.0.2"
-
 "@storybook/addon-viewport@5.3.12":
   version "5.3.12"
   resolved "https://registry.yarnpkg.com/@storybook/addon-viewport/-/addon-viewport-5.3.12.tgz#2f1e415d3f070e454818074faf2ccfb2b4a99ffa"


### PR DESCRIPTION
# PR description

When making the refactoring, changes were applied to preview in order to keep the display for root elements.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] `package.json` is up-to-date and `@ecl/[system]-base` is part of the dependencies
- [ ] I have checked the dependencies
- [ ] I have given the fractal status “ready” to my component
- [ ] I have declared `@define mycomponent` in the SCSS file
- [ ] I have specified `margin: 0;` on the CSS component
- [ ] I have provided tests
- [ ] I follow the naming guidelines
- [ ] the component supports composition
- [ ] there are no hardcoded strings (all content come from the context)
- [ ] I have filled the README.md file (at least a few lines)
- [ ] My component is listed in the root README
- [ ] My PR has the right label(s)
- [ ] The redirects in `src/website/src/routes/Redirects.jsx` are up-to-date
