### PR TITLE
chore(webtools): story integration example - FRONT-996

### DIFF
--- a/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
@@ -14,7 +14,7 @@ export default {
     story => (
       <>
         <WebtoolsLoader
-          src="https://europa.eu/webtools/load.js?globan=1110"
+          query={{ globan: 1110 }}
           options={{ type: 'text/javascript', defer: true }}
           onLoad={() => console.log('global banner loaded')}
           onError={() => console.error('global banner failed to load')}

--- a/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { withKnobs } from '@storybook/addon-knobs';
-import StoryWrapper from '@ecl/story-wrapper';
+import StoryWrapper, { WebtoolsLoader } from '@ecl/story-wrapper';
 import demoContent from '@ecl/ec-specs-gallery/demo/data';
 
 import { Gallery } from '../src/Gallery';
@@ -12,21 +12,29 @@ export default {
   decorators: [
     withKnobs,
     story => (
-      <StoryWrapper
-        afterMount={() => {
-          if (!window.ECL) return {};
+      <>
+        <WebtoolsLoader
+          src="https://europa.eu/webtools/load.js?globan=1110"
+          options={{ type: 'text/javascript', defer: true }}
+          onLoad={() => console.log('global banner loaded')}
+          onError={() => console.error('global banner failed to load')}
+        />
+        <StoryWrapper
+          afterMount={() => {
+            if (!window.ECL) return {};
 
-          const autoinit = window.ECL.autoInit();
-          return { components: autoinit.components };
-        }}
-        beforeUnmount={context => {
-          if (context.components) {
-            context.components.forEach(c => c.destroy());
-          }
-        }}
-      >
-        {story()}
-      </StoryWrapper>
+            const autoinit = window.ECL.autoInit();
+            return { components: autoinit.components };
+          }}
+          beforeUnmount={context => {
+            if (context.components) {
+              context.components.forEach(c => c.destroy());
+            }
+          }}
+        >
+          {story()}
+        </StoryWrapper>
+      </>
     ),
   ],
 };

--- a/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
@@ -14,9 +14,25 @@ export default {
     story => (
       <>
         <WebtoolsLoader
-          query={{ globan: 1110 }}
+          // query={{ globan: 1110 }}
           options={{ type: 'text/javascript', defer: true }}
-          onLoad={() => console.log('global banner loaded')}
+          onLoad={() => {
+            const root = document.getElementById('root');
+            const div = document.createElement('div');
+            div.setAttribute('id', 'wt-init');
+
+            root.prepend(div);
+
+            $wt.render(div, {
+              utility: 'globan',
+              lang: 'en',
+              theme: 'dark',
+              logo: true,
+              link: true,
+              mode: false,
+              zindex: 40,
+            });
+          }}
           onError={() => console.error('global banner failed to load')}
         />
         <StoryWrapper

--- a/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/gallery/stories/Index.jsx
@@ -12,45 +12,41 @@ export default {
   decorators: [
     withKnobs,
     story => (
-      <>
-        <WebtoolsLoader
-          // query={{ globan: 1110 }}
-          options={{ type: 'text/javascript', defer: true }}
-          onLoad={() => {
-            const root = document.getElementById('root');
-            const div = document.createElement('div');
-            div.setAttribute('id', 'wt-init');
+      <StoryWrapper
+        afterMount={() => {
+          const root = document.getElementById('root');
+          const div = document.createElement('div');
+          div.setAttribute('id', 'wt-init');
 
-            root.prepend(div);
+          root.prepend(div);
 
-            $wt.render(div, {
-              utility: 'globan',
-              lang: 'en',
-              theme: 'dark',
-              logo: true,
-              link: true,
-              mode: false,
-              zindex: 40,
+          (function($wt) {
+            $wt.ready(function() {
+              $wt.render(div, {
+                utility: 'globan',
+                lang: 'en',
+                theme: 'dark',
+                logo: true,
+                link: true,
+                mode: false,
+                zindex: 40,
+              });
             });
-          }}
-          onError={() => console.error('global banner failed to load')}
-        />
-        <StoryWrapper
-          afterMount={() => {
-            if (!window.ECL) return {};
+          })($wt);
 
-            const autoinit = window.ECL.autoInit();
-            return { components: autoinit.components };
-          }}
-          beforeUnmount={context => {
-            if (context.components) {
-              context.components.forEach(c => c.destroy());
-            }
-          }}
-        >
-          {story()}
-        </StoryWrapper>
-      </>
+          if (!window.ECL) return {};
+
+          const autoinit = window.ECL.autoInit();
+          return { components: autoinit.components };
+        }}
+        beforeUnmount={context => {
+          if (context.components) {
+            context.components.forEach(c => c.destroy());
+          }
+        }}
+      >
+        {story()}
+      </StoryWrapper>
     ),
   ],
 };

--- a/src/systems/ec/implementations/react/storybook/.storybook/preview-head.html
+++ b/src/systems/ec/implementations/react/storybook/.storybook/preview-head.html
@@ -21,24 +21,17 @@
     return link;
   }
 
-  if (
-    inIframe() &&
-    window.frameElement &&
-    window.frameElement.id === 'storybook-preview-iframe'
-  ) {
+  if (inIframe() && window.frameElement && window.frameElement.id === 'storybook-preview-iframe') {
     // Let CSS Resources inject the styles
   } else {
     // Manually inject styles
     var head = document.head || document.getElementsByTagName('head')[0];
-    head.appendChild(
-      createLink('./styles/ecl-ec-preset-legacy-website.css', 'screen')
-    );
-    head.appendChild(
-      createLink('./styles/ecl-ec-preset-legacy-website-print.css', 'print')
-    );
+    head.append(createLink('./styles/ecl-ec-preset-legacy-website.css', 'screen'));
+    head.append(createLink('./styles/ecl-ec-preset-legacy-website-print.css', 'print'));
   }
 </script>
 <script
   type="text/javascript"
   src="./scripts/ecl-ec-preset-legacy-website.js"
 ></script>
+<script defer src="https://europa.eu/webtools/load.js" type="text/javascript"></script>

--- a/src/tools/story-wrapper/WebtoolsLoader.jsx
+++ b/src/tools/story-wrapper/WebtoolsLoader.jsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+const cachedScripts = [];
+
+const WebtoolsLoader = ({ src, options, onLoad, onError }) => {
+  const [state, setState] = useState({ loaded: false, error: false });
+
+  useEffect(() => {
+    if (cachedScripts.includes(src)) {
+      return setState({
+        loaded: true,
+        error: false,
+      });
+    }
+
+    cachedScripts.push(src);
+
+    /**
+     * Create script tag.
+     */
+    const script = document.createElement('script');
+
+    /**
+     * Define handlers. They depend on script existence.
+     */
+    const onWebtoolsSuccess = () => {
+      onLoad();
+      return setState({ loaded: true, error: false });
+    };
+
+    const onWebtoolsError = () => {
+      onError();
+      const index = cachedScripts.indexOf(src);
+      if (index >= 0) cachedScripts.splice(index, 1);
+      if (script) script.remove();
+
+      return setState({ loaded: true, error: true });
+    };
+
+    /**
+     * Decorate the script tag.
+     */
+    script.src = src;
+
+    ['type', 'async', 'defer', 'charset'].forEach(option => {
+      if (options[option]) {
+        script[option] = options[option];
+      }
+    });
+
+    script.addEventListener('load', onWebtoolsSuccess);
+    script.addEventListener('error', onWebtoolsError);
+
+    document.body.appendChild(script);
+
+    return () => {
+      script.removeEventListener('load', onWebtoolsSuccess);
+      script.removeEventListener('error', onWebtoolsError);
+    };
+  }, [src]);
+
+  return [state.loaded, state.error];
+};
+
+WebtoolsLoader.propTypes = {
+  src: PropTypes.string.isRequired,
+  options: PropTypes.shape({
+    type: PropTypes.string,
+    charset: PropTypes.string,
+    async: PropTypes.bool,
+    defer: PropTypes.bool,
+  }),
+  onLoad: PropTypes.func,
+  onError: PropTypes.func,
+};
+
+WebtoolsLoader.defaultProps = {
+  options: {
+    type: 'text/javascript',
+    async: true,
+    charset: 'UTF-8',
+  },
+  onLoad: () => {},
+  onError: () => {},
+};
+
+export default WebtoolsLoader;

--- a/src/tools/story-wrapper/WebtoolsLoader.jsx
+++ b/src/tools/story-wrapper/WebtoolsLoader.jsx
@@ -1,10 +1,17 @@
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import querystring from 'querystring';
 
 const cachedScripts = [];
 
-const WebtoolsLoader = ({ src, options, onLoad, onError }) => {
+const WebtoolsLoader = ({ loader, query, options, onLoad, onError }) => {
   const [state, setState] = useState({ loaded: false, error: false });
+
+  let src = loader || 'https://europa.eu/webtools/load.js';
+
+  if (query) {
+    src += `?${querystring.stringify(query)}`;
+  }
 
   useEffect(() => {
     if (cachedScripts.includes(src)) {
@@ -52,7 +59,7 @@ const WebtoolsLoader = ({ src, options, onLoad, onError }) => {
     script.addEventListener('load', onWebtoolsSuccess);
     script.addEventListener('error', onWebtoolsError);
 
-    document.body.appendChild(script);
+    document.body.append(script);
 
     return () => {
       script.removeEventListener('load', onWebtoolsSuccess);
@@ -64,7 +71,8 @@ const WebtoolsLoader = ({ src, options, onLoad, onError }) => {
 };
 
 WebtoolsLoader.propTypes = {
-  src: PropTypes.string.isRequired,
+  loader: PropTypes.string,
+  query: PropTypes.shape({}),
   options: PropTypes.shape({
     type: PropTypes.string,
     charset: PropTypes.string,
@@ -76,6 +84,8 @@ WebtoolsLoader.propTypes = {
 };
 
 WebtoolsLoader.defaultProps = {
+  loader: 'https://europa.eu/webtools/load.js',
+  query: {},
   options: {
     type: 'text/javascript',
     async: true,

--- a/src/tools/story-wrapper/index.js
+++ b/src/tools/story-wrapper/index.js
@@ -1,0 +1,4 @@
+import StoryWrapper from './StoryWrapper';
+import WebtoolsLoader from './WebtoolsLoader';
+
+export { StoryWrapper as default, WebtoolsLoader };

--- a/src/tools/story-wrapper/package.json
+++ b/src/tools/story-wrapper/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@ecl/story-wrapper",
   "version": "2.26.0",
-  "main": "StoryWrapper.jsx",
+  "main": "index.js",
   "dependencies": {
     "prop-types": "15.7.2",
     "react": "16.13.0"


### PR DESCRIPTION
# PR description

Suggested approaches:

1) Lazy (https://github.com/ec-europa/europa-component-library/pull/1571/commits/5d3730c14bd779867d6af006f3c4d5948b46c663)

```jsx
<WebtoolsLoader
  query={{ globan: 1110 }}
  options={{ type: "text/javascript", defer: true }}
  onLoad={() => console.log("global banner loaded")}
  onError={() => console.error("global banner failed to load")}
/>
```

2) Micro-manage (https://github.com/ec-europa/europa-component-library/pull/1571/commits/2197f1621f7dce652515dbd5b5d14b7fa80d734f)

```jsx
<WebtoolsLoader
  options={{ type: "text/javascript", defer: true }}
  onLoad={() => {
    const root = document.getElementById("root");
    const div = document.createElement("div");
    div.setAttribute("id", "wt-init");

    root.prepend(div);

    $wt.render(div, {
      utility: "globan",
      lang: "en",
      theme: "dark",
      logo: true,
      link: true,
      mode: false,
      zindex: 40,
    });
  }}
  onError={() => console.error("global banner failed to load")}
/>
```

3. IIFE (https://github.com/ec-europa/europa-component-library/pull/1571/commits/78bf769ce7075f70e1995e1c35d7c8355deef898)

```jsx
<StoryWrapper
  afterMount={() => {
    const root = document.getElementById("root");
    const div = document.createElement("div");
    div.setAttribute("id", "wt-init");

    root.prepend(div);

    (function ($wt) {
      $wt.ready(function () {
        $wt.render(div, {
          utility: "globan",
          lang: "en",
          theme: "dark",
          logo: true,
          link: true,
          mode: false,
          zindex: 40,
        });
      });
    })($wt);

    if (!window.ECL) return {};

    const autoinit = window.ECL.autoInit();
    return { components: autoinit.components };
  }}
  beforeUnmount={(context) => {
    if (context.components) {
      context.components.forEach((c) => c.destroy());
    }
  }}
>
  {story()}
</StoryWrapper>
```

Script does not work with iframes, most probably because of the loader assuming DOM structure. Full-view is ok though:

![screenshot-nimbus-capture-2020 04 06-14_52_18](https://user-images.githubusercontent.com/1923476/78560668-b89afc80-7816-11ea-8bb4-33a7ddc4b916.png)
