### PR TITLE
feat(legacy-page-header): add background image - FRONT-1130

### DIFF
--- a/src/systems/ec/implementations/react/deprecated/page-header/src/PageHeader.jsx
+++ b/src/systems/ec/implementations/react/deprecated/page-header/src/PageHeader.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import Icon from '@ecl/ec-react-component-icon';
 
 const PageHeader = ({
+  backgroundImage,
   breadcrumb,
   title,
   description,
@@ -12,12 +13,22 @@ const PageHeader = ({
   className,
   ...props
 }) => {
-  const classNames = classnames(className, 'ecl-page-header');
+  const classNames = classnames(className, 'ecl-page-header', {
+    [`ecl-page-header--background-image`]: backgroundImage,
+  });
 
   const infosArray = Array.isArray(infos) ? infos : [infos];
 
   return (
-    <div {...props} className={classNames}>
+    <div
+      {...props}
+      className={classNames}
+      {...(backgroundImage
+        ? {
+            style: { 'background-image': `url(${backgroundImage})` },
+          }
+        : {})}
+    >
       <div className="ecl-container">
         {React.cloneElement(breadcrumb, {
           className: 'ecl-page-header__breadcrumb',
@@ -49,6 +60,7 @@ const PageHeader = ({
 };
 
 PageHeader.propTypes = {
+  backgroundImage: PropTypes.string,
   breadcrumb: PropTypes.node,
   title: PropTypes.string,
   description: PropTypes.string,
@@ -63,6 +75,7 @@ PageHeader.propTypes = {
 };
 
 PageHeader.defaultProps = {
+  backgroundImage: '',
   breadcrumb: null,
   title: '',
   description: '',

--- a/src/systems/ec/implementations/react/deprecated/page-header/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/deprecated/page-header/stories/Index.jsx
@@ -10,6 +10,7 @@ import demoMetaTitleDescriptionContent from '@ecl/ec-specs-page-header/demo/data
 import demoTitleDescriptionContent from '@ecl/ec-specs-page-header/demo/data--title-description';
 import demoEventsContent from '@ecl/ec-specs-page-header/demo/data--events';
 import demoEventsDescriptionContent from '@ecl/ec-specs-page-header/demo/data--events-description';
+import demoBackgroundImage from '@ecl/ec-specs-page-header/demo/data--background-image';
 
 import PageHeader from '../src/PageHeader';
 
@@ -109,4 +110,18 @@ export const EventsDescription = () => (
 
 EventsDescription.story = {
   name: 'events-description',
+};
+
+export const BackgroundImage = () => (
+  <PageHeader
+    breadcrumb={breadcrumb}
+    title={text('Title', demoBackgroundImage.title)}
+    description={text('Description', demoBackgroundImage.description)}
+    meta={text('Meta', demoBackgroundImage.meta)}
+    backgroundImage={demoBackgroundImage.backgroundImage}
+  />
+);
+
+BackgroundImage.story = {
+  name: 'background-image',
 };

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-page-header/ec-component-page-header.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-page-header/ec-component-page-header.scss
@@ -93,7 +93,7 @@
       background: linear-gradient(
         to bottom,
         rgba(0, 0, 0, 0.4) 0%,
-        rgba(0, 0, 0, 0.2) 100%
+        rgba(0, 0, 0, 0) 100%
       );
       content: '';
       display: block;

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-page-header/ec-component-page-header.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-page-header/ec-component-page-header.scss
@@ -22,6 +22,7 @@
 
   .ecl-page-header__meta-list {
     font: $ecl-font-m;
+    text-transform: uppercase;
   }
 
   .ecl-page-header__title {
@@ -75,6 +76,21 @@
 
   .ecl-page-header__info-icon {
     margin-right: $ecl-spacing-xs;
+  }
+
+  /*
+   * Background image
+   */
+  .ecl-page-header--background-image {
+    background-position: 0 0;
+    background-size: cover;
+    display: block;
+    height: auto;
+    width: 100%;
+
+    .ecl-page-header__breadcrumb {
+      background-color: transparent;
+    }
   }
 }
 

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-page-header/ec-component-page-header.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-page-header/ec-component-page-header.scss
@@ -86,7 +86,21 @@
     background-size: cover;
     display: block;
     height: auto;
+    position: relative;
     width: 100%;
+
+    &::before {
+      background: linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 0.4) 0%,
+        rgba(0, 0, 0, 0.2) 100%
+      );
+      content: '';
+      display: block;
+      height: 100%;
+      position: absolute;
+      width: 100%;
+    }
 
     .ecl-page-header__breadcrumb {
       background-color: transparent;

--- a/src/systems/ec/specs/components/page-header/demo/data--background-image.js
+++ b/src/systems/ec/specs/components/page-header/demo/data--background-image.js
@@ -1,0 +1,8 @@
+module.exports = {
+  title: 'Page title',
+  description:
+    'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium',
+  meta: 'News article | 17 October 2015',
+  backgroundImage:
+    'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
+};


### PR DESCRIPTION
# PR description

Add a variant to allow background image on legacy page header

demo: https://5ea932019d7a378c696b1ec2--europa-component-library.netlify.app/playground/ec/?path=/story/deprecated-page-header-ecl-2-14-0--background-image