### PR TITLE
chore(github-actions): fix netlify previews - FRONT-1254

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,16 @@ module.exports = {
   env: {
     node: true,
   },
-  rules: {},
+  rules: {
+    'class-methods-use-this': 'off',
+    'no-underscore-dangle': 'off',
+    'no-param-reassign': 'off',
+    'react/jsx-fragments': 'off',
+    'react/jsx-props-no-spreading': 'off',
+    // Temporary disable rule until https://github.com/yannickcr/eslint-plugin-react/issues/2427 is fixed
+    'react/jsx-curly-brace-presence': 'off',
+    'import/no-extraneous-dependencies': 'off',
+  },
   overrides: [
     {
       files: '**/scripts/**/*.js',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Build icons
         run: yarn build:icons
       - name: Build themes
@@ -42,6 +44,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Build icons
         run: yarn build:icons
       - name: Build themes
@@ -61,8 +65,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
-      - name: Clean
-        run: yarn clean
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
       - name: Build themes
         run: yarn build:themes
       - name: Build presets
@@ -79,7 +83,7 @@ jobs:
         with:
           node-version: '12'
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Build icons
         run: yarn build:icons
       - name: Build themes
@@ -89,7 +93,7 @@ jobs:
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.1
         with:
-          alias: deploy-preview-${{ github.event.number }}
+          alias: ecl-preview-${{ github.event.number }}
           publish-dir: 'dist/website'
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
           alias: ${{ github.head_ref }}
           publish-dir: 'dist/website'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: 'Deploy from GitHub Actions'
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,72 @@ on:
     types: [opened, synchronize]
 
 jobs:
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - name: Test
+        run: ./scripts/audit.sh
+  conventions:
+    name: code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - name: Build icons
+        run: yarn build:icons
+      - name: Build themes
+        run: yarn build:themes
+      - name: Build presets
+        run: yarn build:presets
+      - name: Test
+        run: yarn test:coding-conventions
+  examples:
+    name: examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - name: Build icons
+        run: yarn build:icons
+      - name: Build themes
+        run: yarn build:themes
+      - name: Build presets
+        run: yarn build:presets
+      - name: Test webpack4
+        run: cd examples/webpack4 && yarn build --display=errors-only
+      - name: Test webpack4-eu
+        run: cd ../webpack4-eu && yarn build --display=errors-only
+  size:
+    name: size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - name: Clean
+        run: yarn clean
+      - name: Build themes
+        run: yarn build:themes
+      - name: Build presets
+        run: yarn build:presets
+      - name: Test
+        run: size-limit
   deploy:
-    name: netlify preview
+    name: preview
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +89,7 @@ jobs:
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.1
         with:
-          alias: ${{ github.head_ref }}
+          alias: deploy-preview-${{ github.event.number }}
           publish-dir: 'dist/website'
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build icons
@@ -54,16 +44,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build icons
@@ -85,16 +65,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build themes
@@ -112,16 +82,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build icons

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Test webpack4
         run: cd examples/webpack4 && yarn build --display=errors-only
       - name: Test webpack4-eu
-        run: cd ../webpack4-eu && yarn build --display=errors-only
+        run: cd examples/webpack4-eu && yarn build --display=errors-only
   size:
     name: size
     runs-on: ubuntu-latest
@@ -72,7 +72,7 @@ jobs:
       - name: Build presets
         run: yarn build:presets
       - name: Test
-        run: size-limit
+        run: yarn size-limit
   deploy:
     name: preview
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build icons
@@ -44,6 +54,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build icons
@@ -65,6 +85,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build themes
@@ -82,6 +112,16 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '12'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build icons


### PR DESCRIPTION
- New pattern `https://ecl-preview-{pull-request-id}--europa-component-library.netlify.app`
- Drone still deploys branch name
- the 2 CI systems are separate, failing drone is backed up by actions
- actions status checks are non-blocking for v2 branch (see repo settings)