### PR TITLE
fix(skip-link): put skip link in full preset - FRONT-1224

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/package.json
@@ -59,6 +59,7 @@
     "@ecl/ec-component-page-header-standardised": "^2.30.0",
     "@ecl/ec-component-pagination": "^2.30.0",
     "@ecl/ec-component-search-form": "^2.30.0",
+    "@ecl/ec-component-skip-link": "^2.30.0",
     "@ecl/ec-component-site-header": "^2.30.0",
     "@ecl/ec-component-site-header-core": "^2.30.0",
     "@ecl/ec-component-site-header-harmonised": "^2.30.0",

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev-print.scss
@@ -26,6 +26,7 @@
 @import '@ecl/ec-component-label/ec-component-label-print';
 @import '@ecl/ec-component-link/ec-component-link-print';
 @import '@ecl/ec-component-message/ec-component-message-print';
+@import '@ecl/ec-component-skip-link/ec-component-skip-link-print';
 @import '@ecl/ec-component-site-switcher/ec-component-site-switcher-print';
 @import '@ecl/ec-component-table/ec-component-table-print';
 @import '@ecl/ec-component-tag/ec-component-tag-print';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-dev/src/ec-preset-dev.scss
@@ -19,6 +19,7 @@
 @import '@ecl/ec-component-form-text-area/ec-component-form-text-area';
 @import '@ecl/ec-component-form-form-group/ec-component-form-form-group';
 @import '@ecl/ec-component-form-checkbox/ec-component-form-checkbox';
+
 // Other atoms
 @import '@ecl/ec-component-blockquote/ec-component-blockquote';
 @import '@ecl/ec-component-button/ec-component-button';
@@ -26,6 +27,7 @@
 @import '@ecl/ec-component-label/ec-component-label';
 @import '@ecl/ec-component-link/ec-component-link';
 @import '@ecl/ec-component-message/ec-component-message';
+@import '@ecl/ec-component-skip-link/ec-component-skip-link';
 @import '@ecl/ec-component-site-switcher/ec-component-site-switcher';
 @import '@ecl/ec-component-table/ec-component-table';
 @import '@ecl/ec-component-tag/ec-component-tag';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy-website/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy-website/package.json
@@ -27,7 +27,6 @@
     "@ecl/ec-component-dropdown-legacy": "^2.30.0",
     "@ecl/ec-component-list": "^2.30.0",
     "@ecl/ec-component-menu-legacy": "^2.30.0",
-    "@ecl/ec-component-skip-link": "^2.30.0",
     "@ecl/ec-component-timeline": "^2.30.0",
     "@ecl/ec-preset-dev": "^2.30.0",
     "@ecl/ec-resources-icons": "^2.30.0",

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy-website/src/ec-preset-legacy-website-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy-website/src/ec-preset-legacy-website-print.scss
@@ -18,5 +18,4 @@ $ecl-check-imports-warn: true;
 @import '@ecl/ec-component-dropdown-legacy/ec-component-dropdown-legacy-print';
 @import '@ecl/ec-component-list/ec-component-list-print';
 @import '@ecl/ec-component-menu-legacy/ec-component-menu-legacy-print';
-@import '@ecl/ec-component-skip-link/ec-component-skip-link-print';
 @import '@ecl/ec-component-timeline/ec-component-timeline-print';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy-website/src/ec-preset-legacy-website.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy-website/src/ec-preset-legacy-website.scss
@@ -18,7 +18,6 @@ $ecl-check-imports-warn: true;
 @import '@ecl/ec-component-dropdown-legacy/ec-component-dropdown-legacy';
 @import '@ecl/ec-component-list/ec-component-list';
 @import '@ecl/ec-component-menu-legacy/ec-component-menu-legacy';
-@import '@ecl/ec-component-skip-link/ec-component-skip-link';
 @import '@ecl/ec-component-timeline/ec-component-timeline';
 @import '@ecl/ec-utility-colorize/ec-utility-colorize';
 @import '@ecl/ec-utility-font-size/ec-utility-font-size';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy/package.json
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy/package.json
@@ -24,7 +24,6 @@
     "@ecl/ec-component-dropdown-legacy": "^2.30.0",
     "@ecl/ec-component-list": "^2.30.0",
     "@ecl/ec-component-menu-legacy": "^2.30.0",
-    "@ecl/ec-component-skip-link": "^2.30.0",
     "@ecl/ec-component-timeline": "^2.30.0",
     "@ecl/ec-preset-dev": "^2.30.0",
     "@ecl/ec-resources-icons": "^2.30.0",

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy/src/ec-preset-legacy-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy/src/ec-preset-legacy-print.scss
@@ -12,5 +12,4 @@ $ecl-check-imports-warn: true;
 @import '@ecl/ec-component-dropdown-legacy/ec-component-dropdown-legacy-print';
 @import '@ecl/ec-component-list/ec-component-list-print';
 @import '@ecl/ec-component-menu-legacy/ec-component-menu-legacy-print';
-@import '@ecl/ec-component-skip-link/ec-component-skip-link-print';
 @import '@ecl/ec-component-timeline/ec-component-timeline-print';

--- a/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy/src/ec-preset-legacy.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-preset-legacy/src/ec-preset-legacy.scss
@@ -12,7 +12,6 @@ $ecl-check-imports-warn: true;
 @import '@ecl/ec-component-dropdown-legacy/ec-component-dropdown-legacy';
 @import '@ecl/ec-component-list/ec-component-list';
 @import '@ecl/ec-component-menu-legacy/ec-component-menu-legacy';
-@import '@ecl/ec-component-skip-link/ec-component-skip-link';
 @import '@ecl/ec-component-timeline/ec-component-timeline';
 @import '@ecl/ec-utility-colorize/ec-utility-colorize';
 @import '@ecl/ec-utility-font-size/ec-utility-font-size';

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-dev/package.json
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-dev/package.json
@@ -38,6 +38,7 @@
     "@ecl/eu-component-form-help-block": "^2.30.0",
     "@ecl/eu-component-form-label": "^2.30.0",
     "@ecl/eu-component-form-radio": "^2.30.0",
+    "@ecl/eu-component-skip-link": "^2.30.0",
     "@ecl/eu-component-form-select": "^2.30.0",
     "@ecl/eu-component-form-text-area": "^2.30.0",
     "@ecl/eu-component-form-text-input": "^2.30.0",

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-dev/src/eu-preset-dev-print.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-dev/src/eu-preset-dev-print.scss
@@ -26,6 +26,7 @@
 @import '@ecl/eu-component-label/eu-component-label-print';
 @import '@ecl/eu-component-link/eu-component-link-print';
 @import '@ecl/eu-component-message/eu-component-message-print';
+@import '@ecl/eu-component-skip-link/eu-component-skip-link-print';
 @import '@ecl/eu-component-table/eu-component-table-print';
 @import '@ecl/eu-component-tag/eu-component-tag-print';
 

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-dev/src/eu-preset-dev.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-dev/src/eu-preset-dev.scss
@@ -19,6 +19,7 @@
 @import '@ecl/eu-component-form-text-area/eu-component-form-text-area';
 @import '@ecl/eu-component-form-form-group/eu-component-form-form-group';
 @import '@ecl/eu-component-form-checkbox/eu-component-form-checkbox';
+
 // Other atoms
 @import '@ecl/eu-component-blockquote/eu-component-blockquote';
 @import '@ecl/eu-component-button/eu-component-button';
@@ -26,6 +27,7 @@
 @import '@ecl/eu-component-label/eu-component-label';
 @import '@ecl/eu-component-link/eu-component-link';
 @import '@ecl/eu-component-message/eu-component-message';
+@import '@ecl/eu-component-skip-link/eu-component-skip-link';
 @import '@ecl/eu-component-table/eu-component-table';
 @import '@ecl/eu-component-tag/eu-component-tag';
 

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy-website/package.json
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy-website/package.json
@@ -27,7 +27,6 @@
     "@ecl/eu-component-dropdown-legacy": "^2.30.0",
     "@ecl/eu-component-list": "^2.30.0",
     "@ecl/eu-component-menu-legacy": "^2.30.0",
-    "@ecl/eu-component-skip-link": "^2.30.0",
     "@ecl/eu-component-timeline": "^2.30.0",
     "@ecl/eu-preset-dev": "^2.30.0",
     "@ecl/eu-resources-icons": "^2.30.0",

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy-website/src/eu-preset-legacy-website-print.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy-website/src/eu-preset-legacy-website-print.scss
@@ -18,5 +18,4 @@ $ecl-check-imports-warn: true;
 @import '@ecl/eu-component-dropdown-legacy/eu-component-dropdown-legacy-print';
 @import '@ecl/eu-component-list/eu-component-list-print';
 @import '@ecl/eu-component-menu-legacy/eu-component-menu-legacy-print';
-@import '@ecl/eu-component-skip-link/eu-component-skip-link-print';
 @import '@ecl/eu-component-timeline/eu-component-timeline-print';

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy-website/src/eu-preset-legacy-website.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy-website/src/eu-preset-legacy-website.scss
@@ -18,7 +18,6 @@ $ecl-check-imports-warn: true;
 @import '@ecl/eu-component-dropdown-legacy/eu-component-dropdown-legacy';
 @import '@ecl/eu-component-list/eu-component-list';
 @import '@ecl/eu-component-menu-legacy/eu-component-menu-legacy';
-@import '@ecl/eu-component-skip-link/eu-component-skip-link';
 @import '@ecl/eu-component-timeline/eu-component-timeline';
 @import '@ecl/eu-utility-colorize/eu-utility-colorize';
 @import '@ecl/eu-utility-font-size/eu-utility-font-size';

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy/package.json
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy/package.json
@@ -24,7 +24,6 @@
     "@ecl/eu-component-dropdown-legacy": "^2.30.0",
     "@ecl/eu-component-list": "^2.30.0",
     "@ecl/eu-component-menu-legacy": "^2.30.0",
-    "@ecl/eu-component-skip-link": "^2.30.0",
     "@ecl/eu-component-timeline": "^2.30.0",
     "@ecl/eu-preset-dev": "^2.30.0",
     "@ecl/eu-resources-icons": "^2.30.0",

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy/src/eu-preset-legacy-print.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy/src/eu-preset-legacy-print.scss
@@ -12,5 +12,4 @@ $ecl-check-imports-warn: true;
 @import '@ecl/eu-component-dropdown-legacy/eu-component-dropdown-legacy-print';
 @import '@ecl/eu-component-list/eu-component-list-print';
 @import '@ecl/eu-component-menu-legacy/eu-component-menu-legacy-print';
-@import '@ecl/eu-component-skip-link/eu-component-skip-link-print';
 @import '@ecl/eu-component-timeline/eu-component-timeline-print';

--- a/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy/src/eu-preset-legacy.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-preset-legacy/src/eu-preset-legacy.scss
@@ -12,7 +12,6 @@ $ecl-check-imports-warn: true;
 @import '@ecl/eu-component-dropdown-legacy/eu-component-dropdown-legacy';
 @import '@ecl/eu-component-list/eu-component-list';
 @import '@ecl/eu-component-menu-legacy/eu-component-menu-legacy';
-@import '@ecl/eu-component-skip-link/eu-component-skip-link';
 @import '@ecl/eu-component-timeline/eu-component-timeline';
 @import '@ecl/eu-utility-colorize/eu-utility-colorize';
 @import '@ecl/eu-utility-font-size/eu-utility-font-size';


### PR DESCRIPTION
# PR description

Put skip link in all "standard" presets, and no longer in legacy (the component is not marked as deprecated)
