### PR TITLE
fix(banners): update links in usage page - FRONT-1600

### DIFF
--- a/src/website/src/pages/ec/components/banners/hero-banner/docs/usage.mdx
+++ b/src/website/src/pages/ec/components/banners/hero-banner/docs/usage.mdx
@@ -62,7 +62,7 @@ import { Paragraph, Link, Anatomy } from '@ecl/website-components';
 - **always use a short, distinct and indicative heading**
 - select **an appropriate image**, that is of high quality, suggestive, complementary and relevant for the related content
 - **keep in mind the font-to-background contrast ratio**, this improves a page's readability (e.g. dark backgrounds - white text / light backgrounds - black text)
-- **if using an image banner, make sure the highlight or main object within the image is visible** (text alignment & variants, see <Link to="/ec/components/banners/hero-banner/code/">playground</Link>)
+- **if using an image banner, make sure the highlight or main object within the image is visible** (text alignment & variants, see <Link to="/playground/ec/?path=/story/components-banners-hero-banner--image-box">playground</Link>)
 
 ## Don'ts
 

--- a/src/website/src/pages/ec/components/banners/page-banner/docs/usage.mdx
+++ b/src/website/src/pages/ec/components/banners/page-banner/docs/usage.mdx
@@ -62,7 +62,7 @@ import { Paragraph, Link, Anatomy } from '@ecl/website-components';
 - **always use a short, distinct and indicative heading**
 - select **an appropriate image**, that is of high quality, suggestive, complementary and relevant for the related content
 - **keep in mind the font-to-background contrast ratio**, this improves a page's readability (e.g. dark backgrounds - white text / light backgrounds - black text)
-- **if using an image banner, make sure the highlight or main object within the image is visible** (text alignment & variants, see <Link to="/ec/components/banners/page-banner/code/">playground</Link>)
+- **if using an image banner, make sure the highlight or main object within the image is visible** (text alignment & variants, see <Link to="/playground/ec/?path=/story/components-banners-page-banner--image-box">playground</Link>)
 
 ## Don'ts
 

--- a/src/website/src/website-components/Anatomy/Anatomy.jsx
+++ b/src/website/src/website-components/Anatomy/Anatomy.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import iconSprite from '@ecl/ec-resources-icons/dist/sprites/icons.svg';
 
 import Col from '../../components/Grid/Col';
@@ -81,8 +82,8 @@ const Anatomy = ({
                 <li
                   className={`${styles.legend__item} ${styles['legend__item-last']}`}
                 >
-                  <a
-                    href={additionalLink.href}
+                  <Link
+                    to={additionalLink.href}
                     className={`${styles.link} ${styles['link--icon']} ${styles['playground-link']}`}
                   >
                     <span className={styles.link__label}>
@@ -95,7 +96,7 @@ const Anatomy = ({
                     >
                       <use xlinkHref={`${iconSprite}#ui--corner-arrow`} />
                     </svg>
-                  </a>
+                  </Link>
                 </li>
               )}
             </ul>


### PR DESCRIPTION
# PR description

- link "showcase" was broken on production (worked fine on test environment)
- link "playground" now leads to storybook instead of the showcase

That's quite hard to test, as the URL pattern is not the same between production and preview, but with these modifications, it should work in both cases