### PR TITLE
fix(select): allows several multiple select lists - FRONT-1579

### DIFF
--- a/src/systems/ec/implementations/react/components/select/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/select/stories/Index.jsx
@@ -109,6 +109,7 @@ export const Multiple = () => {
       data-ecl-select-default={defaultText}
       data-ecl-select-search={searchText}
       data-ecl-select-all={selectAllText}
+      data-ecl-auto-init="Select"
     />
   );
 };

--- a/src/systems/ec/implementations/react/templates/pages/search/src/SearchPage.jsx
+++ b/src/systems/ec/implementations/react/templates/pages/search/src/SearchPage.jsx
@@ -105,7 +105,6 @@ const SearchPage = () => (
               id="select-multiple"
               label="Content type"
               groupClassName="ecl-u-mt-m"
-              helperText="Helper text"
               invalidText="No results"
               width="m"
               multiple
@@ -126,6 +125,38 @@ const SearchPage = () => (
                 {
                   value: '4',
                   label: 'Meetings',
+                },
+              ]}
+              data-ecl-auto-init="Select"
+              multiplePlaceholder="Placeholder text"
+              multipleSearchText="Search"
+              multipleAllText="Select all"
+              data-ecl-select-multiple="true"
+            />
+            <Select
+              id="select-multiple-2"
+              label="Topic"
+              groupClassName="ecl-u-mt-m"
+              invalidText="No results"
+              width="m"
+              multiple
+              className="ecl-select"
+              options={[
+                {
+                  value: '1',
+                  label: 'Economy',
+                },
+                {
+                  value: '2',
+                  label: 'Agriculture',
+                },
+                {
+                  value: '3',
+                  label: 'Climate action',
+                },
+                {
+                  value: '4',
+                  label: 'Environment',
                 },
               ]}
               data-ecl-auto-init="Select"

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-form-select/ec-component-form-select.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-form-select/ec-component-form-select.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-return-assign */
-import { queryOne } from '@ecl/ec-base/helpers/dom';
 import iconSvgUiCheck from '@ecl/ec-resources-icons/dist/svg/ui/check.svg';
 import iconSvgUiCornerArrow from '@ecl/ec-resources-icons/dist/svg/ui/corner-arrow.svg';
 
@@ -191,7 +190,7 @@ export class Select {
    * Initialise component.
    */
   init() {
-    this.select = queryOne(this.selectMultipleSelector);
+    this.select = this.element;
     const containerClasses = Array.from(this.select.parentElement.classList);
     this.textDefault =
       this.defaultText || this.element.getAttribute(this.defaultTextAttribute);

--- a/src/systems/eu/implementations/react/components/select/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/select/stories/Index.jsx
@@ -109,6 +109,7 @@ export const Multiple = () => {
       data-ecl-select-default={defaultText}
       data-ecl-select-search={searchText}
       data-ecl-select-all={selectAllText}
+      data-ecl-auto-init="Select"
     />
   );
 };

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-form-select/eu-component-form-select.js
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-form-select/eu-component-form-select.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-return-assign */
-import { queryOne } from '@ecl/eu-base/helpers/dom';
 import iconSvgUiCheck from '@ecl/eu-resources-icons/dist/svg/ui/check.svg';
 import iconSvgUiCornerArrow from '@ecl/eu-resources-icons/dist/svg/ui/corner-arrow.svg';
 
@@ -191,7 +190,7 @@ export class Select {
    * Initialise component.
    */
   init() {
-    this.select = queryOne(this.selectMultipleSelector);
+    this.select = this.element;
     const containerClasses = Array.from(this.select.parentElement.classList);
     this.textDefault =
       this.defaultText || this.element.getAttribute(this.defaultTextAttribute);


### PR DESCRIPTION
# PR description

Fixes a bug which prevented two or more multiple select lists to be displayed on the same screen
Examples have been updated too, to add missing auto init attribute

To test: use the provided html file. Just make sure to copy the css and js from the dist folder to the same place as the html file
[select.zip](https://github.com/ec-europa/europa-component-library/files/5255298/select.zip)
