### PR TITLE
feat(tags): updat usage page and tag variants - FRONT-1334

### DIFF
--- a/src/systems/ec/implementations/react/components/tag/src/Tag.jsx
+++ b/src/systems/ec/implementations/react/components/tag/src/Tag.jsx
@@ -20,7 +20,7 @@ const Tag = ({
   let TagName = href ? 'a' : 'button';
   const TagNameIcon = TagName;
 
-  if (variant === 'removable') {
+  if (variant === 'removable' || variant === 'display') {
     TagName = 'span';
   }
 

--- a/src/systems/ec/implementations/react/components/tag/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/components/tag/stories/Index.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 
+import demoDataDisplay from '@ecl/ec-specs-tag/demo/data--display';
 import demoDataLink from '@ecl/ec-specs-tag/demo/data--link';
-import demoDataButton from '@ecl/ec-specs-tag/demo/data--button';
 import demoDataRemovable from '@ecl/ec-specs-tag/demo/data--removable';
 
 import Tag from '../src/Tag';
@@ -12,23 +12,23 @@ export default {
   decorators: [withKnobs],
 };
 
-export const AsALink = () => (
+export const Display = () => (
+  <Tag label={text('Label', demoDataDisplay.label)} variant="display" />
+);
+
+Display.story = {
+  name: 'display tag',
+};
+
+export const Link = () => (
   <Tag
     label={text('Label', demoDataLink.label)}
     href={text('Link', demoDataLink.href)}
   />
 );
 
-AsALink.story = {
-  name: 'as a link',
-};
-
-export const AsAButton = () => (
-  <Tag label={text('Label', demoDataButton.label)} type="button" />
-);
-
-AsAButton.story = {
-  name: 'as a button',
+Link.story = {
+  name: 'link tag',
 };
 
 export const Removable = () => (
@@ -40,5 +40,5 @@ export const Removable = () => (
 );
 
 Removable.story = {
-  name: 'removable',
+  name: 'removable tag',
 };

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-tag/ec-component-tag.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-tag/ec-component-tag.scss
@@ -35,6 +35,10 @@
     }
   }
 
+  .ecl-tag--display {
+    text-decoration: none;
+  }
+
   .ecl-tag--removable {
     pointer-events: none;
     text-decoration: none;

--- a/src/systems/ec/specs/components/tag/demo/data--display.js
+++ b/src/systems/ec/specs/components/tag/demo/data--display.js
@@ -1,0 +1,3 @@
+module.exports = {
+  label: 'Display tag',
+};

--- a/src/systems/eu/implementations/react/components/tag/src/Tag.jsx
+++ b/src/systems/eu/implementations/react/components/tag/src/Tag.jsx
@@ -20,7 +20,7 @@ const Tag = ({
   let TagName = href ? 'a' : 'button';
   const TagNameIcon = TagName;
 
-  if (variant === 'removable') {
+  if (variant === 'removable' || variant === 'display') {
     TagName = 'span';
   }
 

--- a/src/systems/eu/implementations/react/components/tag/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/components/tag/stories/Index.jsx
@@ -1,28 +1,44 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { withKnobs, text } from '@storybook/addon-knobs';
 
+import demoDataDisplay from '@ecl/eu-specs-tag/demo/data--display';
 import demoDataLink from '@ecl/eu-specs-tag/demo/data--link';
-import demoDataButton from '@ecl/eu-specs-tag/demo/data--button';
 import demoDataRemovable from '@ecl/eu-specs-tag/demo/data--removable';
 
 import Tag from '../src/Tag';
 
-storiesOf('Components/Tag', module)
-  .addDecorator(withKnobs)
-  .add('as a link', () => (
-    <Tag
-      label={text('Label', demoDataLink.label)}
-      href={text('Link', demoDataLink.href)}
-    />
-  ))
-  .add('as a button', () => (
-    <Tag label={text('Label', demoDataButton.label)} type="button" />
-  ))
-  .add('removable', () => (
-    <Tag
-      label={text('Label', demoDataRemovable.label)}
-      variant="removable"
-      dismissButtonLabel={demoDataRemovable.dismissButtonLabel}
-    />
-  ));
+export default {
+  title: 'Components/Tag',
+  decorators: [withKnobs],
+};
+
+export const Display = () => (
+  <Tag label={text('Label', demoDataDisplay.label)} variant="display" />
+);
+
+Display.story = {
+  name: 'display tag',
+};
+
+export const Link = () => (
+  <Tag
+    label={text('Label', demoDataLink.label)}
+    href={text('Link', demoDataLink.href)}
+  />
+);
+
+Link.story = {
+  name: 'link tag',
+};
+
+export const Removable = () => (
+  <Tag
+    label={text('Label', demoDataRemovable.label)}
+    variant="removable"
+    dismissButtonLabel={demoDataRemovable.dismissButtonLabel}
+  />
+);
+
+Removable.story = {
+  name: 'removable tag',
+};

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-tag/eu-component-tag.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-tag/eu-component-tag.scss
@@ -35,6 +35,10 @@
     }
   }
 
+  .ecl-tag--display {
+    text-decoration: none;
+  }
+
   .ecl-tag--removable {
     pointer-events: none;
     text-decoration: none;

--- a/src/systems/eu/specs/components/tag/demo/data--display.js
+++ b/src/systems/eu/specs/components/tag/demo/data--display.js
@@ -1,0 +1,3 @@
+module.exports = {
+  label: 'Display tag',
+};

--- a/src/website/src/pages/ec/components/tag/docs/code.mdx
+++ b/src/website/src/pages/ec/components/tag/docs/code.mdx
@@ -6,20 +6,23 @@ order: 2
 import Playground from '@ecl/website-components/Playground';
 import Tag from '@ecl/ec-react-component-tag';
 
+import demoContentDisplay from '@ecl/ec-specs-tag/demo/data--display';
 import demoContentLink from '@ecl/ec-specs-tag/demo/data--link';
 import demoContentRemovable from '@ecl/ec-specs-tag/demo/data--removable';
 
-## Link
+## Display tag
 
-When the click on the tag leads to another page.
+<Playground system="ec" selectedKind="components-tag" selectedStory="display">
+  <Tag {...demoContentDisplay} variant="display" />
+</Playground>
 
-<Playground system="ec" selectedKind="components-tag" selectedStory="as-a-link">
+## Link tag
+
+<Playground system="ec" selectedKind="components-tag" selectedStory="link">
   <Tag {...demoContentLink} />
 </Playground>
 
-## Removable
-
-When using the `removable` variant, the tag gets a "Remove" icon. It can be either a button or a link, dependening on your need.
+## Removable tag
 
 <Playground system="ec" selectedKind="components-tag" selectedStory="removable">
   <Tag {...demoContentRemovable} variant="removable" />

--- a/src/website/src/pages/ec/components/tag/docs/usage.mdx
+++ b/src/website/src/pages/ec/components/tag/docs/usage.mdx
@@ -3,52 +3,146 @@ title: Usage
 order: 1
 ---
 
-import { Paragraph } from '@ecl/website-components';
+import { Paragraph, Anatomy } from '@ecl/website-components';
 
 <Paragraph size="lead">
-  Tags are used to provide contextual information; find related content using
-  keywords, labels or links. Tags are also used as keywords in search boxes,
-  filters and category lists. In some cases, they can be added or removed by the
-  user.
+  Tags are <strong>components that indicate a taxonomy type</strong>. They can
+  be found in different variants, offering a different interaction type, based
+  on the use-case.
 </Paragraph>
 
-## Anatomy
+<h2 id="display">Display tag(s)</h2>
 
-There are 2 variants of tags to accommodate different needs.
+### Introduction
 
-### Link tags
+**Display tags only indicate the taxonomy term**, users cannot interact with them, as they are used only for display purposes.
 
-| Elements | Mandatory |
-| -------- | --------- |
-| label    | yes       |
-| URL-link | yes       |
+### Anatomy
 
-### Removable tags
+<Anatomy
+  image="https://inno-ecl.s3.amazonaws.com/media/images/EC/Tags/Tags%20-%20Display.png"
+  alt="Anatomy of display tags"
+  legend={{
+    items: [
+      {
+        color: '#404040',
+        label: 'mandatory',
+      },
+      {
+        color: '#004494',
+        label: 'optional',
+      },
+    ],
+  }}
+/>
 
-| Elements     | Mandatory |
-| ------------ | --------- |
-| label        | yes       |
-| dismiss icon | yes       |
+| Elements | Mandatory | Description                |
+| -------- | --------- | -------------------------- |
+| label    | yes       | **label** of the component |
 
-## When to use
+### Do's
 
-### Link tags
+- use **short, distinct and indicative labels**, representative for the taxonomy term
 
-- to navigate to another page/content.
-- to link current content to other related content.
-- to show information which helps a user make sense of the content on the page, such as filter parameters or object metadata.
-- to display information that clarifies the content on the page, such as metadata.
-- to showcase the specific attributes of an item.
-- to display applied filters or options.
+### Don'ts
 
-### Removable tags
+- don't use abstract or elaborate terms, unless they are contextual to content presented on the page
 
-- to dismiss a tag from a search query, for example search filters, facets...
+### When to use
 
-## When not to use
+- when tags can **offer complementary information** associated to the page's content
 
-### Link tags
+### When not to use
 
-- avoid using too many tags as they might cause a visual overload.
-- avoid using tags that are too long (more than 3 words).
-- don’t use tags that are redundant.
+- do not use when you need to link to another page - use [Link tag(s)](#link) instead
+- do not use for search filters that can be removed - use [Removable tag(s)](#removable) instead
+
+<h2 id="link">Link tag(s)</h2>
+
+### Introduction
+
+**Link tags provide users with further navigation**, related to the context in which they are used.
+
+### Anatomy
+
+<Anatomy
+  image="https://inno-ecl.s3.amazonaws.com/media/images/EC/Tags/Tags%20-%20Link.png"
+  alt="Anatomy of link tags"
+  legend={{
+    items: [
+      {
+        color: '#404040',
+        label: 'mandatory',
+      },
+      {
+        color: '#004494',
+        label: 'optional',
+      },
+    ],
+  }}
+/>
+
+| Elements | Mandatory | Description                         |
+| -------- | --------- | ----------------------------------- |
+| link     | yes       | **link** to internal page or source |
+
+### Do's
+
+- use **short, distinct and indicative links**, representative for the content you are linking to
+
+### Don'ts
+
+- do not use unless there is an internal page where further related information is found
+
+### When to use
+
+- **for navigation**, when the tags link to pages relevant to the content presented on the page
+
+### When not to use
+
+- do not use when the tags are only for display purposes - use [Display tag(s)](#display) instead
+- do not use for search filters that can be removed - use [Removable tag(s)](#removable) instead
+
+<h2 id="removable">Removable tag(s)</h2>
+
+### Introduction
+
+**Removable tags are used as an indicator for performed searches**. When they are removed (via the close button - icon), the taxonomy term used as a filter will be removed as well.
+
+### Anatomy
+
+<Anatomy
+  image="https://inno-ecl.s3.amazonaws.com/media/images/EC/Tags/Tags%20-%20Removable.png"
+  alt="Anatomy of removable tags"
+  legend={{
+    items: [
+      {
+        color: '#404040',
+        label: 'mandatory',
+      },
+      {
+        color: '#004494',
+        label: 'optional',
+      },
+    ],
+  }}
+/>
+
+| Elements | Mandatory | Description                                             |
+| -------- | --------- | ------------------------------------------------------- |
+| label    | yes       | **label** of the component                              |
+| icon     | no        | **affordance or action indicator** for removing the tag |
+
+### Do's
+
+- use **short, distinct and indicative labels**, representative for the content you are linking to
+- make sure the tag matches the filter option used in the search query
+
+### When to use
+
+- **use on list/pool pages**, where search queries can be seen through the tags, and removed accordingly
+
+### When not to use
+
+- do not use when the tags are only for display purposes - use [Display tag(s)](#display) instead
+- do not use when you need to link to another page - use [Link tag(s)](#link) instead


### PR DESCRIPTION
# PR description

specs: https://citnet.tech.ec.europa.eu/CITnet/confluence/display/NEXTEUROPA/2020-07+Tags+-+ECL+Page+-+final

main modifications:
- usage page updated
- new variant "display"
- variant "button" is considered deprecated (but will still work)