### PR TITLE
chore(scss): remove import check - FRONT-1680

### DIFF
--- a/src/implementations/vanilla/packages/ec-base/ec-base.scss
+++ b/src/implementations/vanilla/packages/ec-base/ec-base.scss
@@ -1,2 +1,3 @@
 // Core variables & mixins
-@import './mixins/index';
+@import './mixins/breakpoints';
+@import './mixins/import-once';

--- a/src/implementations/vanilla/packages/ec-base/mixins/_import-once.scss
+++ b/src/implementations/vanilla/packages/ec-base/mixins/_import-once.scss
@@ -18,15 +18,3 @@ $imported-modules: () !default;
     @warn 'Module `#{$name}` has already been imported.';
   }
 }
-
-// Warn if external dependencies have not been imported yet
-@mixin check-imports($dependencies, $warn: $ecl-check-imports-warn) {
-  @if $warn == true {
-    @each $dep in $dependencies {
-      /* stylelint-disable-next-line */
-      @if (index($imported-modules, $dep) == null) {
-        @warn 'Module `#{$dep}` has not been imported yet.';
-      }
-    }
-  }
-}

--- a/src/implementations/vanilla/packages/ec-base/mixins/index.scss
+++ b/src/implementations/vanilla/packages/ec-base/mixins/index.scss
@@ -1,4 +1,0 @@
-// Import all ECL base mixins
-
-@import './breakpoints';
-@import './import-once';

--- a/src/implementations/vanilla/packages/ec-component-button/ec-component-button.scss
+++ b/src/implementations/vanilla/packages/ec-component-button/ec-component-button.scss
@@ -6,8 +6,6 @@
 // Import base
 @import '@ecl/ec-base/ec-base';
 
-@include check-imports(('ec-component-icon'));
-
 @mixin ecl-button(
   $_border-width: 2px,
   $_outline-width: 3px,


### PR DESCRIPTION
# PR description

remove scss import check

I tried to use scss' `@use` commend, which is the new way of importing files, but it seems that it is not supported yet by libsass (which we rely on).
So for now we should stick to `@import`