### PR TITLE
chore: correct storybook iframe styles

### DIFF
--- a/src/implementations/twig/storybook/.storybook/preview-head.html
+++ b/src/implementations/twig/storybook/.storybook/preview-head.html
@@ -31,9 +31,7 @@
     // Manually inject styles
     var head = document.head || document.getElementsByTagName('head')[0];
     head.appendChild(createLink('./styles/ec-core.css', 'screen'));
-    head.appendChild(createLink('./styles/eu-core.css', 'screen'));
     head.appendChild(createLink('./styles/ec-core-print.css', 'print'));
-    head.appendChild(createLink('./styles/eu-core-print.css', 'print'));
   }
 </script>
 <script type="text/javascript" src="./scripts/ec-core.js"></script>


### PR DESCRIPTION
It is not necessary and even wrong to load the eu without context

Example: expandable gets rounded corners because eu is loaded after ec:

![Screenshot from 2020-11-11 07-36-21](https://user-images.githubusercontent.com/1923476/98777263-b2927d00-23f0-11eb-8770-9a97792201f5.png)

`src/implementations/twig/storybook/.storybook/preview.js` has `withCssResources` which already suffice for toggling these classes in the storybook manager.

We'll probably need to rework this later to load only those resources actually needed in the playground component of the website.