### PR TITLE
feat(menu): update menu display and behavior - FRONT-1790

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-component-menu/ec-component-menu.js
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-menu/ec-component-menu.js
@@ -250,23 +250,6 @@ export class Menu {
       return false;
     }
 
-    // Check menu width and available space
-    const containerWidth = this.inner.getBoundingClientRect().width;
-
-    if (containerWidth === 0) {
-      return false;
-    }
-
-    const allItemsWidth = this.links
-      .map((link) => link.clientWidth)
-      .reduce((a, b) => a + b);
-
-    // If there is not enough space, mobile display is used
-    if (allItemsWidth === 0 || allItemsWidth > containerWidth) {
-      this.element.classList.add('ecl-menu--forced-mobile');
-      return false;
-    }
-
     // Everything is fine to use desktop display
     this.element.classList.remove('ecl-menu--forced-mobile');
     return true;

--- a/src/systems/ec/implementations/vanilla/packages/ec-component-menu/ec-component-menu.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-component-menu/ec-component-menu.scss
@@ -233,6 +233,7 @@
 
   .ecl-menu__link {
     align-items: center;
+    box-sizing: content-box;
     color: $ecl-color-white;
     display: inline-flex;
     font: $ecl-font-m;
@@ -309,10 +310,10 @@
         margin-right: 0;
         padding-left: $ecl-spacing-m;
         padding-right: $ecl-spacing-m;
-        white-space: nowrap; // Needed to check menu width and switch to mobile display
       }
 
       .ecl-menu__link-icon {
+        flex-shrink: 0;
         height: $ecl-icon-2-xs;
         margin-left: $ecl-spacing-xs;
         transform: rotate(180deg);
@@ -339,14 +340,17 @@
       .ecl-menu__link {
         background-color: transparent;
         border-bottom: 3px solid transparent;
+        box-sizing: border-box;
         color: $ecl-color-white;
         display: inline-flex;
+        height: 100%;
         padding-bottom: calc(#{$ecl-spacing-m} - 3px);
         padding-left: $ecl-spacing-m;
         padding-right: $ecl-spacing-m;
         padding-top: $ecl-spacing-m;
         transition-property: background-color, border-bottom-color, color,
           z-index;
+        width: auto;
         z-index: 0;
       }
 

--- a/src/systems/ec/specs/components/menu/demo/data--en.js
+++ b/src/systems/ec/specs/components/menu/demo/data--en.js
@@ -78,7 +78,7 @@ module.exports = {
         { label: 'Item 5.7', href: '/example' },
       ],
     },
-    /* {
+    {
       label: 'News and events',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
@@ -100,7 +100,7 @@ module.exports = {
         { label: 'Item 6.15', href: '/example' },
         { label: 'Item 6.16', href: '/example' },
       ],
-    }, */
+    },
     {
       label: 'Contact the EU',
       href: '/example',

--- a/src/systems/ec/specs/components/menu/demo/data--en.js
+++ b/src/systems/ec/specs/components/menu/demo/data--en.js
@@ -6,11 +6,12 @@ module.exports = {
   siteName: 'Site name',
   menuLink: '/example',
   items: [
-    { label: 'Home', href: '/example', isCurrent: true },
+    { label: 'Home', href: '/example' },
     {
-      label: 'Principles, countries, history',
+      label: 'Item 2',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
+      isCurrent: true,
       subItems: [
         { label: 'Item 2.1', href: '/example' },
         { label: 'Item 2.2', href: '/example' },
@@ -31,7 +32,7 @@ module.exports = {
       ],
     },
     {
-      label: 'Institutions, law, budget',
+      label: 'Item 3',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [
@@ -41,7 +42,7 @@ module.exports = {
       ],
     },
     {
-      label: 'Priorities and actions',
+      label: 'Item 4',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [
@@ -65,7 +66,7 @@ module.exports = {
       ],
     },
     {
-      label: 'Live, work, study',
+      label: 'Item 5',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [
@@ -79,7 +80,7 @@ module.exports = {
       ],
     },
     {
-      label: 'News and events',
+      label: 'Item 6',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [
@@ -102,7 +103,7 @@ module.exports = {
       ],
     },
     {
-      label: 'Contact the EU',
+      label: 'Item 7 with a long label',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [

--- a/src/systems/ec/specs/components/menu/demo/data--en.js
+++ b/src/systems/ec/specs/components/menu/demo/data--en.js
@@ -6,12 +6,11 @@ module.exports = {
   siteName: 'Site name',
   menuLink: '/example',
   items: [
-    { label: 'Home', href: '/example' },
+    { label: 'Home', href: '/example', isCurrent: true },
     {
-      label: 'Item 2',
+      label: 'Principles, countries, history',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
-      isCurrent: true,
       subItems: [
         { label: 'Item 2.1', href: '/example' },
         { label: 'Item 2.2', href: '/example' },
@@ -32,7 +31,7 @@ module.exports = {
       ],
     },
     {
-      label: 'Item 3',
+      label: 'Institutions, law, budget',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [
@@ -42,7 +41,7 @@ module.exports = {
       ],
     },
     {
-      label: 'Item 4',
+      label: 'Priorities and actions',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [
@@ -66,7 +65,7 @@ module.exports = {
       ],
     },
     {
-      label: 'Item 5',
+      label: 'Live, work, study',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [
@@ -79,8 +78,8 @@ module.exports = {
         { label: 'Item 5.7', href: '/example' },
       ],
     },
-    {
-      label: 'Item 6',
+    /* {
+      label: 'News and events',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [
@@ -101,9 +100,9 @@ module.exports = {
         { label: 'Item 6.15', href: '/example' },
         { label: 'Item 6.16', href: '/example' },
       ],
-    },
+    }, */
     {
-      label: 'Item 7 with a long label',
+      label: 'Contact the EU',
       href: '/example',
       hasSubmenuLabel: 'has submenu',
       subItems: [

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-menu/eu-component-menu.js
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-menu/eu-component-menu.js
@@ -250,23 +250,6 @@ export class Menu {
       return false;
     }
 
-    // Check menu width and available space
-    const containerWidth = this.inner.getBoundingClientRect().width;
-
-    if (containerWidth === 0) {
-      return false;
-    }
-
-    const allItemsWidth = this.links
-      .map((link) => link.clientWidth)
-      .reduce((a, b) => a + b);
-
-    // If there is not enough space, mobile display is used
-    if (allItemsWidth === 0 || allItemsWidth > containerWidth) {
-      this.element.classList.add('ecl-menu--forced-mobile');
-      return false;
-    }
-
     // Everything is fine to use desktop display
     this.element.classList.remove('ecl-menu--forced-mobile');
     return true;

--- a/src/systems/eu/implementations/vanilla/packages/eu-component-menu/eu-component-menu.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-component-menu/eu-component-menu.scss
@@ -233,6 +233,7 @@
 
   .ecl-menu__link {
     align-items: center;
+    box-sizing: content-box;
     color: $ecl-color-white;
     display: inline-flex;
     font: $ecl-font-m;
@@ -309,10 +310,10 @@
         margin-right: 0;
         padding-left: $ecl-spacing-m;
         padding-right: $ecl-spacing-m;
-        white-space: nowrap; // Needed to check menu width and switch to mobile display
       }
 
       .ecl-menu__link-icon {
+        flex-shrink: 0;
         height: $ecl-icon-2-xs;
         margin-left: $ecl-spacing-xs;
         transform: rotate(180deg);
@@ -339,14 +340,17 @@
       .ecl-menu__link {
         background-color: transparent;
         border-bottom: 3px solid transparent;
+        box-sizing: border-box;
         color: $ecl-color-white;
         display: inline-flex;
+        height: 100%;
         padding-bottom: calc(#{$ecl-spacing-m} - 3px);
         padding-left: $ecl-spacing-m;
         padding-right: $ecl-spacing-m;
         padding-top: $ecl-spacing-m;
         transition-property: background-color, border-bottom-color, color,
           z-index;
+        width: auto;
         z-index: 0;
       }
 


### PR DESCRIPTION
# PR description

Change behavior of menu on desktop, to display menu items on several lines if there is not enough space (and not turn them into hamburger menu)

preview: https://ecl-preview-1766--europa-component-library.netlify.app/playground/eu/iframe.html?id=components-navigation-menu--default&viewMode=story
to see the new behavior, edit the items' label in the inspector to have them displayed on more than one line.

Note that this modification is done on both EC and EU, but display of existing sites won't be affected, unless they had too many items already

The design has been approved by DG COMM (Geraud)
