### PR TITLE
fix(footers): remove reference to Brexit - FRONT-1794

### DIFF
--- a/src/systems/ec/specs/components/footer-core/demo/data.js
+++ b/src/systems/ec/specs/components/footer-core/demo/data.js
@@ -149,11 +149,6 @@ module.exports = {
           ariaLabel: 'Link to Legal notice',
           href: '/example',
         },
-        {
-          label: 'Brexit content disclaimer',
-          ariaLabel: 'Link to Brexit content disclaimer',
-          href: '/example',
-        },
       ],
     },
   },

--- a/src/systems/ec/specs/components/footer-harmonised/demo/data--group1.js
+++ b/src/systems/ec/specs/components/footer-harmonised/demo/data--group1.js
@@ -180,11 +180,6 @@ module.exports = {
           ariaLabel: 'Link to Legal notice',
           href: '/example',
         },
-        {
-          label: 'Brexit content disclaimer',
-          ariaLabel: 'Link to Brexit content disclaimer',
-          href: '/example',
-        },
       ],
     },
   },

--- a/src/systems/ec/specs/components/footer-harmonised/demo/data--group2.js
+++ b/src/systems/ec/specs/components/footer-harmonised/demo/data--group2.js
@@ -56,11 +56,6 @@ module.exports = {
           ariaLabel: 'Link to Legal notice',
           href: '/example',
         },
-        {
-          label: 'Brexit content disclaimer',
-          ariaLabel: 'Link to Brexit content disclaimer',
-          href: '/example',
-        },
       ],
     },
   },

--- a/src/systems/ec/specs/components/footer-standardised/demo/data.js
+++ b/src/systems/ec/specs/components/footer-standardised/demo/data.js
@@ -180,11 +180,6 @@ module.exports = {
           ariaLabel: 'Link to Legal notice',
           href: '/example',
         },
-        {
-          label: 'Brexit content disclaimer',
-          ariaLabel: 'Link to Brexit content disclaimer',
-          href: '/example',
-        },
       ],
     },
   },

--- a/src/systems/eu/specs/components/footer-core/demo/data.js
+++ b/src/systems/eu/specs/components/footer-core/demo/data.js
@@ -68,11 +68,6 @@ module.exports = {
             href: '/example',
           },
           {
-            label: 'Brexit content disclaimer',
-            ariaLabel: 'Link to Brexit content disclaimer',
-            href: '/example',
-          },
-          {
             label: 'Cookies',
             ariaLabel: 'Link to Cookies info',
             href: '/example',

--- a/src/systems/eu/specs/components/footer-harmonised/demo/data.js
+++ b/src/systems/eu/specs/components/footer-harmonised/demo/data.js
@@ -152,11 +152,6 @@ module.exports = {
             href: '/example',
           },
           {
-            label: 'Brexit content disclaimer',
-            ariaLabel: 'Link to Brexit content disclaimer',
-            href: '/example',
-          },
-          {
             label: 'Cookies',
             ariaLabel: 'Link to Cookies',
             href: '/example',

--- a/src/systems/eu/specs/components/footer-standardised/demo/data.js
+++ b/src/systems/eu/specs/components/footer-standardised/demo/data.js
@@ -152,11 +152,6 @@ module.exports = {
             href: '/example',
           },
           {
-            label: 'Brexit content disclaimer',
-            ariaLabel: 'Link to Brexit content disclaimer',
-            href: '/example',
-          },
-          {
             label: 'Cookies',
             ariaLabel: 'Link to Cookies',
             href: '/example',


### PR DESCRIPTION
# PR description

Update all footer demo to remove link about brexit

Note: usage pages will be updated at a later stage