### PR TITLE
chore: illustrate forward at rule

### DIFF
--- a/src/implementations/vanilla/components/button/button.scss
+++ b/src/implementations/vanilla/components/button/button.scss
@@ -5,15 +5,12 @@
 
 @use "sass:map";
 @use '@ecl/theme-dev/globals';
-@use '@ecl/theme-dev/maps/color';
-@use '@ecl/theme-dev/maps/shape';
-@use '@ecl/theme-dev/maps/spacing';
-@use '@ecl/theme-dev/maps/typography';
+@use '@ecl/theme-dev/theme';
 
 $_border-width: 2px;
 $_outline-width: 3px;
-$_padding-horizontal: map.get(spacing.$spacing, 'm');
-$_padding-vertical: map.get(spacing.$spacing, 's');
+$_padding-horizontal: map.get(theme.$spacing, 'm');
+$_padding-vertical: map.get(theme.$spacing, 's');
 
 .ecl-button {
   appearance: none;
@@ -21,15 +18,15 @@ $_padding-vertical: map.get(spacing.$spacing, 's');
   border-radius: map.get(
     (
       no: 0,
-      yes: map.get(shape.$border-radius, 'm'),
+      yes: map.get(theme.$border-radius, 'm'),
     ),
     globals.$border-radius
   );
   border-width: 0;
   box-sizing: border-box;
   display: inline-block;
-  font: map.get(typography.$font, 'm');
-  font-weight: map.get(typography.$font-weight, 'bold');
+  font: map.get(theme.$font, 'm');
+  font-weight: map.get(theme.$font-weight, 'bold');
   margin: 0;
   padding: $_padding-vertical $_padding-horizontal;
   text-decoration: none;
@@ -41,7 +38,7 @@ $_padding-vertical: map.get(spacing.$spacing, 's');
   }
 
   &:focus {
-    outline: $_outline-width solid map.get(color.$color, 'secondary');
+    outline: $_outline-width solid map.get(theme.$color, 'secondary');
     outline-offset: -($_outline-width);
   }
 
@@ -59,31 +56,31 @@ $_padding-vertical: map.get(spacing.$spacing, 's');
 
 .ecl-button__icon--before,
 .ecl-button__icon + .ecl-button__label {
-  margin-right: map.get(spacing.$spacing, 'xs');
+  margin-right: map.get(theme.$spacing, 'xs');
 }
 
 .ecl-button__icon--after,
 .ecl-button__label + .ecl-button__icon {
-  margin-left: map.get(spacing.$spacing, 'xs');
+  margin-left: map.get(theme.$spacing, 'xs');
 }
 
 /**
 * Primary
 */
 .ecl-button--primary {
-  background-color: map.get(color.$color, 'blue-100');
-  color: map.get(color.$color, 'white-100');
+  background-color: map.get(theme.$color, 'blue-100');
+  color: map.get(theme.$color, 'white-100');
 
   &:hover,
   &:active {
-    background-color: map.get(color.$color, 'blue-130');
+    background-color: map.get(theme.$color, 'blue-130');
   }
 
   &[disabled],
   &[disabled]:hover {
-    background-color: map.get(color.$color, 'blue-25');
-    border-color: map.get(color.$color, 'blue-25');
-    color: map.get(color.$color, 'white-100');
+    background-color: map.get(theme.$color, 'blue-25');
+    border-color: map.get(theme.$color, 'blue-25');
+    color: map.get(theme.$color, 'white-100');
   }
 }
 
@@ -91,23 +88,23 @@ $_padding-vertical: map.get(spacing.$spacing, 's');
 * Secondary
 */
 .ecl-button--secondary {
-  background-color: map.get(color.$color, 'white-100');
-  border: $_border-width solid map.get(color.$color, 'blue-100');
-  color: map.get(color.$color, 'blue-100');
+  background-color: map.get(theme.$color, 'white-100');
+  border: $_border-width solid map.get(theme.$color, 'blue-100');
+  color: map.get(theme.$color, 'blue-100');
   padding: calc(#{$_padding-vertical} - #{$_border-width})
     calc(#{$_padding-horizontal} - #{$_border-width});
 
   &:hover,
   &:active {
-    border-color: map.get(color.$color, 'blue-130');
-    color: map.get(color.$color, 'blue-130');
+    border-color: map.get(theme.$color, 'blue-130');
+    color: map.get(theme.$color, 'blue-130');
   }
 
   &[disabled],
   &[disabled]:hover {
-    background-color: map.get(color.$color, 'white-100');
-    border-color: map.get(color.$color, 'blue-25');
-    color: map.get(color.$color, 'blue-25');
+    background-color: map.get(theme.$color, 'white-100');
+    border-color: map.get(theme.$color, 'blue-25');
+    color: map.get(theme.$color, 'blue-25');
   }
 }
 
@@ -115,16 +112,16 @@ $_padding-vertical: map.get(spacing.$spacing, 's');
 * Ghost
 */
 .ecl-button--ghost {
-  color: map.get(color.$color, 'blue-100');
+  color: map.get(theme.$color, 'blue-100');
 
   &:hover,
   &:active {
-    color: map.get(color.$color, 'blue-130');
+    color: map.get(theme.$color, 'blue-130');
   }
 
   &[disabled],
   &[disabled]:hover {
-    color: map.get(color.$color, 'blue-25');
+    color: map.get(theme.$color, 'blue-25');
   }
 }
 
@@ -132,25 +129,25 @@ $_padding-vertical: map.get(spacing.$spacing, 's');
 * Call to action
 */
 .ecl-button--call {
-  background-color: map.get(color.$color, 'yellow-100');
-  color: map.get(color.$color, 'black-100');
+  background-color: map.get(theme.$color, 'yellow-100');
+  color: map.get(theme.$color, 'black-100');
 
   &:hover,
   &:active {
-    border: $_border-width solid map.get(color.$color, 'black-100');
+    border: $_border-width solid map.get(theme.$color, 'black-100');
     padding: calc(#{$_padding-vertical} - #{$_border-width})
       calc(#{$_padding-horizontal} - #{$_border-width});
   }
 
   &:focus {
-    outline-color: map.get(color.$color, 'black-100');
+    outline-color: map.get(theme.$color, 'black-100');
   }
 
   &[disabled],
   &[disabled]:hover {
-    background-color: map.get(color.$color, 'yellow-25');
-    border-color: map.get(color.$color, 'yellow-25');
-    color: map.get(color.$color, 'grey-50');
+    background-color: map.get(theme.$color, 'yellow-25');
+    border-color: map.get(theme.$color, 'yellow-25');
+    color: map.get(theme.$color, 'grey-50');
   }
 }
 
@@ -158,17 +155,17 @@ $_padding-vertical: map.get(spacing.$spacing, 's');
 * Search
 */
 .ecl-button--search {
-  background-color: map.get(color.$color, 'grey-10');
-  color: map.get(color.$color, 'blue-100');
+  background-color: map.get(theme.$color, 'grey-10');
+  color: map.get(theme.$color, 'blue-100');
 
   &:hover,
   &:active {
-    background-color: map.get(color.$color, 'grey-25');
+    background-color: map.get(theme.$color, 'grey-25');
   }
 
   &[disabled],
   &[disabled]:hover {
-    background-color: map.get(color.$color, 'grey-5');
-    color: map.get(color.$color, 'grey-50');
+    background-color: map.get(theme.$color, 'grey-5');
+    color: map.get(theme.$color, 'grey-50');
   }
 }

--- a/src/presets/dev/src/dev-print.scss
+++ b/src/presets/dev/src/dev-print.scss
@@ -2,68 +2,68 @@
 @use '@ecl/vanilla-component-icon/icon-print';
 
 // Forms
-@use '@ecl/vanilla-component-checkbox/checkbox-print';
-@use '@ecl/vanilla-component-file-upload/file-upload-print';
-@use '@ecl/vanilla-component-form/form-print';
-@use '@ecl/vanilla-component-radio/radio-print';
-@use '@ecl/vanilla-component-select/select-print';
-@use '@ecl/vanilla-component-text-area/text-area-print';
-@use '@ecl/vanilla-component-text-input/text-input-print';
-@use '@ecl/vanilla-component-datepicker/datepicker-print';
+// @use '@ecl/vanilla-component-checkbox/checkbox-print';
+// @use '@ecl/vanilla-component-file-upload/file-upload-print';
+// @use '@ecl/vanilla-component-form/form-print';
+// @use '@ecl/vanilla-component-radio/radio-print';
+// @use '@ecl/vanilla-component-select/select-print';
+// @use '@ecl/vanilla-component-text-area/text-area-print';
+// @use '@ecl/vanilla-component-text-input/text-input-print';
+// @use '@ecl/vanilla-component-datepicker/datepicker-print';
 
-// Other atoms
-@use '@ecl/vanilla-component-blockquote/blockquote-print';
-@use '@ecl/vanilla-component-button/button-print';
-@use '@ecl/vanilla-component-date-block/date-block-print';
-@use '@ecl/vanilla-component-label/label-print';
-@use '@ecl/vanilla-component-link/link-print';
-@use '@ecl/vanilla-component-message/message-print';
-@use '@ecl/vanilla-component-skip-link/skip-link-print';
-@use '@ecl/vanilla-component-table/table-print';
-@use '@ecl/vanilla-component-tag/tag-print';
+// // Other atoms
+// @use '@ecl/vanilla-component-blockquote/blockquote-print';
+// @use '@ecl/vanilla-component-button/button-print';
+// @use '@ecl/vanilla-component-date-block/date-block-print';
+// @use '@ecl/vanilla-component-label/label-print';
+// @use '@ecl/vanilla-component-link/link-print';
+// @use '@ecl/vanilla-component-message/message-print';
+// @use '@ecl/vanilla-component-skip-link/skip-link-print';
+// @use '@ecl/vanilla-component-table/table-print';
+// @use '@ecl/vanilla-component-tag/tag-print';
 
-// Molecules
-@use '@ecl/vanilla-component-hero-banner/hero-banner-print';
-@use '@ecl/vanilla-component-page-banner/page-banner-print';
-@use '@ecl/vanilla-component-card/card-print';
-@use '@ecl/vanilla-component-expandable/expandable-print';
-@use '@ecl/vanilla-component-fact-figures/fact-figures-print';
-@use '@ecl/vanilla-component-file/file-print';
-@use '@ecl/vanilla-component-footer-core/footer-core-print';
-@use '@ecl/vanilla-component-footer-harmonised/footer-harmonised-print';
-@use '@ecl/vanilla-component-footer-standardised/footer-standardised-print';
-@use '@ecl/vanilla-component-language-list/language-list-print';
-@use '@ecl/vanilla-component-media-container/media-container-print';
-@use '@ecl/vanilla-component-description-list/description-list-print';
-@use '@ecl/vanilla-component-ordered-list/ordered-list-print';
-@use '@ecl/vanilla-component-unordered-list/unordered-list-print';
-@use '@ecl/vanilla-component-pagination/pagination-print';
-@use '@ecl/vanilla-component-search-form/search-form';
-@use '@ecl/vanilla-component-social-media-follow/social-media-follow-print';
-@use '@ecl/vanilla-component-social-media-share/social-media-share-print';
-@use '@ecl/vanilla-component-timeline/timeline-print';
+// // Molecules
+// @use '@ecl/vanilla-component-hero-banner/hero-banner-print';
+// @use '@ecl/vanilla-component-page-banner/page-banner-print';
+// @use '@ecl/vanilla-component-card/card-print';
+// @use '@ecl/vanilla-component-expandable/expandable-print';
+// @use '@ecl/vanilla-component-fact-figures/fact-figures-print';
+// @use '@ecl/vanilla-component-file/file-print';
+// @use '@ecl/vanilla-component-footer-core/footer-core-print';
+// @use '@ecl/vanilla-component-footer-harmonised/footer-harmonised-print';
+// @use '@ecl/vanilla-component-footer-standardised/footer-standardised-print';
+// @use '@ecl/vanilla-component-language-list/language-list-print';
+// @use '@ecl/vanilla-component-media-container/media-container-print';
+// @use '@ecl/vanilla-component-description-list/description-list-print';
+// @use '@ecl/vanilla-component-ordered-list/ordered-list-print';
+// @use '@ecl/vanilla-component-unordered-list/unordered-list-print';
+// @use '@ecl/vanilla-component-pagination/pagination-print';
+// @use '@ecl/vanilla-component-search-form/search-form';
+// @use '@ecl/vanilla-component-social-media-follow/social-media-follow-print';
+// @use '@ecl/vanilla-component-social-media-share/social-media-share-print';
+// @use '@ecl/vanilla-component-timeline/timeline-print';
 
-// Organisms
-@use '@ecl/vanilla-component-accordion/accordion-print';
-@use '@ecl/vanilla-component-breadcrumb-core/breadcrumb-core-print';
-@use '@ecl/vanilla-component-breadcrumb-standardised/breadcrumb-standardised-print';
-@use '@ecl/vanilla-component-breadcrumb-harmonised/breadcrumb-harmonised-print';
-@use '@ecl/vanilla-component-gallery/gallery-print';
-@use '@ecl/vanilla-component-inpage-navigation/inpage-navigation';
-@use '@ecl/vanilla-component-menu/menu-print';
-@use '@ecl/vanilla-component-page-header-harmonised/page-header-harmonised-print';
-@use '@ecl/vanilla-component-page-header-standardised/page-header-standardised-print';
-@use '@ecl/vanilla-component-site-header-core/site-header-core-print';
-@use '@ecl/vanilla-component-site-header-harmonised/site-header-harmonised-print';
-@use '@ecl/vanilla-component-site-header-standardised/site-header-standardised-print';
+// // Organisms
+// @use '@ecl/vanilla-component-accordion/accordion-print';
+// @use '@ecl/vanilla-component-breadcrumb-core/breadcrumb-core-print';
+// @use '@ecl/vanilla-component-breadcrumb-standardised/breadcrumb-standardised-print';
+// @use '@ecl/vanilla-component-breadcrumb-harmonised/breadcrumb-harmonised-print';
+// @use '@ecl/vanilla-component-gallery/gallery-print';
+// @use '@ecl/vanilla-component-inpage-navigation/inpage-navigation';
+// @use '@ecl/vanilla-component-menu/menu-print';
+// @use '@ecl/vanilla-component-page-header-harmonised/page-header-harmonised-print';
+// @use '@ecl/vanilla-component-page-header-standardised/page-header-standardised-print';
+// @use '@ecl/vanilla-component-site-header-core/site-header-core-print';
+// @use '@ecl/vanilla-component-site-header-harmonised/site-header-harmonised-print';
+// @use '@ecl/vanilla-component-site-header-standardised/site-header-standardised-print';
 
-// Utilities
-@use '@ecl/vanilla-utility-background/background-print';
-@use '@ecl/vanilla-utility-border/border-print';
-@use '@ecl/vanilla-utility-dimension/dimension-print';
-@use '@ecl/vanilla-utility-display/display-print';
-@use '@ecl/vanilla-utility-flex/flex-print';
-@use '@ecl/vanilla-utility-media/media-print';
-@use '@ecl/vanilla-utility-print/print-print';
-@use '@ecl/vanilla-utility-spacing/spacing-print';
-@use '@ecl/vanilla-utility-typography/typography-print';
+// // Utilities
+// @use '@ecl/vanilla-utility-background/background-print';
+// @use '@ecl/vanilla-utility-border/border-print';
+// @use '@ecl/vanilla-utility-dimension/dimension-print';
+// @use '@ecl/vanilla-utility-display/display-print';
+// @use '@ecl/vanilla-utility-flex/flex-print';
+// @use '@ecl/vanilla-utility-media/media-print';
+// @use '@ecl/vanilla-utility-print/print-print';
+// @use '@ecl/vanilla-utility-spacing/spacing-print';
+// @use '@ecl/vanilla-utility-typography/typography-print';

--- a/src/presets/dev/src/dev.scss
+++ b/src/presets/dev/src/dev.scss
@@ -2,76 +2,76 @@
 @use '@ecl/vanilla-component-icon/icon';
 
 // Layout
-@use '@ecl/vanilla-layout-grid/grid';
+// @use '@ecl/vanilla-layout-grid/grid';
 
-// Forms
-@use '@ecl/vanilla-component-checkbox/checkbox';
-@use '@ecl/vanilla-component-file-upload/file-upload';
-@use '@ecl/vanilla-component-form/form';
-@use '@ecl/vanilla-component-radio/radio';
-@use '@ecl/vanilla-component-select/select';
-@use '@ecl/vanilla-component-text-area/text-area';
-@use '@ecl/vanilla-component-text-input/text-input';
-@use '@ecl/vanilla-component-datepicker/datepicker';
+// // Forms
+// @use '@ecl/vanilla-component-checkbox/checkbox';
+// @use '@ecl/vanilla-component-file-upload/file-upload';
+// @use '@ecl/vanilla-component-form/form';
+// @use '@ecl/vanilla-component-radio/radio';
+// @use '@ecl/vanilla-component-select/select';
+// @use '@ecl/vanilla-component-text-area/text-area';
+// @use '@ecl/vanilla-component-text-input/text-input';
+// @use '@ecl/vanilla-component-datepicker/datepicker';
 
-// Other atoms
-@use '@ecl/vanilla-component-blockquote/blockquote';
+// // Other atoms
+// @use '@ecl/vanilla-component-blockquote/blockquote';
 @use '@ecl/vanilla-component-button/button';
-@use '@ecl/vanilla-component-date-block/date-block';
-@use '@ecl/vanilla-component-label/label';
-@use '@ecl/vanilla-component-link/link';
-@use '@ecl/vanilla-component-message/message';
-@use '@ecl/vanilla-component-skip-link/skip-link';
-@use '@ecl/vanilla-component-table/table';
-@use '@ecl/vanilla-component-tag/tag';
+// @use '@ecl/vanilla-component-date-block/date-block';
+// @use '@ecl/vanilla-component-label/label';
+// @use '@ecl/vanilla-component-link/link';
+// @use '@ecl/vanilla-component-message/message';
+// @use '@ecl/vanilla-component-skip-link/skip-link';
+// @use '@ecl/vanilla-component-table/table';
+// @use '@ecl/vanilla-component-tag/tag';
 
-// Molecules
-@use '@ecl/vanilla-component-hero-banner/hero-banner';
-@use '@ecl/vanilla-component-page-banner/page-banner';
-@use '@ecl/vanilla-component-card/card';
-@use '@ecl/vanilla-component-expandable/expandable';
-@use '@ecl/vanilla-component-fact-figures/fact-figures';
-@use '@ecl/vanilla-component-file/file';
-@use '@ecl/vanilla-component-footer-core/footer-core';
-@use '@ecl/vanilla-component-footer-harmonised/footer-harmonised';
-@use '@ecl/vanilla-component-footer-standardised/footer-standardised';
-@use '@ecl/vanilla-component-language-list/language-list';
-@use '@ecl/vanilla-component-media-container/media-container';
-@use '@ecl/vanilla-component-description-list/description-list';
-@use '@ecl/vanilla-component-ordered-list/ordered-list';
-@use '@ecl/vanilla-component-unordered-list/unordered-list';
-@use '@ecl/vanilla-component-pagination/pagination';
-@use '@ecl/vanilla-component-search-form/search-form';
-@use '@ecl/vanilla-component-social-media-follow/social-media-follow';
-@use '@ecl/vanilla-component-social-media-share/social-media-share';
-@use '@ecl/vanilla-component-timeline/timeline';
+// // Molecules
+// @use '@ecl/vanilla-component-hero-banner/hero-banner';
+// @use '@ecl/vanilla-component-page-banner/page-banner';
+// @use '@ecl/vanilla-component-card/card';
+// @use '@ecl/vanilla-component-expandable/expandable';
+// @use '@ecl/vanilla-component-fact-figures/fact-figures';
+// @use '@ecl/vanilla-component-file/file';
+// @use '@ecl/vanilla-component-footer-core/footer-core';
+// @use '@ecl/vanilla-component-footer-harmonised/footer-harmonised';
+// @use '@ecl/vanilla-component-footer-standardised/footer-standardised';
+// @use '@ecl/vanilla-component-language-list/language-list';
+// @use '@ecl/vanilla-component-media-container/media-container';
+// @use '@ecl/vanilla-component-description-list/description-list';
+// @use '@ecl/vanilla-component-ordered-list/ordered-list';
+// @use '@ecl/vanilla-component-unordered-list/unordered-list';
+// @use '@ecl/vanilla-component-pagination/pagination';
+// @use '@ecl/vanilla-component-search-form/search-form';
+// @use '@ecl/vanilla-component-social-media-follow/social-media-follow';
+// @use '@ecl/vanilla-component-social-media-share/social-media-share';
+// @use '@ecl/vanilla-component-timeline/timeline';
 
-// Organisms
-@use '@ecl/vanilla-component-accordion/accordion';
-@use '@ecl/vanilla-component-breadcrumb-core/breadcrumb-core';
-@use '@ecl/vanilla-component-breadcrumb-standardised/breadcrumb-standardised';
-@use '@ecl/vanilla-component-breadcrumb-harmonised/breadcrumb-harmonised';
-@use '@ecl/vanilla-component-gallery/gallery';
-@use '@ecl/vanilla-component-inpage-navigation/inpage-navigation';
-@use '@ecl/vanilla-component-menu/menu';
-@use '@ecl/vanilla-component-page-header-harmonised/page-header-harmonised';
-@use '@ecl/vanilla-component-page-header-standardised/page-header-standardised';
-@use '@ecl/vanilla-component-site-header-core/site-header-core';
-@use '@ecl/vanilla-component-site-header-harmonised/site-header-harmonised';
-@use '@ecl/vanilla-component-site-header-standardised/site-header-standardised';
+// // Organisms
+// @use '@ecl/vanilla-component-accordion/accordion';
+// @use '@ecl/vanilla-component-breadcrumb-core/breadcrumb-core';
+// @use '@ecl/vanilla-component-breadcrumb-standardised/breadcrumb-standardised';
+// @use '@ecl/vanilla-component-breadcrumb-harmonised/breadcrumb-harmonised';
+// @use '@ecl/vanilla-component-gallery/gallery';
+// @use '@ecl/vanilla-component-inpage-navigation/inpage-navigation';
+// @use '@ecl/vanilla-component-menu/menu';
+// @use '@ecl/vanilla-component-page-header-harmonised/page-header-harmonised';
+// @use '@ecl/vanilla-component-page-header-standardised/page-header-standardised';
+// @use '@ecl/vanilla-component-site-header-core/site-header-core';
+// @use '@ecl/vanilla-component-site-header-harmonised/site-header-harmonised';
+// @use '@ecl/vanilla-component-site-header-standardised/site-header-standardised';
 
-// Utilities
-@use '@ecl/vanilla-utility-background/background';
-@use '@ecl/vanilla-utility-border/border';
-@use '@ecl/vanilla-utility-clearfix/clearfix';
-@use '@ecl/vanilla-utility-dimension/dimension';
-@use '@ecl/vanilla-utility-flex/flex';
-@use '@ecl/vanilla-utility-float/float';
-@use '@ecl/vanilla-utility-disablescroll/disablescroll';
-@use '@ecl/vanilla-utility-display/display';
-@use '@ecl/vanilla-utility-media/media';
-@use '@ecl/vanilla-utility-print/print';
-@use '@ecl/vanilla-utility-screen-reader/screen-reader';
-@use '@ecl/vanilla-utility-spacing/spacing';
-@use '@ecl/vanilla-utility-typography/typography';
-@use '@ecl/vanilla-utility-z-index/z-index';
+// // Utilities
+// @use '@ecl/vanilla-utility-background/background';
+// @use '@ecl/vanilla-utility-border/border';
+// @use '@ecl/vanilla-utility-clearfix/clearfix';
+// @use '@ecl/vanilla-utility-dimension/dimension';
+// @use '@ecl/vanilla-utility-flex/flex';
+// @use '@ecl/vanilla-utility-float/float';
+// @use '@ecl/vanilla-utility-disablescroll/disablescroll';
+// @use '@ecl/vanilla-utility-display/display';
+// @use '@ecl/vanilla-utility-media/media';
+// @use '@ecl/vanilla-utility-print/print';
+// @use '@ecl/vanilla-utility-screen-reader/screen-reader';
+// @use '@ecl/vanilla-utility-spacing/spacing';
+// @use '@ecl/vanilla-utility-typography/typography';
+// @use '@ecl/vanilla-utility-z-index/z-index';

--- a/src/themes/dev/theme.scss
+++ b/src/themes/dev/theme.scss
@@ -1,0 +1,10 @@
+@forward 'maps/color';
+@forward 'maps/icon';
+@forward 'maps/form';
+@forward 'maps/layout';
+@forward 'maps/media';
+@forward 'maps/social-media-list';
+@forward 'maps/spacing';
+@forward 'maps/shape';
+@forward 'maps/typography';
+@forward 'maps/z-index';


### PR DESCRIPTION
I didn't know that `@forward` at-rule exists until yesterday while working on https://github.com/ec-europa/europa-component-library/pull/1783

This is the smallest diff I could think of to try the functionality and see whether it's going to be liked by the team.

The benefit I see probably comes a bit too late in the migration process, but what we could have is `theme.{token}` for theme tokens instead of including and using them directly.

Speaking about accessing tokens indirectly, it's probably worth reflecting a bit on possible combination of `@forward` plus https://github.com/ec-europa/europa-component-library/pull/1740

The direction of though is like following:

```scss
// inside a component

@use '@ecl/theme-dev/theme' // new file containing facilities to access tokens indirectly

.ecl-button--primary {
  background-color: theme.get('color', 'blue-100');
  color: theme.get('color', 'white-100');
}
```

In `.get()` (or whatever other function/mixin) there is a (ec|eu) context which is hidden from the component and returns a value for the requested token.

This only a shared experiment for a discussion