### PR TITLE
fix(date-block): Use 'ecl-u-sr-only' instead of 'ecl-date-block__daytime' class - FRONT-1841

### DIFF
--- a/src/implementations/twig/components/date-block/date-block.html.twig
+++ b/src/implementations/twig/components/date-block/date-block.html.twig
@@ -60,7 +60,7 @@
 
   <time class="{{ _css_class }}"{{ _extra_attributes|raw }}>
     {% if _date_time is not empty %}
-      <span class="ecl-date-block__daytime">{{ _date_time }}</span>
+      <span class="ecl-u-sr-only">{{ _date_time }}</span>
     {% endif %}
     <span class="ecl-date-block__day" aria-hidden="true">{{ _day }}</span>
     {{ _month_markup|raw }}

--- a/src/implementations/vanilla/components/date-block/date-block.scss
+++ b/src/implementations/vanilla/components/date-block/date-block.scss
@@ -112,21 +112,6 @@ $_circle-width: 0.6rem;
     padding-bottom: map.get(spacing.$spacing, 'xs');
     padding-top: map.get(spacing.$spacing, 'xs');
   }
-
-  .ecl-date-block__daytime {
-    border: 0;
-    clip: rect(0, 0, 0, 0);
-    /* stylelint-disable-next-line property-no-vendor-prefix */
-    -webkit-clip-path: inset(50%);
-    clip-path: inset(50%);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
 }
 
 // ongoing


### PR DESCRIPTION
Not sure why a new css class and property was created for this element which so far uses the `ecl-u-sr-only` class? @planctus 

To solve the display problem, I removed the newly created class `ecl-date-block__daytime` and I use the existing class `ecl-u-sr-only`