### PR TITLE
feat(controls): Search form, replacing knobs with controls - front-1863

### DIFF
--- a/src/implementations/twig/components/search-form/search-form.story.js
+++ b/src/implementations/twig/components/search-form/search-form.story.js
@@ -1,38 +1,51 @@
-import { withKnobs, text, optionsKnob } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl/storybook-addon-notes';
-import { getExtraKnobs, tabLabels } from '@ecl/story-utils';
 import withCode from '@ecl/storybook-addon-code';
+import { correctSvgPath } from '@ecl/story-utils';
 
-import defaultSprite from '@ecl/resources-ec-icons/dist/sprites/icons.svg';
 import dataDefault from '@ecl/specs-component-search-form/demo/data';
 import searchForm from './search-form.html.twig';
 import notes from './README.md';
 
-const prepareSearchForm = (data) => {
-  data.button.label = text(
-    'button.label',
-    data.button.label,
-    tabLabels.required
-  );
-  data.button.icon.path = optionsKnob(
-    'button.icon.path',
-    { current: defaultSprite, 'no path': '' },
-    defaultSprite,
-    { display: 'inline-radio' },
-    tabLabels.required
-  );
+const getArgTypes = (data) => {
+  return {
+    input_label: {
+      name: 'label',
+      type: { name: 'string', required: true },
+      description: 'The form element label (hidden via css)',
+      defaultValue: data.text_input.label,
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '' },
+        category: 'Content',
+      },
+    },
+    button_label: {
+      name: 'label of the submit button',
+      type: { name: 'string', required: true },
+      defaultValue: data.button.label,
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '' },
+        category: 'Content',
+      },
+    },
+  };
+};
 
-  getExtraKnobs(data);
+const prepareData = (data, args) => {
+  data.text_input.label = args.input_label;
+  data.button.label = args.button_label;
 
-  return data;
+  return correctSvgPath(data);
 };
 
 export default {
   title: 'Components/Forms/Search Form',
 };
 
-export const Default = () => searchForm(prepareSearchForm(dataDefault));
+export const Default = (args) => searchForm(prepareData(dataDefault, args));
 
 Default.storyName = 'default';
+Default.argTypes = getArgTypes(dataDefault);
 Default.parameters = { notes: { markdown: notes, json: dataDefault } };
-Default.decorators = [withKnobs, withNotes, withCode];
+Default.decorators = [withNotes, withCode];


### PR DESCRIPTION
By chance i've tried to add also disabled and invalid use cases for the text input. It seems that we have, at least for the invalid one, a style issue. The red border is only visible when hovering the input, the issue seems inherited from v2.