### PR TITLE
fix(forms): update deprecated css - FRONT-1899

### DIFF
--- a/docs/Migrating-v3.md
+++ b/docs/Migrating-v3.md
@@ -50,6 +50,7 @@ The following packages have been re-organized:
 - `@ecl/polyfills` has been moved to `@ecl/dom-utils/polyfills`
 - `@ecl/(ec|eu)-auto-init` have been moved to `@ecl/dom-utils/autoinit`
 - `@ecl/(ec|eu)-base/helpers` have been moved to `@ecl/dom-utils`
+- all generic form packages (feedback-message, form-group, help-block, form-label) have been merged into `@ecl/vanilla-component-form`
 
 Example from v2:
 

--- a/docs/Migrating-v3.md
+++ b/docs/Migrating-v3.md
@@ -47,10 +47,10 @@ The following packages have been re-organized:
 - `@ecl/ec-utility-font-size` has been removed
 - `@ecl/ec-utility-ratio` has been removed
 - `@ecl/ec-utility-text` has been removed
+- `@ecl/(ec|eu)-component-form-form-group`, `@ecl/(ec|eu)-component-form-feedback-message`, `@ecl/(ec|eu)-component-form-help-block` and `@ecl/(ec|eu)-component-form-form-label` have been consolidated in `@ecl/vanilla-component-form`
 - `@ecl/polyfills` has been moved to `@ecl/dom-utils/polyfills`
 - `@ecl/(ec|eu)-auto-init` have been moved to `@ecl/dom-utils/autoinit`
 - `@ecl/(ec|eu)-base/helpers` have been moved to `@ecl/dom-utils`
-- all generic form packages (feedback-message, form-group, help-block, form-label) have been merged into `@ecl/vanilla-component-form`
 
 Example from v2:
 

--- a/src/implementations/vanilla/components/form/form.scss
+++ b/src/implementations/vanilla/components/form/form.scss
@@ -22,37 +22,22 @@
   margin: 0;
   padding: 0;
 
-  > *:not(.ecl-form-label--hidden) + * {
+  > *:not(.ecl-u-sr-only) + * {
     margin-top: map.get(theme.$spacing, 'xs');
   }
 
-  > *:not(.ecl-form-label--hidden) + .ecl-checkbox {
+  > *:not(.ecl-u-sr-only) + .ecl-checkbox,
+  > *:not(.ecl-u-sr-only) + .ecl-file-upload,
+  > *:not(.ecl-u-sr-only) + .ecl-file-upload__button-container,
+  > *:not(.ecl-u-sr-only) + .ecl-radio,
+  > *:not(.ecl-u-sr-only) + .ecl-select__container,
+  > *:not(.ecl-u-sr-only) + .ecl-select__multiple,
+  > *:not(.ecl-u-sr-only) + .ecl-text-input,
+  > *:not(.ecl-u-sr-only) + .ecl-text-area {
     margin-top: map.get(theme.$spacing, 's');
   }
 
-  > *:not(.ecl-form-label--hidden) + .ecl-text-input {
-    margin-top: map.get(theme.$spacing, 's');
-  }
-
-  > *:not(.ecl-form-label--hidden) + .ecl-text-area {
-    margin-top: map.get(theme.$spacing, 's');
-  }
-
-  > *:not(.ecl-form-label--hidden) + .ecl-select__container,
-  > *:not(.ecl-form-label--hidden) + .ecl-select__multiple {
-    margin-top: map.get(theme.$spacing, 's');
-  }
-
-  > *:not(.ecl-form-label--hidden) + .ecl-radio {
-    margin-top: map.get(theme.$spacing, 's');
-  }
-
-  > *:not(.ecl-form-label--hidden) + .ecl-file-upload,
-  > *:not(.ecl-form-label--hidden) + .ecl-file-upload__button-container {
-    margin-top: map.get(theme.$spacing, 's');
-  }
-
-  > *:not(.ecl-form-label--hidden) + .ecl-file-upload__list {
+  > *:not(.ecl-u-sr-only) + .ecl-file-upload__list {
     margin-top: map.get(theme.$spacing, 'm');
   }
 


### PR DESCRIPTION
adapt form css according to recommandations made in the migration documentation