### PR TITLE
fix(search-form): fix invalid state - FRONT-1923

### DIFF
--- a/src/implementations/twig/components/search-form/search-form.story.js
+++ b/src/implementations/twig/components/search-form/search-form.story.js
@@ -8,33 +8,48 @@ import notes from './README.md';
 
 const getArgTypes = (data) => {
   return {
-    input_label: {
-      name: 'label',
+    button_label: {
+      name: 'button label',
       type: { name: 'string', required: true },
-      description: 'The form element label (hidden via css)',
-      defaultValue: data.text_input.label,
+      defaultValue: data.button.label,
+      description: 'Label of the search button',
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: '' },
         category: 'Content',
       },
     },
-    button_label: {
-      name: 'label of the submit button',
-      type: { name: 'string', required: true },
-      defaultValue: data.button.label,
+    invalid: {
+      name: 'invalid',
+      type: 'boolean',
+      defaultValue: false,
+      description: `Marks the search form as invalid`,
       table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: '' },
-        category: 'Content',
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+        category: 'States',
+      },
+    },
+    disabled: {
+      name: 'disabled',
+      type: 'boolean',
+      defaultValue: false,
+      description: `Disabled search form`,
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+        category: 'States',
       },
     },
   };
 };
 
 const prepareData = (data, args) => {
-  data.text_input.label = args.input_label;
+  data.text_input.disabled = args.disabled;
+  data.text_input.invalid = args.invalid;
   data.button.label = args.button_label;
+  data.button.disabled = args.disabled;
+  data.button.invalid = args.invalid;
 
   return correctSvgPath(data);
 };

--- a/src/implementations/vanilla/components/search-form/search-form.scss
+++ b/src/implementations/vanilla/components/search-form/search-form.scss
@@ -41,13 +41,16 @@ $_border-color: map.get(theme.$color, 'grey-50');
 }
 
 .ecl-search-form__text-input {
+  flex-grow: 1;
+  margin-top: 0 !important;
+  width: 100%;
+}
+
+.ecl-search-form__text-input:not(.ecl-text-input--invalid) {
   border-bottom-color: $_border-color;
   border-left-color: $_border-color;
   border-right-width: 0;
   border-top-color: $_border-color;
-  flex-grow: 1;
-  margin-top: 0 !important;
-  width: 100%;
 }
 
 .ecl-search-form__button {


### PR DESCRIPTION
Fix invalid state display (red border).
Also add controls for invalid and disabled state.

Note:
We don't have specs for the desing of invalid search form, so for now I just fixed the red border on the text field. If later on we have detailed specs, we may update the component. It may require a modification of the component structure (it is currently not possible to have a red border on the button, for instance)