### PR TITLE
feat(docs): file-downloads-usage-page

### DIFF
--- a/src/website/src/pages/ec/components/file/docs/usage.mdx
+++ b/src/website/src/pages/ec/components/file/docs/usage.mdx
@@ -6,7 +6,9 @@ order: 1
 import { Paragraph, Anatomy, Link } from '@ecl/website-components';
 
 <Paragraph size="lead">
-The file downloads component shows downloadable content to users in a container. When the file is available in more than one language, the file downloads component displays the files in an expandable sub container.
+  The file downloads component shows downloadable content to users in a
+  container. When the file is available in more than one language, the file
+  downloads component displays the files in an expandable sub container.
 </Paragraph>
 
 ## Anatomy
@@ -31,19 +33,19 @@ The file downloads component shows downloadable content to users in a container.
 
 ### Default
 
-| Elements     | Mandatory | Description                                                          |
-| ------------ | --------- | -------------------------------------------------------------------- |
-| heading      | yes       | heading of the file that is available for download           |
+| Elements     | Mandatory | Description                                                         |
+| ------------ | --------- | ------------------------------------------------------------------- |
+| heading      | yes       | heading of the file that is available for download                  |
 | file details | yes       | file details display the **file language, file type and file size** |
-| link         | yes       | the link downloads the file when selected                            |
+| link         | yes       | the link downloads the file when selected                           |
 
 ### Conditional (translated/multiple languages)
 
-| Elements    | Mandatory | Description                                                                                                     |
-| ----------- | --------- | --------------------------------------------------------------------------------------------------------------- |
-| button      | yes       | button indicates file is available to download in multiple languages |
-| translated content    | yes       | translated content of the file that is available for download                                              |
-| helper text | no        | helper text assists the user in selecting the appropriate file and language                                     |
+| Elements           | Mandatory | Description                                                                 |
+| ------------------ | --------- | --------------------------------------------------------------------------- |
+| button             | yes       | button indicates file is available to download in multiple languages        |
+| translated content | yes       | translated content of the file that is available for download               |
+| helper text        | no        | helper text assists the user in selecting the appropriate file and language |
 
 ## Do's
 
@@ -53,7 +55,7 @@ The file downloads component shows downloadable content to users in a container.
 ## Don'ts
 
 - don't use it without additional relevant content on the same page
-- don't use heading that is ambiguous 
+- don't use heading that is ambiguous
 
 ## When to use
 
@@ -66,9 +68,14 @@ The file downloads component shows downloadable content to users in a container.
 # File downloads with thumbnail/taxonomy
 
 <Paragraph size="lead">
-The file downloads with thumbnail component delivers downloadable content accompanied by a thumbnail image and description. When multiple translations are available, they are displayed in the container below the description.
-<br/>
-The file downloads with taxonomy component provides a quick overview on the information linked to the taxonomy terms assigned to it. When multiple translations are available, they are placed in an expandable container below description.
+  The file downloads with thumbnail component delivers downloadable content
+  accompanied by a thumbnail image and description. When multiple translations
+  are available, they are displayed in the container below the description.
+  <br />
+  The file downloads with taxonomy component provides a quick overview on the
+  information linked to the taxonomy terms assigned to it. When multiple
+  translations are available, they are placed in an expandable container below
+  description.
 </Paragraph>
 
 ## Anatomy
@@ -93,24 +100,24 @@ The file downloads with taxonomy component provides a quick overview on the info
 
 ### Default
 
-| Elements        | Mandatory desktop | Description  |
-| --------------- | ----------------- | ---------------- |
-| label           | no                | label shows the importance of the file     |
-| metadata        | no                | metadata related to the file to be downloaded<br/>**Note**: Note: the first metadata tag is emphasised and it will be capitalised; tags following have normal (sentence) capitalisation and are separated by a divider |
-| heading         | yes               | heading of the downloadable file      |
-| description     | no                | a summary of the downloadable file    |
-| thumbnail image | no                | image thumbnail is related to the linked media  |
-| file details    | yes               | file details displays the **file language, file type and file size**      |
-| link            | yes               | the link downloads the file when selected   |
-| horizontal description list         | no               | a list of items with taxonomy tags   |
+| Elements                    | Mandatory desktop | Description                                                                                                                                                                                                            |
+| --------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| label                       | no                | label shows the importance of the file                                                                                                                                                                                 |
+| metadata                    | no                | metadata related to the file to be downloaded<br/>**Note**: Note: the first metadata tag is emphasised and it will be capitalised; tags following have normal (sentence) capitalisation and are separated by a divider |
+| heading                     | yes               | heading of the downloadable file                                                                                                                                                                                       |
+| description                 | no                | a summary of the downloadable file                                                                                                                                                                                     |
+| thumbnail image             | no                | image thumbnail is related to the linked media                                                                                                                                                                         |
+| file details                | yes               | file details displays the **file language, file type and file size**                                                                                                                                                   |
+| link                        | yes               | the link downloads the file when selected                                                                                                                                                                              |
+| horizontal description list | no                | a list of items with taxonomy tags                                                                                                                                                                                     |
 
 ### Conditional (translated/multiple languages)
 
-| Elements           | Mandatory desktop | Description      |
-| ------------------ | ----------------- | ---------------- | 
-| button             | yes               | button indicates file is available for download in multiple languages  |
-| translated content | yes               | translated content of the file that is available for download    |
-| helper text        | no                | helper text assists the user in selecting the appropriate file and language          |
+| Elements           | Mandatory desktop | Description                                                                 |
+| ------------------ | ----------------- | --------------------------------------------------------------------------- |
+| button             | yes               | button indicates file is available for download in multiple languages       |
+| translated content | yes               | translated content of the file that is available for download               |
+| helper text        | no                | helper text assists the user in selecting the appropriate file and language |
 
 ## Do's
 
@@ -121,7 +128,7 @@ The file downloads with taxonomy component provides a quick overview on the info
 ## Don'ts
 
 - don't use it without additional relevant content on the same page
-- don't use heading that is ambiguous 
+- don't use heading that is ambiguous
 - don't choose images with large file size
 
 ## When to use

--- a/src/website/src/pages/ec/components/file/docs/usage.mdx
+++ b/src/website/src/pages/ec/components/file/docs/usage.mdx
@@ -43,7 +43,7 @@ The file downloads component shows downloadable content to users in a container.
 | ----------- | --------- | --------------------------------------------------------------------------------------------------------------- |
 | button      | yes       | button indicates file is available to download in multiple languages |
 | translated content    | yes       | translated content of the file that is available for download                                              |
-| helper Text | no        | helper text assists the user in selecting the appropriate file and language                                     |
+| helper text | no        | helper text assists the user in selecting the appropriate file and language                                     |
 
 ## Do's
 

--- a/src/website/src/pages/ec/components/file/docs/usage.mdx
+++ b/src/website/src/pages/ec/components/file/docs/usage.mdx
@@ -6,10 +6,7 @@ order: 1
 import { Paragraph, Anatomy, Link } from '@ecl/website-components';
 
 <Paragraph size="lead">
-  The file component <strong>delivers downloadable content</strong> to users in
-  an easy to use container. When the file is available in more than one language
-  the file component makes these files accessible in an expandable sub
-  container.
+The file downloads component shows downloadable content to users in a container. When the file is available in more than one language, the file downloads component displays the files in an expandable sub container.
 </Paragraph>
 
 ## Anatomy
@@ -36,27 +33,27 @@ import { Paragraph, Anatomy, Link } from '@ecl/website-components';
 
 | Elements     | Mandatory | Description                                                          |
 | ------------ | --------- | -------------------------------------------------------------------- |
-| heading      | yes       | the Heading must describe the downloadable file accurately           |
-| file Details | yes       | file Details displays the **file language, file type and file size** |
-| link         | yes       | the Link downloads the file when selected                            |
+| heading      | yes       | heading of the file that is available for download           |
+| file details | yes       | file details display the **file language, file type and file size** |
+| link         | yes       | the link downloads the file when selected                            |
 
 ### Conditional (translated/multiple languages)
 
 | Elements    | Mandatory | Description                                                                                                     |
 | ----------- | --------- | --------------------------------------------------------------------------------------------------------------- |
-| button      | yes       | the Button, when selected, displays the file in different languages available, **below the download container** |
-| language    | yes       | the Language of the downloaded content **acting as a heading**                                                  |
-| helper Text | no        | helper Text assists the user in selecting the appropriate file and language                                     |
+| button      | yes       | button indicates file is available to download in multiple languages |
+| translated content    | yes       | translated content of the file that is available for download                                              |
+| helper Text | no        | helper text assists the user in selecting the appropriate file and language                                     |
 
 ## Do's
 
-- **the heading of each item should be** short, distinct and indicative
+- keep the heading of each file short, distinct and indicative
 - always include the **file language, file type and file size**
 
 ## Don'ts
 
-- **don't use without additional relevant content** on the same page
-- **don't use the same heading as the file name**
+- don't use it without additional relevant content on the same page
+- don't use heading that is ambiguous 
 
 ## When to use
 
@@ -64,19 +61,14 @@ import { Paragraph, Anatomy, Link } from '@ecl/website-components';
 
 ## When not to use
 
-- Do not use to include **important information** that should be present at all time
+- Do not use link to hide important information that should be present at all time
 
-# File download with thumbnail
+# File download with thumbnail/taxonomy
 
 <Paragraph size="lead">
-  The File download with thumbnail component is a variation of the File download
-  component, and{' '}
-  <strong>
-    delivers downloadable content accompanied by a thumbnail image
-  </strong>{' '}
-  in an easy to use container. When the file is available in more than one
-  language, the file component makes these files accessible in an expandable sub
-  container.
+The file downloads with thumbnail component delivers downloadable content accompanied by a thumbnail image and description. When multiple translations are available, they are displayed in the container below the description.
+<br/>
+The File downloads with taxonomy component provides a quick overview on the information linked to the taxonomy terms assigned to it. When multiple translations are available, they are placed in an expandable container below description.
 </Paragraph>
 
 ## Anatomy
@@ -101,34 +93,36 @@ import { Paragraph, Anatomy, Link } from '@ecl/website-components';
 
 ### Default
 
-| Elements        | Mandatory desktop | Mandatory mobile | Description                                                                                                                                                                                                                |
-| --------------- | ----------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| metadata        | no                | no               | **metadata** related to the subject within the container<br/>**Note**: the first item is emphasised and it will be capitalised; items following that will have normal (sentence) capitalisation and separated by a divider |
-| heading         | yes               | yes              | the Heading must describe the downloadable file accurately                                                                                                                                                                 |
-| description     | no                | no               | a **summary** of the content that the component links to                                                                                                                                                                   |
-| Thumbnail image | no                | no               | **image thumbnail** representative of the linked media                                                                                                                                                                     |
-| file details    | yes               | yes              | file Details displays the **file language, file type and file size**                                                                                                                                                       |
-| link            | yes               | yes              | the Link downloads the file when selected                                                                                                                                                                                  |
+| Elements        | Mandatory desktop | Description  |
+| --------------- | ----------------- | ---------------- |
+| label           | no                | label shows the importance of the file     |
+| metadata        | no                | metadata related to the file to be downloaded<br/>**Note**: Note: the first metadata tag is emphasised and it will be capitalised; tags following that will have normal (sentence) capitalisation and are separated by a divider |
+| heading         | yes               | heading of the downloadable file      |
+| description     | no                | a summary of the downloadable file    |
+| thumbnail image | no                | image thumbnail is related to the linked media  |
+| file details    | yes               | file details displays the **file language, file type and file size**      |
+| link            | yes               | the link downloads the file when selected   |
+| horizontal description list         | no               | a list of items with taxonomy tags   |
 
 ### Conditional (translated/multiple languages)
 
-| Elements           | Mandatory desktop | Mandatory mobile | Description                                                                                                     |
-| ------------------ | ----------------- | ---------------- | --------------------------------------------------------------------------------------------------------------- |
-| button             | yes               | yes              | The Button, when selected, displays the file in different languages available, **below the download container** |
-| translated version | yes               | yes              | the Heading must describe the downloadable file accurately                                                      |
-| helper text        | no                | no               | a **summary** of the content that the component links to                                                        |
+| Elements           | Mandatory desktop | Description      |
+| ------------------ | ----------------- | ---------------- | 
+| button             | yes               | button indicates file is available for download in multiple languages  |
+| translated content | yes               | translated content of the file that is available for download    |
+| helper text        | no                | helper text assists the user in selecting the appropriate file and language          |
 
 ## Do's
 
-- **the heading of each item should be** short, distinct and indicative
+- keep the heading of each file short, distinct and indicative
 - always include the **file language, file type and file size**
-- **select appropriate images for thumbnails**, they need to be representative of file that is linked
+- select images that are appropriate for thumbnails, illustrative of the linked file
 
 ## Don'ts
 
-- **don't use without additional relevant content** on the same page
-- **don't use the same heading as the file name**
-- **don't choose images that are too complex to be distinguished in thumbnail size**
+- don't use it without additional relevant content on the same page
+- don't use heading that is ambiguous 
+- don't choose images with large file size
 
 ## When to use
 
@@ -136,4 +130,4 @@ import { Paragraph, Anatomy, Link } from '@ecl/website-components';
 
 ## When not to use
 
-- Do not use to include **important information** that should be present at all time
+- Do not use link to hide important information that should be present at all time

--- a/src/website/src/pages/ec/components/file/docs/usage.mdx
+++ b/src/website/src/pages/ec/components/file/docs/usage.mdx
@@ -63,12 +63,12 @@ The file downloads component shows downloadable content to users in a container.
 
 - Do not use link to hide important information that should be present at all time
 
-# File download with thumbnail/taxonomy
+# File downloads with thumbnail/taxonomy
 
 <Paragraph size="lead">
 The file downloads with thumbnail component delivers downloadable content accompanied by a thumbnail image and description. When multiple translations are available, they are displayed in the container below the description.
 <br/>
-The File downloads with taxonomy component provides a quick overview on the information linked to the taxonomy terms assigned to it. When multiple translations are available, they are placed in an expandable container below description.
+The file downloads with taxonomy component provides a quick overview on the information linked to the taxonomy terms assigned to it. When multiple translations are available, they are placed in an expandable container below description.
 </Paragraph>
 
 ## Anatomy
@@ -96,7 +96,7 @@ The File downloads with taxonomy component provides a quick overview on the info
 | Elements        | Mandatory desktop | Description  |
 | --------------- | ----------------- | ---------------- |
 | label           | no                | label shows the importance of the file     |
-| metadata        | no                | metadata related to the file to be downloaded<br/>**Note**: Note: the first metadata tag is emphasised and it will be capitalised; tags following that will have normal (sentence) capitalisation and are separated by a divider |
+| metadata        | no                | metadata related to the file to be downloaded<br/>**Note**: Note: the first metadata tag is emphasised and it will be capitalised; tags following have normal (sentence) capitalisation and are separated by a divider |
 | heading         | yes               | heading of the downloadable file      |
 | description     | no                | a summary of the downloadable file    |
 | thumbnail image | no                | image thumbnail is related to the linked media  |
@@ -116,7 +116,7 @@ The File downloads with taxonomy component provides a quick overview on the info
 
 - keep the heading of each file short, distinct and indicative
 - always include the **file language, file type and file size**
-- select images that are appropriate for thumbnails, illustrative of the linked file
+- select images that are appropriate and representative of the linked file
 
 ## Don'ts
 


### PR DESCRIPTION
Mobile section is removed as we don't have anatomy images for mobile in ECL 2.
Edits and taxonomy is added in addition to thumbnail.
Images will be uploaded/updated when S3 is back.