### PR TITLE
fix(ecl-editor): fix button override

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--button.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--button.scss
@@ -12,7 +12,7 @@
   $padding-vertical: $ecl-spacing-m
 ) {
   /* stylelint-disable selector-no-qualifying-type */
-  .ecl-editor button:not(.ecl-file__translation-toggle),
+  .ecl-editor button,
   .ecl-editor input[type='button'],
   .ecl-editor input[type='submit'] {
     appearance: none;
@@ -39,5 +39,17 @@
       outline: $outline-width solid $ecl-color-secondary;
       outline-offset: -($outline-width);
     }
+  }
+}
+
+.ecl-editor .ecl-file__translation-toggle {
+  background-color: transparent;
+  color: $ecl-color-blue-100;
+  font-weight: normal;
+
+  &:hover,
+  &:focus {
+    background-color: transparent;
+    color: $ecl-color-blue-130;
   }
 }


### PR DESCRIPTION
Fix conflict between ecl-editor and webtools map.

To test:
- apply css modification on the example page provided by client (https://webgate.ec.europa.eu/ewcms/uat/testpageadrian_en), meaning removing the `:not(.ecl-file__translation-toggle)` on the buttons
- ensure that file download component is still good with ecl-editor. It could be checked on this codepen https://codepen.io/emeryro/pen/QWGoYea (it loads ECL css and the new ecl-editor one)