### PR TITLE
Add wt-btn exclusion rule for ecl-editor

### DIFF
--- a/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--button.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--button.scss
@@ -12,7 +12,7 @@
   $padding-vertical: $ecl-spacing-m
 ) {
   /* stylelint-disable selector-no-qualifying-type */
-  .ecl-editor button:not('.wt-btn'),
+  .ecl-editor button:not(.wt-btn),
   .ecl-editor input[type='button'],
   .ecl-editor input[type='submit'] {
     appearance: none;

--- a/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--button.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--button.scss
@@ -12,7 +12,7 @@
   $padding-vertical: $ecl-spacing-m
 ) {
   /* stylelint-disable selector-no-qualifying-type */
-  .ecl-editor button,
+  .ecl-editor button:not('.wt-btn'),
   .ecl-editor input[type='button'],
   .ecl-editor input[type='submit'] {
     appearance: none;

--- a/src/systems/eu/implementations/vanilla/packages/eu-editor/_eu-editor--button.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-editor/_eu-editor--button.scss
@@ -12,7 +12,7 @@
   $padding-vertical: $ecl-spacing-m
 ) {
   /* stylelint-disable selector-no-qualifying-type */
-  .ecl-editor button:not(.ecl-file__translation-toggle),
+  .ecl-editor button:not(.ecl-file__translation-toggle):not('.wt-btn'),
   .ecl-editor input[type='button'],
   .ecl-editor input[type='submit'] {
     appearance: none;

--- a/src/systems/eu/implementations/vanilla/packages/eu-editor/_eu-editor--button.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-editor/_eu-editor--button.scss
@@ -12,7 +12,7 @@
   $padding-vertical: $ecl-spacing-m
 ) {
   /* stylelint-disable selector-no-qualifying-type */
-  .ecl-editor button:not(.ecl-file__translation-toggle):not('.wt-btn'),
+  .ecl-editor button:not(.ecl-file__translation-toggle):not(.wt-btn),
   .ecl-editor input[type='button'],
   .ecl-editor input[type='submit'] {
     appearance: none;


### PR DESCRIPTION
Hi,

As seen on: https://europa.eu/year-of-rail/index_en the ecl-editor overwrites some styles provided by a webtools component.

I proposed a fix, but please feel free to implement a different solution.

Kind regards,
