### PR TITLE
feat(utilities): improve dimension utilities (ECL2) - FRONT-2196

### DIFF
--- a/src/systems/ec/implementations/react/utilities/dimension/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/dimension/stories/Index.jsx
@@ -4,75 +4,81 @@ import { withKnobs, select } from '@storybook/addon-knobs';
 
 const styleContainer = {
   backgroundColor: '#d9d9d9',
-  padding: '0.5rem',
+  border: '2px dashed #404040',
+  height: '10rem',
+  width: '10rem',
 };
 
 const styleBox = {
   backgroundColor: '#ebebeb',
+  boxSizing: 'border-box',
   border: '2px solid #000',
-  height: '5rem',
-  margin: '0.5rem',
-  padding: '0.5rem',
-  width: '5rem',
+  display: 'inline-block',
+};
+
+const styleImage = {
+  width: '12rem',
+  height: '12rem',
 };
 
 export default {
-  title: 'Utilities/Display',
+  title: 'Utilities/Dimension',
   decorators: [withKnobs],
 };
 
 export const Custom = () => {
-  const displayContainer = select(
-    'Display (container)',
+  const width = select(
+    'Width',
     {
-      Block: 'ecl-u-d-block',
-      Inline: 'ecl-u-d-inline',
-      'Inline block': 'ecl-u-d-inline-block',
-      Flex: 'ecl-u-d-flex',
-      'inline-flex': 'ecl-u-d-inline-flex',
-      Table: 'ecl-u-d-table',
-      'Table cell': 'ecl-u-d-table-cell',
-      None: 'ecl-u-d-none',
+      Auto: 'ecl-u-width-auto',
+      '100%': 'ecl-u-width-100',
     },
-    'ecl-u-d-block'
+    'ecl-u-width-auto'
   );
 
-  const displayInner = select(
-    'Display (inner box)',
+  const height = select(
+    'Height',
     {
-      Block: 'ecl-u-d-block',
-      Inline: 'ecl-u-d-inline',
-      'Inline block': 'ecl-u-d-inline-block',
-      Flex: 'ecl-u-d-flex',
-      'inline-flex': 'ecl-u-d-inline-flex',
-      Table: 'ecl-u-d-table',
-      'Table cell': 'ecl-u-d-table-cell',
-      None: 'ecl-u-d-none',
+      Auto: 'ecl-u-height-auto',
+      '100%': 'ecl-u-height-100',
     },
-    'ecl-u-d-block'
+    'ecl-u-height-auto'
   );
 
-  const boxSizing = select(
-    'Box sizing',
+  const maxWidth = select(
+    'Max width',
     {
-      'Content box': 'ecl-u-box-sizing-content',
-      'Border box': 'ecl-u-box-sizing-border',
+      None: 'ecl-u-max-width-none',
+      '100%': 'ecl-u-max-width-100',
     },
-    'ecl-u-box-sizing-content'
+    'ecl-u-max-width-none'
+  );
+
+  const maxHeight = select(
+    'Max height',
+    {
+      None: 'ecl-u-max-height-none',
+      '100%': 'ecl-u-max-height-100',
+    },
+    'ecl-u-max-height-none'
   );
 
   return (
-    <div style={styleContainer} className={displayContainer}>
-      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
-        Box
+    <>
+      <div style={styleContainer}>
+        <div style={styleBox} className={classnames(width, height)}>
+          Content box
+        </div>
       </div>
-      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
-        Box
+      <div style={styleContainer} className="ecl-u-mt-m">
+        <img
+          src="https://inno-ecl.s3.amazonaws.com/media/examples/example-image-square.jpg"
+          alt="example"
+          style={styleImage}
+          className={classnames(maxWidth, maxHeight)}
+        />
       </div>
-      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
-        Box
-      </div>
-    </div>
+    </>
   );
 };
 

--- a/src/systems/ec/implementations/react/utilities/display/stories/Index.jsx
+++ b/src/systems/ec/implementations/react/utilities/display/stories/Index.jsx
@@ -4,45 +4,73 @@ import { withKnobs, select } from '@storybook/addon-knobs';
 
 const styleContainer = {
   backgroundColor: '#d9d9d9',
-  height: '10rem',
-  width: '10rem',
+  padding: '0.5rem',
 };
 
 const styleBox = {
   backgroundColor: '#ebebeb',
-  boxSizing: 'border-box',
   border: '2px solid #000',
-  display: 'inline-block',
+  height: '5rem',
+  margin: '0.5rem',
+  padding: '0.5rem',
+  width: '5rem',
 };
 
 export default {
-  title: 'Utilities/Dimension',
+  title: 'Utilities/Display',
   decorators: [withKnobs],
 };
 
 export const Custom = () => {
-  const width = select(
-    'Width',
+  const displayContainer = select(
+    'Display (container)',
     {
-      Auto: 'ecl-u-width-auto',
-      '100%': 'ecl-u-width-100',
+      Block: 'ecl-u-d-block',
+      Inline: 'ecl-u-d-inline',
+      'Inline block': 'ecl-u-d-inline-block',
+      Flex: 'ecl-u-d-flex',
+      'inline-flex': 'ecl-u-d-inline-flex',
+      Table: 'ecl-u-d-table',
+      'Table cell': 'ecl-u-d-table-cell',
+      None: 'ecl-u-d-none',
     },
-    'ecl-u-width-auto'
+    'ecl-u-d-block'
   );
 
-  const height = select(
-    'Height',
+  const displayInner = select(
+    'Display (inner box)',
     {
-      Auto: 'ecl-u-height-auto',
-      '100%': 'ecl-u-height-100',
+      Block: 'ecl-u-d-block',
+      Inline: 'ecl-u-d-inline',
+      'Inline block': 'ecl-u-d-inline-block',
+      Flex: 'ecl-u-d-flex',
+      'inline-flex': 'ecl-u-d-inline-flex',
+      Table: 'ecl-u-d-table',
+      'Table cell': 'ecl-u-d-table-cell',
+      None: 'ecl-u-d-none',
     },
-    'ecl-u-height-auto'
+    'ecl-u-d-block'
+  );
+
+  const boxSizing = select(
+    'Box sizing',
+    {
+      'Content box': 'ecl-u-box-sizing-content',
+      'Border box': 'ecl-u-box-sizing-border',
+    },
+    'ecl-u-box-sizing-content'
   );
 
   return (
-    <div style={styleContainer}>
-      <div style={styleBox} className={classnames(width, height)}>
-        Content box
+    <div style={styleContainer} className={displayContainer}>
+      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
+        Box
+      </div>
+      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
+        Box
+      </div>
+      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
+        Box
       </div>
     </div>
   );

--- a/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--media.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-editor/_ec-editor--media.scss
@@ -1,0 +1,12 @@
+/**
+ * Editor media styles
+ */
+
+// Import base
+@import '@ecl/ec-base/ec-base';
+
+@mixin ecl-editor-media() {
+  .ecl-editor img {
+    max-width: 100%;
+  }
+}

--- a/src/systems/ec/implementations/vanilla/packages/ec-editor/ec-editor.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-editor/ec-editor.scss
@@ -7,6 +7,7 @@
 @import 'ec-editor--button';
 @import 'ec-editor--link';
 @import 'ec-editor--list';
+@import 'ec-editor--media';
 @import 'ec-editor--table';
 @import 'ec-editor--typography';
 
@@ -16,6 +17,7 @@
   @include ecl-editor-button();
   @include ecl-editor-description-list();
   @include ecl-editor-link();
+  @include ecl-editor-media();
   @include ecl-editor-ordered-list();
   @include ecl-editor-table();
   @include ecl-editor-typography();

--- a/src/systems/ec/implementations/vanilla/packages/ec-utility-dimension/ec-utility-dimension-print.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-utility-dimension/ec-utility-dimension-print.scss
@@ -15,6 +15,14 @@
     height: 100% !important;
   }
 
+  .ecl-u-max-height-none {
+    max-height: none !important;
+  }
+
+  .ecl-u-max-height-100 {
+    max-height: 100% !important;
+  }
+
   /* Width */
   .ecl-u-width-auto {
     width: auto !important;
@@ -22,6 +30,14 @@
 
   .ecl-u-width-100 {
     width: 100% !important;
+  }
+
+  .ecl-u-max-width-none {
+    max-width: none !important;
+  }
+
+  .ecl-u-max-width-100 {
+    max-width: 100% !important;
   }
 }
 

--- a/src/systems/ec/implementations/vanilla/packages/ec-utility-dimension/ec-utility-dimension.scss
+++ b/src/systems/ec/implementations/vanilla/packages/ec-utility-dimension/ec-utility-dimension.scss
@@ -15,6 +15,14 @@
     height: 100% !important;
   }
 
+  .ecl-u-max-height-none {
+    max-height: none !important;
+  }
+
+  .ecl-u-max-height-100 {
+    max-height: 100% !important;
+  }
+
   /* Width */
   .ecl-u-width-auto {
     width: auto !important;
@@ -22,6 +30,14 @@
 
   .ecl-u-width-100 {
     width: 100% !important;
+  }
+
+  .ecl-u-max-width-none {
+    max-width: none !important;
+  }
+
+  .ecl-u-max-width-100 {
+    max-width: 100% !important;
   }
 }
 

--- a/src/systems/eu/implementations/react/utilities/dimension/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/utilities/dimension/stories/Index.jsx
@@ -4,75 +4,81 @@ import { withKnobs, select } from '@storybook/addon-knobs';
 
 const styleContainer = {
   backgroundColor: '#d9d9d9',
-  padding: '0.5rem',
+  border: '2px dashed #404040',
+  height: '10rem',
+  width: '10rem',
 };
 
 const styleBox = {
   backgroundColor: '#ebebeb',
+  boxSizing: 'border-box',
   border: '2px solid #000',
-  height: '5rem',
-  margin: '0.5rem',
-  padding: '0.5rem',
-  width: '5rem',
+  display: 'inline-block',
+};
+
+const styleImage = {
+  width: '12rem',
+  height: '12rem',
 };
 
 export default {
-  title: 'Utilities/Display',
+  title: 'Utilities/Dimension',
   decorators: [withKnobs],
 };
 
 export const Custom = () => {
-  const displayContainer = select(
-    'Display (container)',
+  const width = select(
+    'Width',
     {
-      Block: 'ecl-u-d-block',
-      Inline: 'ecl-u-d-inline',
-      'Inline block': 'ecl-u-d-inline-block',
-      Flex: 'ecl-u-d-flex',
-      'inline-flex': 'ecl-u-d-inline-flex',
-      Table: 'ecl-u-d-table',
-      'Table cell': 'ecl-u-d-table-cell',
-      None: 'ecl-u-d-none',
+      Auto: 'ecl-u-width-auto',
+      '100%': 'ecl-u-width-100',
     },
-    'ecl-u-d-block'
+    'ecl-u-width-auto'
   );
 
-  const displayInner = select(
-    'Display (inner box)',
+  const height = select(
+    'Height',
     {
-      Block: 'ecl-u-d-block',
-      Inline: 'ecl-u-d-inline',
-      'Inline block': 'ecl-u-d-inline-block',
-      Flex: 'ecl-u-d-flex',
-      'inline-flex': 'ecl-u-d-inline-flex',
-      Table: 'ecl-u-d-table',
-      'Table cell': 'ecl-u-d-table-cell',
-      None: 'ecl-u-d-none',
+      Auto: 'ecl-u-height-auto',
+      '100%': 'ecl-u-height-100',
     },
-    'ecl-u-d-block'
+    'ecl-u-height-auto'
   );
 
-  const boxSizing = select(
-    'Box sizing',
+  const maxWidth = select(
+    'Max width',
     {
-      'Content box': 'ecl-u-box-sizing-content',
-      'Border box': 'ecl-u-box-sizing-border',
+      None: 'ecl-u-max-width-none',
+      '100%': 'ecl-u-max-width-100',
     },
-    'ecl-u-box-sizing-content'
+    'ecl-u-max-width-none'
+  );
+
+  const maxHeight = select(
+    'Max height',
+    {
+      None: 'ecl-u-max-height-none',
+      '100%': 'ecl-u-max-height-100',
+    },
+    'ecl-u-max-height-none'
   );
 
   return (
-    <div style={styleContainer} className={displayContainer}>
-      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
-        Box
+    <>
+      <div style={styleContainer}>
+        <div style={styleBox} className={classnames(width, height)}>
+          Content box
+        </div>
       </div>
-      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
-        Box
+      <div style={styleContainer} className="ecl-u-mt-m">
+        <img
+          src="https://inno-ecl.s3.amazonaws.com/media/examples/example-image-square.jpg"
+          alt="example"
+          style={styleImage}
+          className={classnames(maxWidth, maxHeight)}
+        />
       </div>
-      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
-        Box
-      </div>
-    </div>
+    </>
   );
 };
 

--- a/src/systems/eu/implementations/react/utilities/display/stories/Index.jsx
+++ b/src/systems/eu/implementations/react/utilities/display/stories/Index.jsx
@@ -4,45 +4,73 @@ import { withKnobs, select } from '@storybook/addon-knobs';
 
 const styleContainer = {
   backgroundColor: '#d9d9d9',
-  height: '10rem',
-  width: '10rem',
+  padding: '0.5rem',
 };
 
 const styleBox = {
   backgroundColor: '#ebebeb',
-  boxSizing: 'border-box',
   border: '2px solid #000',
-  display: 'inline-block',
+  height: '5rem',
+  margin: '0.5rem',
+  padding: '0.5rem',
+  width: '5rem',
 };
 
 export default {
-  title: 'Utilities/Dimension',
+  title: 'Utilities/Display',
   decorators: [withKnobs],
 };
 
 export const Custom = () => {
-  const width = select(
-    'Width',
+  const displayContainer = select(
+    'Display (container)',
     {
-      Auto: 'ecl-u-width-auto',
-      '100%': 'ecl-u-width-100',
+      Block: 'ecl-u-d-block',
+      Inline: 'ecl-u-d-inline',
+      'Inline block': 'ecl-u-d-inline-block',
+      Flex: 'ecl-u-d-flex',
+      'inline-flex': 'ecl-u-d-inline-flex',
+      Table: 'ecl-u-d-table',
+      'Table cell': 'ecl-u-d-table-cell',
+      None: 'ecl-u-d-none',
     },
-    'ecl-u-width-auto'
+    'ecl-u-d-block'
   );
 
-  const height = select(
-    'Height',
+  const displayInner = select(
+    'Display (inner box)',
     {
-      Auto: 'ecl-u-height-auto',
-      '100%': 'ecl-u-height-100',
+      Block: 'ecl-u-d-block',
+      Inline: 'ecl-u-d-inline',
+      'Inline block': 'ecl-u-d-inline-block',
+      Flex: 'ecl-u-d-flex',
+      'inline-flex': 'ecl-u-d-inline-flex',
+      Table: 'ecl-u-d-table',
+      'Table cell': 'ecl-u-d-table-cell',
+      None: 'ecl-u-d-none',
     },
-    'ecl-u-height-auto'
+    'ecl-u-d-block'
+  );
+
+  const boxSizing = select(
+    'Box sizing',
+    {
+      'Content box': 'ecl-u-box-sizing-content',
+      'Border box': 'ecl-u-box-sizing-border',
+    },
+    'ecl-u-box-sizing-content'
   );
 
   return (
-    <div style={styleContainer}>
-      <div style={styleBox} className={classnames(width, height)}>
-        Content box
+    <div style={styleContainer} className={displayContainer}>
+      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
+        Box
+      </div>
+      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
+        Box
+      </div>
+      <div style={styleBox} className={classnames(displayInner, boxSizing)}>
+        Box
       </div>
     </div>
   );

--- a/src/systems/eu/implementations/vanilla/packages/eu-editor/_eu-editor--media.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-editor/_eu-editor--media.scss
@@ -1,0 +1,12 @@
+/**
+ * Editor media styles
+ */
+
+// Import base
+@import '@ecl/eu-base/eu-base';
+
+@mixin ecl-editor-media() {
+  .ecl-editor img {
+    max-width: 100%;
+  }
+}

--- a/src/systems/eu/implementations/vanilla/packages/eu-editor/eu-editor.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-editor/eu-editor.scss
@@ -7,6 +7,7 @@
 @import 'eu-editor--button';
 @import 'eu-editor--link';
 @import 'eu-editor--list';
+@import 'eu-editor--media';
 @import 'eu-editor--table';
 @import 'eu-editor--typography';
 
@@ -16,6 +17,7 @@
   @include ecl-editor-button();
   @include ecl-editor-description-list();
   @include ecl-editor-link();
+  @include ecl-editor-media();
   @include ecl-editor-ordered-list();
   @include ecl-editor-table();
   @include ecl-editor-typography();

--- a/src/systems/eu/implementations/vanilla/packages/eu-utility-dimension/eu-utility-dimension-print.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-utility-dimension/eu-utility-dimension-print.scss
@@ -15,6 +15,14 @@
     height: 100% !important;
   }
 
+  .ecl-u-max-height-none {
+    max-height: none !important;
+  }
+
+  .ecl-u-max-height-100 {
+    max-height: 100% !important;
+  }
+
   /* Width */
   .ecl-u-width-auto {
     width: auto !important;
@@ -22,6 +30,14 @@
 
   .ecl-u-width-100 {
     width: 100% !important;
+  }
+
+  .ecl-u-max-width-none {
+    max-width: none !important;
+  }
+
+  .ecl-u-max-width-100 {
+    max-width: 100% !important;
   }
 }
 

--- a/src/systems/eu/implementations/vanilla/packages/eu-utility-dimension/eu-utility-dimension.scss
+++ b/src/systems/eu/implementations/vanilla/packages/eu-utility-dimension/eu-utility-dimension.scss
@@ -15,6 +15,14 @@
     height: 100% !important;
   }
 
+  .ecl-u-max-height-none {
+    max-height: none !important;
+  }
+
+  .ecl-u-max-height-100 {
+    max-height: 100% !important;
+  }
+
   /* Width */
   .ecl-u-width-auto {
     width: auto !important;
@@ -22,6 +30,14 @@
 
   .ecl-u-width-100 {
     width: 100% !important;
+  }
+
+  .ecl-u-max-width-none {
+    max-width: none !important;
+  }
+
+  .ecl-u-max-width-100 {
+    max-width: 100% !important;
   }
 }
 

--- a/src/website/src/pages/ec/utilities/dimension/docs/usage.mdx
+++ b/src/website/src/pages/ec/utilities/dimension/docs/usage.mdx
@@ -9,18 +9,22 @@ import { Paragraph } from '@ecl/website-components';
   Dimension utilities let you manage the width and height of elements.
 </Paragraph>
 
-## Width
+## Width and max width
 
-By using classes `ecl-u-width-*` you can set the width of an element.
+By using classes `ecl-u-width-*` and `ecl-u-max-width-*` you can set the width or max-width of an element.
 Available values are:
 
 - ecl-u-width-auto
 - ecl-u-width-100 (100%)
+- ecl-u-max-width-none
+- ecl-u-max-width-100 (100%)
 
-## Height
+## Height and max height
 
-By using classes `ecl-u-height-*` you can set the height of an element.
+By using classes `ecl-u-height-*` and `ecl-u-max-height-*` you can set the height or max-height of an element.
 Available values are:
 
 - ecl-u-height-auto
 - ecl-u-height-100 (100%)
+- ecl-u-max-height-none
+- ecl-u-max-height-100 (100%)


### PR DESCRIPTION
- add max-width:100% to images inside ecl-editor
- add new utilities to manage max-width and max-height (part of the 'dimension' utilities)
- fix utilities files for dimension and display (they were inverted in file system)

preview: https://ecl-preview-2047--europa-component-library.netlify.app/ec/utilities/dimension/usage/