### PR TITLE
feat(table): Adding EU styles, revamping EC - FRONT-2247

### DIFF
--- a/src/implementations/vanilla/components/table/_table.scss
+++ b/src/implementations/vanilla/components/table/_table.scss
@@ -86,7 +86,8 @@ $_sort-arrow-margin-top: null !default;
   .ecl-table__cell {
     border-width: 0;
     display: table-cell;
-    padding: map.get(theme.$spacing, 's') map.get(theme.$spacing, 'xl') map.get(theme.$spacing, 's') map.get(theme.$spacing, 'm');
+    padding: map.get(theme.$spacing, 's') map.get(theme.$spacing, 'xl')
+      map.get(theme.$spacing, 's') map.get(theme.$spacing, 'm');
 
     &::before {
       display: none;

--- a/src/implementations/vanilla/components/table/_table.scss
+++ b/src/implementations/vanilla/components/table/_table.scss
@@ -7,9 +7,16 @@
 @use '@ecl/theme-dev/theme';
 @use '@ecl/vanilla-layout-grid/mixins/breakpoints';
 
+$_table-color: null !default;
+$_header-border-color: null !default;
+$_row-border-color: null !default;
+$_sort-icon-color: null !default;
+$_sort-icon-color-active: null !default;
+$_sort-arrow-margin-top: null !default;
+
 .ecl-table {
   border-collapse: collapse;
-  color: map.get(theme.$color, 'grey-100');
+  color: $_table-color;
   font: map.get(theme.$font, 'm');
   margin: 0;
   width: 100%;
@@ -20,13 +27,13 @@
 }
 
 .ecl-table__cell {
-  border-top: 1px solid map.get(theme.$color, 'grey-25');
+  border-top: 1px solid $_row-border-color;
   display: flex;
   padding: map.get(theme.$spacing, 's');
 
   &::before {
     background-color: map.get(theme.$color, 'blue-5');
-    border-right: 2px solid map.get(theme.$color, 'grey-50');
+    border-right: 2px solid $_header-border-color;
     content: attr(data-ecl-table-header);
     display: block;
     flex-basis: 10rem;
@@ -44,7 +51,7 @@
   }
 
   &:last-of-type {
-    border-bottom: 1px solid map.get(theme.$color, 'grey-25');
+    border-bottom: 1px solid $_row-border-color;
     margin-bottom: map.get(theme.$spacing, 'l');
   }
 }
@@ -64,18 +71,22 @@
   }
 
   .ecl-table__row {
-    border-bottom: 1px solid map.get(theme.$color, 'grey-25');
+    border-bottom: 1px solid $_row-border-color;
     border-top-width: 0;
   }
 
   .ecl-table__head .ecl-table__row:first-child {
-    border-bottom: 2px solid map.get(theme.$color, 'grey-50');
+    border-bottom: 2px solid $_header-border-color;
+
+    .ecl-table__header {
+      padding-top: map.get(theme.$spacing, 'l');
+    }
   }
 
   .ecl-table__cell {
     border-width: 0;
     display: table-cell;
-    padding: map.get(theme.$spacing, 's') map.get(theme.$spacing, 'm');
+    padding: map.get(theme.$spacing, 's') map.get(theme.$spacing, 'xl') map.get(theme.$spacing, 's') map.get(theme.$spacing, 'm');
 
     &::before {
       display: none;
@@ -116,7 +127,7 @@
 
   &::after {
     background-color: map.get(theme.$color, 'blue-5');
-    border-bottom: 1px solid map.get(theme.$color, 'grey-25');
+    border-bottom: 1px solid $_row-border-color;
     content: attr(data-ecl-table-header-group);
     display: block;
     font-weight: map.get(theme.$font-weight, 'bold');
@@ -179,7 +190,8 @@
 }
 
 .ecl-table__arrow {
-  left: map.get(theme.$spacing, 'm');
+  left: map.get(theme.$spacing, '2xs');
+  margin-top: $_sort-arrow-margin-top;
   position: absolute;
 }
 
@@ -189,24 +201,24 @@
 }
 
 .ecl-table__icon-up {
-  fill: map.get(theme.$color, 'grey-50');
+  fill: $_sort-icon-color;
   top: 0;
 }
 
 .ecl-table__icon-down {
-  fill: map.get(theme.$color, 'grey-50');
+  fill: $_sort-icon-color;
   top: map.get(theme.$icon, '2xs');
   transform: rotate(180deg);
 }
 
 .ecl-table__header[aria-sort='ascending'] {
   .ecl-table__icon-down {
-    fill: map.get(theme.$color, 'grey-100');
+    fill: $_sort-icon-color-active;
   }
 }
 
 .ecl-table__header[aria-sort='descending'] {
   .ecl-table__icon-up {
-    fill: map.get(theme.$color, 'grey-100');
+    fill: $_sort-icon-color-active;
   }
 }

--- a/src/implementations/vanilla/components/table/table-ec.scss
+++ b/src/implementations/vanilla/components/table/table-ec.scss
@@ -1,0 +1,10 @@
+@use "sass:map";
+@use '@ecl/theme-dev/theme';
+@use 'table' with (
+  $_table-color: map.get(theme.$color, 'grey-100'),
+  $_header-border-color: map.get(theme.$color, 'grey-50'),
+  $_row-border-color: map.get(theme.$color, 'grey-25'),
+  $_sort-icon-color: map.get(theme.$color, 'grey-75'),
+  $_sort-icon-color-active: map.get(theme.$color, 'grey-100'),
+  $_sort-arrow-margin-top: -#{map.get(theme.$spacing, 's')},
+);

--- a/src/implementations/vanilla/components/table/table-eu.scss
+++ b/src/implementations/vanilla/components/table/table-eu.scss
@@ -1,0 +1,10 @@
+@use "sass:map";
+@use '@ecl/theme-dev/theme';
+@use 'table' with (
+  $_table-color: map.get(theme.$color, 'grey-140'),
+  $_header-border-color: map.get(theme.$color, 'blue-60'),
+  $_row-border-color: map.get(theme.$color, 'blue-20'),
+  $_sort-icon-color: map.get(theme.$color, 'blue-80'),
+  $_sort-icon-color-active: map.get(theme.$color, 'blue-140'),
+  $_sort-arrow-margin-top: -#{map.get(theme.$spacing, 'xs')},
+);

--- a/src/implementations/vanilla/components/table/table.js
+++ b/src/implementations/vanilla/components/table/table.js
@@ -5,6 +5,7 @@ import iconSvgAllArrowEu from '@ecl/resources-eu-icons/dist/svg/all/solid-arrow.
 
 const system = getSystem();
 const iconSvgAllArrow = system === 'eu' ? iconSvgAllArrowEu : iconSvgAllArrowEc;
+const iconSvgAllArrowSize = system === 'eu' ? 'm' : 'l';
 
 /**
  * @param {HTMLElement} element DOM element for component instantiation and scope
@@ -61,7 +62,7 @@ export class Table {
     // The following element is <path> which does not support classList API as others.
     svg.setAttribute(
       'class',
-      `ecl-table__icon ecl-icon ecl-icon--2xs ${customClass}`
+      `ecl-table__icon ecl-icon ecl-icon--${iconSvgAllArrowSize} ${customClass}`
     );
     return svg;
   }

--- a/src/presets/ec/src/ec.scss
+++ b/src/presets/ec/src/ec.scss
@@ -24,7 +24,7 @@
 @use '@ecl/vanilla-component-link/link-ec';
 @use '@ecl/vanilla-component-message/message-ec';
 @use '@ecl/vanilla-component-skip-link/skip-link';
-@use '@ecl/vanilla-component-table/table';
+@use '@ecl/vanilla-component-table/table-ec';
 @use '@ecl/vanilla-component-tag/tag';
 
 // Molecules

--- a/src/presets/eu/src/eu.scss
+++ b/src/presets/eu/src/eu.scss
@@ -24,7 +24,7 @@
 @use '@ecl/vanilla-component-link/link-eu';
 @use '@ecl/vanilla-component-message/message-eu';
 @use '@ecl/vanilla-component-skip-link/skip-link';
-@use '@ecl/vanilla-component-table/table';
+@use '@ecl/vanilla-component-table/table-eu';
 @use '@ecl/vanilla-component-tag/tag';
 
 // Molecules


### PR DESCRIPTION
Previews:

- EC: https://ecl-preview-2079--europa-component-library.netlify.app/playground/ec/?path=/story/components-table--default
- EU: https://ecl-preview-2079--europa-component-library.netlify.app/playground/eu/?path=/story/components-table--default

Specs: 

- EC: https://citnet.tech.ec.europa.eu/CITnet/confluence/display/ECL/EC+Tables
- EU: https://citnet.tech.ec.europa.eu/CITnet/confluence/display/ECL/EU+Tables
