### PR TITLE
fix(icons): Icons not displaying on footer standardised - FRONT-2328

### DIFF
--- a/src/implementations/twig/components/footer-harmonised/__snapshots__/footer-harmonised.test.js.snap
+++ b/src/implementations/twig/components/footer-harmonised/__snapshots__/footer-harmonised.test.js.snap
@@ -87,7 +87,7 @@ exports[`Footer Harmonised Group 1 renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook"
                   />
                 </svg>
                 <span
@@ -111,7 +111,7 @@ exports[`Footer Harmonised Group 1 renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter"
                   />
                 </svg>
                 <span
@@ -135,7 +135,7 @@ exports[`Footer Harmonised Group 1 renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin"
                   />
                 </svg>
                 <span
@@ -505,7 +505,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra attributes 1`] =
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook"
                   />
                 </svg>
                 <span
@@ -529,7 +529,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra attributes 1`] =
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter"
                   />
                 </svg>
                 <span
@@ -553,7 +553,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra attributes 1`] =
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin"
                   />
                 </svg>
                 <span
@@ -921,7 +921,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra class names 1`] 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook"
                   />
                 </svg>
                 <span
@@ -945,7 +945,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra class names 1`] 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter"
                   />
                 </svg>
                 <span
@@ -969,7 +969,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra class names 1`] 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin"
                   />
                 </svg>
                 <span

--- a/src/implementations/twig/components/footer-harmonised/__snapshots__/footer-harmonised.test.js.snap
+++ b/src/implementations/twig/components/footer-harmonised/__snapshots__/footer-harmonised.test.js.snap
@@ -87,7 +87,7 @@ exports[`Footer Harmonised Group 1 renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook-negative"
                   />
                 </svg>
                 <span
@@ -111,7 +111,7 @@ exports[`Footer Harmonised Group 1 renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter-negative"
                   />
                 </svg>
                 <span
@@ -135,7 +135,7 @@ exports[`Footer Harmonised Group 1 renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin-negative"
                   />
                 </svg>
                 <span
@@ -505,7 +505,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra attributes 1`] =
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook-negative"
                   />
                 </svg>
                 <span
@@ -529,7 +529,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra attributes 1`] =
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter-negative"
                   />
                 </svg>
                 <span
@@ -553,7 +553,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra attributes 1`] =
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin-negative"
                   />
                 </svg>
                 <span
@@ -921,7 +921,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra class names 1`] 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook-negative"
                   />
                 </svg>
                 <span
@@ -945,7 +945,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra class names 1`] 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter-negative"
                   />
                 </svg>
                 <span
@@ -969,7 +969,7 @@ exports[`Footer Harmonised Group 1 renders correctly with extra class names 1`] 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin-negative"
                   />
                 </svg>
                 <span

--- a/src/implementations/twig/components/footer-standardised/__snapshots__/footer-standardised.test.js.snap
+++ b/src/implementations/twig/components/footer-standardised/__snapshots__/footer-standardised.test.js.snap
@@ -87,7 +87,7 @@ exports[`Footer Standardised EC default renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook"
                   />
                 </svg>
                 <span
@@ -111,7 +111,7 @@ exports[`Footer Standardised EC default renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter"
                   />
                 </svg>
                 <span
@@ -135,7 +135,7 @@ exports[`Footer Standardised EC default renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin"
                   />
                 </svg>
                 <span
@@ -505,7 +505,7 @@ exports[`Footer Standardised EC default renders correctly with extra attributes 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook"
                   />
                 </svg>
                 <span
@@ -529,7 +529,7 @@ exports[`Footer Standardised EC default renders correctly with extra attributes 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter"
                   />
                 </svg>
                 <span
@@ -553,7 +553,7 @@ exports[`Footer Standardised EC default renders correctly with extra attributes 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin"
                   />
                 </svg>
                 <span
@@ -921,7 +921,7 @@ exports[`Footer Standardised EC default renders correctly with extra class names
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook"
                   />
                 </svg>
                 <span
@@ -945,7 +945,7 @@ exports[`Footer Standardised EC default renders correctly with extra class names
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter"
                   />
                 </svg>
                 <span
@@ -969,7 +969,7 @@ exports[`Footer Standardised EC default renders correctly with extra class names
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icons.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin"
                   />
                 </svg>
                 <span

--- a/src/implementations/twig/components/footer-standardised/__snapshots__/footer-standardised.test.js.snap
+++ b/src/implementations/twig/components/footer-standardised/__snapshots__/footer-standardised.test.js.snap
@@ -87,7 +87,7 @@ exports[`Footer Standardised EC default renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook-negative"
                   />
                 </svg>
                 <span
@@ -111,7 +111,7 @@ exports[`Footer Standardised EC default renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter-negative"
                   />
                 </svg>
                 <span
@@ -135,7 +135,7 @@ exports[`Footer Standardised EC default renders correctly 1`] = `
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin-negative"
                   />
                 </svg>
                 <span
@@ -505,7 +505,7 @@ exports[`Footer Standardised EC default renders correctly with extra attributes 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook-negative"
                   />
                 </svg>
                 <span
@@ -529,7 +529,7 @@ exports[`Footer Standardised EC default renders correctly with extra attributes 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter-negative"
                   />
                 </svg>
                 <span
@@ -553,7 +553,7 @@ exports[`Footer Standardised EC default renders correctly with extra attributes 
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin-negative"
                   />
                 </svg>
                 <span
@@ -921,7 +921,7 @@ exports[`Footer Standardised EC default renders correctly with extra class names
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#facebook"
+                    xlink:href="/icon-social-media.svg#facebook-negative"
                   />
                 </svg>
                 <span
@@ -945,7 +945,7 @@ exports[`Footer Standardised EC default renders correctly with extra class names
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#twitter"
+                    xlink:href="/icon-social-media.svg#twitter-negative"
                   />
                 </svg>
                 <span
@@ -969,7 +969,7 @@ exports[`Footer Standardised EC default renders correctly with extra class names
                   focusable="false"
                 >
                   <use
-                    xlink:href="/icon-social-media.svg#linkedin"
+                    xlink:href="/icon-social-media.svg#linkedin-negative"
                   />
                 </svg>
                 <span

--- a/src/playground/addons/story-utils/index.js
+++ b/src/playground/addons/story-utils/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import iconPathEc from '@ecl/resources-ec-icons/dist/sprites/icons.svg';
 import iconPathEu from '@ecl/resources-eu-icons/dist/sprites/icons.svg';
+import iconSocialPath from '@ecl/resources-ec-social-icons/dist/sprites/icons-social.svg';
 import iconMediaSocialPath from '@ecl/resources-social-media-icons/dist/sprites/icons-social-media.svg';
 import getSystem from '@ecl/builder/utils/getSystem';
 
@@ -10,9 +11,13 @@ const iconPath = system === 'eu' ? iconPathEu : iconPathEc;
 export const correctSvgPath = (data) => {
   Object.keys(data).forEach((prop) => {
     if (typeof data[prop] === 'string' && data[prop].includes('.svg')) {
-      data[prop] = data[prop].includes('social')
-        ? iconMediaSocialPath
-        : iconPath;
+      if (data[prop].includes('social-media')) {
+        data[prop] = iconMediaSocialPath;
+      } else if (data[prop].includes('social')) {
+        data[prop] = iconSocialPath;
+      } else {
+        data[prop] = iconPath;
+      }
     }
     if (data[prop] !== null && typeof data[prop] === 'object') {
       data[prop] = correctSvgPath(data[prop]);

--- a/src/playground/addons/story-utils/index.js
+++ b/src/playground/addons/story-utils/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import iconPathEc from '@ecl/resources-ec-icons/dist/sprites/icons.svg';
 import iconPathEu from '@ecl/resources-eu-icons/dist/sprites/icons.svg';
-import iconSocialPath from '@ecl/resources-ec-social-icons/dist/sprites/icons-social.svg';
+import iconMediaSocialPath from '@ecl/resources-social-media-icons/dist/sprites/icons-social-media.svg';
 import getSystem from '@ecl/builder/utils/getSystem';
 
 const system = getSystem();
@@ -10,7 +10,9 @@ const iconPath = system === 'eu' ? iconPathEu : iconPathEc;
 export const correctSvgPath = (data) => {
   Object.keys(data).forEach((prop) => {
     if (typeof data[prop] === 'string' && data[prop].includes('.svg')) {
-      data[prop] = data[prop].includes('social') ? iconSocialPath : iconPath;
+      data[prop] = data[prop].includes('social')
+        ? iconMediaSocialPath
+        : iconPath;
     }
     if (data[prop] !== null && typeof data[prop] === 'object') {
       data[prop] = correctSvgPath(data[prop]);

--- a/src/playground/addons/story-utils/package.json
+++ b/src/playground/addons/story-utils/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@ecl/builder": "^3.0.0-beta.1",
     "@ecl/resources-ec-icons": "^3.0.0-beta.1",
-    "@ecl/resources-ec-social-icons": "^3.0.0-beta.1",
+    "@ecl/resources-social-media-icons": "^3.0.0-beta.1",
     "@ecl/resources-eu-icons": "^3.0.0-beta.1",
     "he": "1.2.0"
   }

--- a/src/playground/addons/story-utils/package.json
+++ b/src/playground/addons/story-utils/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@ecl/builder": "^3.0.0-beta.1",
     "@ecl/resources-ec-icons": "^3.0.0-beta.1",
+    "@ecl/resources-ec-social-icons": "^3.0.0-beta.1",
     "@ecl/resources-social-media-icons": "^3.0.0-beta.1",
     "@ecl/resources-eu-icons": "^3.0.0-beta.1",
     "he": "1.2.0"

--- a/src/specs/components/footer-harmonised/demo/data--group1.js
+++ b/src/specs/components/footer-harmonised/demo/data--group1.js
@@ -40,7 +40,7 @@ module.exports = {
               },
               icon: {
                 path: '/icon-social-media.svg',
-                name: 'facebook',
+                name: 'facebook-negative',
                 size: 'xs',
               },
             },
@@ -53,7 +53,7 @@ module.exports = {
               },
               icon: {
                 path: '/icon-social-media.svg',
-                name: 'twitter',
+                name: 'twitter-negative',
                 size: 'xs',
               },
             },
@@ -66,7 +66,7 @@ module.exports = {
               },
               icon: {
                 path: '/icon-social-media.svg',
-                name: 'linkedin',
+                name: 'linkedin-negative',
                 size: 'xs',
               },
             },

--- a/src/specs/components/footer-harmonised/demo/data--group1.js
+++ b/src/specs/components/footer-harmonised/demo/data--group1.js
@@ -39,7 +39,7 @@ module.exports = {
                 icon_position: 'before',
               },
               icon: {
-                path: '/icons.svg',
+                path: '/icon-social-media.svg',
                 name: 'facebook',
                 size: 'xs',
               },
@@ -52,7 +52,7 @@ module.exports = {
                 icon_position: 'before',
               },
               icon: {
-                path: '/icons.svg',
+                path: '/icon-social-media.svg',
                 name: 'twitter',
                 size: 'xs',
               },
@@ -65,7 +65,7 @@ module.exports = {
                 icon_position: 'before',
               },
               icon: {
-                path: '/icons.svg',
+                path: '/icon-social-media.svg',
                 name: 'linkedin',
                 size: 'xs',
               },

--- a/src/specs/components/footer-standardised/demo/data--ec.js
+++ b/src/specs/components/footer-standardised/demo/data--ec.js
@@ -40,7 +40,7 @@ module.exports = {
               },
               icon: {
                 path: '/icon-social-media.svg',
-                name: 'facebook',
+                name: 'facebook-negative',
                 size: 'xs',
               },
             },
@@ -53,7 +53,7 @@ module.exports = {
               },
               icon: {
                 path: '/icon-social-media.svg',
-                name: 'twitter',
+                name: 'twitter-negative',
                 size: 'xs',
               },
             },
@@ -66,7 +66,7 @@ module.exports = {
               },
               icon: {
                 path: '/icon-social-media.svg',
-                name: 'linkedin',
+                name: 'linkedin-negative',
                 size: 'xs',
               },
             },

--- a/src/specs/components/footer-standardised/demo/data--ec.js
+++ b/src/specs/components/footer-standardised/demo/data--ec.js
@@ -39,7 +39,7 @@ module.exports = {
                 icon_position: 'before',
               },
               icon: {
-                path: '/icons.svg',
+                path: '/icon-social-media.svg',
                 name: 'facebook',
                 size: 'xs',
               },
@@ -52,7 +52,7 @@ module.exports = {
                 icon_position: 'before',
               },
               icon: {
-                path: '/icons.svg',
+                path: '/icon-social-media.svg',
                 name: 'twitter',
                 size: 'xs',
               },
@@ -65,7 +65,7 @@ module.exports = {
                 icon_position: 'before',
               },
               icon: {
-                path: '/icons.svg',
+                path: '/icon-social-media.svg',
                 name: 'linkedin',
                 size: 'xs',
               },


### PR DESCRIPTION
Which is the correct version of icons? I included the latest sprite (icon-media-social)
Also we have a problem here, as the links has color white, the icons get filled white but linkedin and facebook are not displaying properly still the twitter icon needs to get filled white in order to be shown. In my opinion, we need another set of icons for fb and linkedin.