### PR TITLE
feat(description-list): add block for definition - FRONT-3204

### DIFF
--- a/src/implementations/twig/components/description-list/README.md
+++ b/src/implementations/twig/components/description-list/README.md
@@ -10,7 +10,7 @@ npm install --save @ecl/twig-component-description-list
 
 - **"items"** (array) (default: [])
   - "term" (string or array of string)
-  - "definition" (string or array of string or array of objects of type "tag")
+  - "definition" (block or array of string or array of objects of type "tag")
 - **"variant"** (optional) (string) (default: '') Modifier of the component (horizontal, vertical, taxonomy)
 - **"extra_classes"** (optional) (string) (default: '') Extra classes (space separated)
 - **"extra_attributes"** (optional) (array) (default: []) Extra attributes

--- a/src/implementations/twig/components/description-list/description-list.html.twig
+++ b/src/implementations/twig/components/description-list/description-list.html.twig
@@ -5,7 +5,7 @@
     - "items" (array) (default: []): format: [
         {
           "term" (string or array of string)
-          "definition" (string or array of string or array of objects of type tag)
+          "definition" (block or array of string or array of objects of type tag)
         },
         ...
       ]
@@ -79,7 +79,7 @@
             </dd>
           {% endif %}
         {% else %}
-          <dd class="ecl-description-list__definition">{{ _item.definition }}</dd>
+          <dd class="ecl-description-list__definition">{%- block definition _item.definition -%}</dd>
         {% endif %}
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
Allow any type of content in the description list's definition