### PR TITLE
fix(radio): Fixing opacity due to cssnano bug - FRONT-3345

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -22,6 +22,8 @@ module.exports = {
       componentSelectors: bemSelector,
       ignoreSelectors: /^\.no-js$/,
     },
+    // Prevent percentages, they break in cssnano
+    'alpha-value-notation': 'number',
     // Allow underscores in class names (BEM)
     'selector-class-pattern': null,
     // Allow underscores in placeholders (BEM)

--- a/src/implementations/vanilla/components/file-upload/file-upload.js
+++ b/src/implementations/vanilla/components/file-upload/file-upload.js
@@ -104,7 +104,7 @@ export class FileUpload {
     let fileList = '';
 
     // Get file names
-    Array.prototype.forEach.call(e.target.files, function (file) {
+    Array.prototype.forEach.call(e.target.files, function themeFile(file) {
       const fileSize = formatBytes(file.size, 1);
       const fileExtension = file.name.split('.').pop();
       fileList += `<li class="ecl-file-upload__item">

--- a/src/implementations/vanilla/components/radio/_radio.scss
+++ b/src/implementations/vanilla/components/radio/_radio.scss
@@ -32,7 +32,7 @@ $_outline-color: null !default;
 
 // Disabled
 .ecl-radio--disabled {
-  opacity: 50%;
+  opacity: 0.5;
 }
 
 .ecl-radio__input {


### PR DESCRIPTION
This is due to a bug in cssnano, https://github.com/cssnano/cssnano/pull/881 which should be fixed in the current major version, we are using the previous (4.x).
So for the moment we can fix this easily not using percentages, i have been adding a stylelint rule so that in case we do it the linter would notice it.
The other fix is still about stylelint, on the file-upload.js file.