### PR TITLE
feat(carousel): Add component - FRONT-2513

### DIFF
--- a/src/implementations/twig/components/carousel/.npmignore
+++ b/src/implementations/twig/components/carousel/.npmignore
@@ -1,0 +1,2 @@
+__snapshots__
+*.js

--- a/src/implementations/twig/components/carousel/README.md
+++ b/src/implementations/twig/components/carousel/README.md
@@ -1,0 +1,52 @@
+# ECL Carousel
+
+npm package: `@ecl/twig-component-carousel`
+
+```shell
+npm install --save @ecl/twig-component-carousel
+```
+
+### Parameters
+
+- **"items"** (array) (default: []): List of page-banner compatible with EC page-banner component structure
+- **"counter_label"** (string) (default: '')
+- **"icon_path"** (string) ) (default: '')
+- **"extra_classes"** (optional) (string) (default: '') Extra classes (space separated)
+- **"extra_attributes"** (optional) (array) (default: []) Extra attributes
+  - "name" (string) Attribute name, eg. 'data-test'
+  - "value" (string) Attribute value, eg: 'data-test-1'
+
+### Example:
+
+<!-- prettier-ignore -->
+```twig 
+{% include '@ecl/carousel/carousel.html.twig' with { 
+  items: [ 
+    { 
+      title: 'EU Budget for the future', 
+      description: 'Innovation, economy, environment and geopolitics', 
+      link: { 
+        link: { 
+          label: 'Subscribe', 
+          path: exampleLink, 
+          aria_label: 'Subscribe', 
+          icon_position: 'after', 
+        }, 
+        icon: { 
+          path: '/icons.svg', 
+          name: 'corner-arrow', 
+          size: 'xs', 
+          transform: 'rotate-90', 
+        }, 
+      }, 
+      image:
+        'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg', 
+      variant: 'image', 
+      centered: false, 
+    }, 
+    ...
+  ], 
+  counter_label: 'of', 
+  icons_path: '/icons.svg', 
+} %} 
+```

--- a/src/implementations/twig/components/carousel/__snapshots__/carousel.test.js.snap
+++ b/src/implementations/twig/components/carousel/__snapshots__/carousel.test.js.snap
@@ -1,0 +1,696 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Carousel Default renders correctly 1`] = `
+<jest>
+  <div
+    class="ecl-carousel"
+    data-ecl-auto-init="Carousel"
+  >
+    <div
+      class="ecl-carousel__slider"
+    >
+      <div>
+        <section
+          class="ecl-page-banner ecl-page-banner--image"
+        >
+          <div
+            class="ecl-page-banner__image"
+            style="background-image:url(https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg)"
+          />
+          <div
+            class="ecl-container"
+          >
+            <div
+              class="ecl-page-banner__container"
+            >
+              <div
+                class="ecl-page-banner__content"
+              >
+                <div
+                  class="ecl-page-banner__title"
+                >
+                  EU Budget for the future
+                </div>
+                <p
+                  class="ecl-page-banner__description"
+                >
+                  Innovation, economy, environment and geopolitics
+                </p>
+                <a
+                  aria-label="Subscribe"
+                  class="ecl-link ecl-link--cta ecl-link--icon ecl-link--icon-after ecl-page-banner__link-cta"
+                  href="/example"
+                >
+                  <span
+                    class="ecl-link__label"
+                  >
+                    Subscribe
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-link__icon"
+                    focusable="false"
+                  >
+                    <use
+                      xlink:href="/icons.svg#corner-arrow"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div>
+        <section
+          class="ecl-page-banner ecl-page-banner--image-gradient"
+        >
+          <div
+            class="ecl-page-banner__image"
+            style="background-image:url(https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg)"
+          />
+          <div
+            class="ecl-container"
+          >
+            <div
+              class="ecl-page-banner__container"
+            >
+              <div
+                class="ecl-page-banner__content"
+              >
+                <div
+                  class="ecl-page-banner__title"
+                >
+                  EU Budget for the future
+                </div>
+                <p
+                  class="ecl-page-banner__description"
+                >
+                  Innovation, economy, environment and geopolitics
+                </p>
+                <a
+                  aria-label="Subscribe"
+                  class="ecl-link ecl-link--cta ecl-link--icon ecl-link--icon-after ecl-page-banner__link-cta"
+                  href="/example"
+                >
+                  <span
+                    class="ecl-link__label"
+                  >
+                    Subscribe
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-link__icon"
+                    focusable="false"
+                  >
+                    <use
+                      xlink:href="/icons.svg#corner-arrow"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div>
+        <section
+          class="ecl-page-banner ecl-page-banner--image-shade"
+        >
+          <div
+            class="ecl-page-banner__image"
+            style="background-image:url(https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg)"
+          />
+          <div
+            class="ecl-container"
+          >
+            <div
+              class="ecl-page-banner__container"
+            >
+              <div
+                class="ecl-page-banner__content"
+              >
+                <div
+                  class="ecl-page-banner__title"
+                >
+                  EU Budget for the future
+                </div>
+                <p
+                  class="ecl-page-banner__description"
+                >
+                  Innovation, economy, environment and geopolitics
+                </p>
+                <a
+                  aria-label="Subscribe"
+                  class="ecl-link ecl-link--cta ecl-link--icon ecl-link--icon-after ecl-page-banner__link-cta"
+                  href="/example"
+                >
+                  <span
+                    class="ecl-link__label"
+                  >
+                    Subscribe
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-link__icon"
+                    focusable="false"
+                  >
+                    <use
+                      xlink:href="/icons.svg#corner-arrow"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+    <div
+      class="ecl-carousel__controls"
+    >
+      <button
+        class="ecl-carousel__prev"
+      >
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--m ecl-icon--rotate-270 ecl-icon--inverted ecl-u-d-block"
+          focusable="false"
+        >
+          <use
+            xlink:href="/icons.svg#corner-arrow"
+          />
+        </svg>
+      </button>
+      <button
+        class="ecl-carousel__next"
+      >
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--m ecl-icon--rotate-90 ecl-icon--inverted ecl-u-d-block"
+          focusable="false"
+        >
+          <use
+            xlink:href="/icons.svg#corner-arrow"
+          />
+        </svg>
+      </button>
+      <div
+        class="ecl-container"
+      >
+        <button
+          class="ecl-carousel__autoplay"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-icon--inverted"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#pause"
+            />
+          </svg>
+        </button>
+        <div
+          class="ecl-carousel__pagination"
+        >
+          <span
+            class="ecl-carousel__current"
+          >
+            1
+          </span>
+           of 3
+      
+        </div>
+        <div
+          class="ecl-carousel__navigation"
+        />
+      </div>
+    </div>
+  </div>
+</jest>
+`;
+
+exports[`Carousel Default renders correctly with extra attributes 1`] = `
+<jest>
+  <div
+    class="ecl-carousel"
+    data-ecl-auto-init="Carousel"
+    data-test="data-test-value"
+    data-test-1="data-test-value-1"
+  >
+    <div
+      class="ecl-carousel__slider"
+    >
+      <div>
+        <section
+          class="ecl-page-banner ecl-page-banner--image"
+        >
+          <div
+            class="ecl-page-banner__image"
+            style="background-image:url(https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg)"
+          />
+          <div
+            class="ecl-container"
+          >
+            <div
+              class="ecl-page-banner__container"
+            >
+              <div
+                class="ecl-page-banner__content"
+              >
+                <div
+                  class="ecl-page-banner__title"
+                >
+                  EU Budget for the future
+                </div>
+                <p
+                  class="ecl-page-banner__description"
+                >
+                  Innovation, economy, environment and geopolitics
+                </p>
+                <a
+                  aria-label="Subscribe"
+                  class="ecl-link ecl-link--cta ecl-link--icon ecl-link--icon-after ecl-page-banner__link-cta"
+                  href="/example"
+                >
+                  <span
+                    class="ecl-link__label"
+                  >
+                    Subscribe
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-link__icon"
+                    focusable="false"
+                  >
+                    <use
+                      xlink:href="/icons.svg#corner-arrow"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div>
+        <section
+          class="ecl-page-banner ecl-page-banner--image-gradient"
+        >
+          <div
+            class="ecl-page-banner__image"
+            style="background-image:url(https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg)"
+          />
+          <div
+            class="ecl-container"
+          >
+            <div
+              class="ecl-page-banner__container"
+            >
+              <div
+                class="ecl-page-banner__content"
+              >
+                <div
+                  class="ecl-page-banner__title"
+                >
+                  EU Budget for the future
+                </div>
+                <p
+                  class="ecl-page-banner__description"
+                >
+                  Innovation, economy, environment and geopolitics
+                </p>
+                <a
+                  aria-label="Subscribe"
+                  class="ecl-link ecl-link--cta ecl-link--icon ecl-link--icon-after ecl-page-banner__link-cta"
+                  href="/example"
+                >
+                  <span
+                    class="ecl-link__label"
+                  >
+                    Subscribe
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-link__icon"
+                    focusable="false"
+                  >
+                    <use
+                      xlink:href="/icons.svg#corner-arrow"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div>
+        <section
+          class="ecl-page-banner ecl-page-banner--image-shade"
+        >
+          <div
+            class="ecl-page-banner__image"
+            style="background-image:url(https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg)"
+          />
+          <div
+            class="ecl-container"
+          >
+            <div
+              class="ecl-page-banner__container"
+            >
+              <div
+                class="ecl-page-banner__content"
+              >
+                <div
+                  class="ecl-page-banner__title"
+                >
+                  EU Budget for the future
+                </div>
+                <p
+                  class="ecl-page-banner__description"
+                >
+                  Innovation, economy, environment and geopolitics
+                </p>
+                <a
+                  aria-label="Subscribe"
+                  class="ecl-link ecl-link--cta ecl-link--icon ecl-link--icon-after ecl-page-banner__link-cta"
+                  href="/example"
+                >
+                  <span
+                    class="ecl-link__label"
+                  >
+                    Subscribe
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-link__icon"
+                    focusable="false"
+                  >
+                    <use
+                      xlink:href="/icons.svg#corner-arrow"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+    <div
+      class="ecl-carousel__controls"
+    >
+      <button
+        class="ecl-carousel__prev"
+      >
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--m ecl-icon--rotate-270 ecl-icon--inverted ecl-u-d-block"
+          focusable="false"
+        >
+          <use
+            xlink:href="/icons.svg#corner-arrow"
+          />
+        </svg>
+      </button>
+      <button
+        class="ecl-carousel__next"
+      >
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--m ecl-icon--rotate-90 ecl-icon--inverted ecl-u-d-block"
+          focusable="false"
+        >
+          <use
+            xlink:href="/icons.svg#corner-arrow"
+          />
+        </svg>
+      </button>
+      <div
+        class="ecl-container"
+      >
+        <button
+          class="ecl-carousel__autoplay"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-icon--inverted"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#pause"
+            />
+          </svg>
+        </button>
+        <div
+          class="ecl-carousel__pagination"
+        >
+          <span
+            class="ecl-carousel__current"
+          >
+            1
+          </span>
+           of 3
+      
+        </div>
+        <div
+          class="ecl-carousel__navigation"
+        />
+      </div>
+    </div>
+  </div>
+</jest>
+`;
+
+exports[`Carousel Default renders correctly with extra class names 1`] = `
+<jest>
+  <div
+    class="ecl-carousel custom-class custom-class--test"
+    data-ecl-auto-init="Carousel"
+  >
+    <div
+      class="ecl-carousel__slider"
+    >
+      <div>
+        <section
+          class="ecl-page-banner ecl-page-banner--image"
+        >
+          <div
+            class="ecl-page-banner__image"
+            style="background-image:url(https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg)"
+          />
+          <div
+            class="ecl-container"
+          >
+            <div
+              class="ecl-page-banner__container"
+            >
+              <div
+                class="ecl-page-banner__content"
+              >
+                <div
+                  class="ecl-page-banner__title"
+                >
+                  EU Budget for the future
+                </div>
+                <p
+                  class="ecl-page-banner__description"
+                >
+                  Innovation, economy, environment and geopolitics
+                </p>
+                <a
+                  aria-label="Subscribe"
+                  class="ecl-link ecl-link--cta ecl-link--icon ecl-link--icon-after ecl-page-banner__link-cta"
+                  href="/example"
+                >
+                  <span
+                    class="ecl-link__label"
+                  >
+                    Subscribe
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-link__icon"
+                    focusable="false"
+                  >
+                    <use
+                      xlink:href="/icons.svg#corner-arrow"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div>
+        <section
+          class="ecl-page-banner ecl-page-banner--image-gradient"
+        >
+          <div
+            class="ecl-page-banner__image"
+            style="background-image:url(https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg)"
+          />
+          <div
+            class="ecl-container"
+          >
+            <div
+              class="ecl-page-banner__container"
+            >
+              <div
+                class="ecl-page-banner__content"
+              >
+                <div
+                  class="ecl-page-banner__title"
+                >
+                  EU Budget for the future
+                </div>
+                <p
+                  class="ecl-page-banner__description"
+                >
+                  Innovation, economy, environment and geopolitics
+                </p>
+                <a
+                  aria-label="Subscribe"
+                  class="ecl-link ecl-link--cta ecl-link--icon ecl-link--icon-after ecl-page-banner__link-cta"
+                  href="/example"
+                >
+                  <span
+                    class="ecl-link__label"
+                  >
+                    Subscribe
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-link__icon"
+                    focusable="false"
+                  >
+                    <use
+                      xlink:href="/icons.svg#corner-arrow"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div>
+        <section
+          class="ecl-page-banner ecl-page-banner--image-shade"
+        >
+          <div
+            class="ecl-page-banner__image"
+            style="background-image:url(https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg)"
+          />
+          <div
+            class="ecl-container"
+          >
+            <div
+              class="ecl-page-banner__container"
+            >
+              <div
+                class="ecl-page-banner__content"
+              >
+                <div
+                  class="ecl-page-banner__title"
+                >
+                  EU Budget for the future
+                </div>
+                <p
+                  class="ecl-page-banner__description"
+                >
+                  Innovation, economy, environment and geopolitics
+                </p>
+                <a
+                  aria-label="Subscribe"
+                  class="ecl-link ecl-link--cta ecl-link--icon ecl-link--icon-after ecl-page-banner__link-cta"
+                  href="/example"
+                >
+                  <span
+                    class="ecl-link__label"
+                  >
+                    Subscribe
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-link__icon"
+                    focusable="false"
+                  >
+                    <use
+                      xlink:href="/icons.svg#corner-arrow"
+                    />
+                  </svg>
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+    <div
+      class="ecl-carousel__controls"
+    >
+      <button
+        class="ecl-carousel__prev"
+      >
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--m ecl-icon--rotate-270 ecl-icon--inverted ecl-u-d-block"
+          focusable="false"
+        >
+          <use
+            xlink:href="/icons.svg#corner-arrow"
+          />
+        </svg>
+      </button>
+      <button
+        class="ecl-carousel__next"
+      >
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--m ecl-icon--rotate-90 ecl-icon--inverted ecl-u-d-block"
+          focusable="false"
+        >
+          <use
+            xlink:href="/icons.svg#corner-arrow"
+          />
+        </svg>
+      </button>
+      <div
+        class="ecl-container"
+      >
+        <button
+          class="ecl-carousel__autoplay"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-icon--inverted"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#pause"
+            />
+          </svg>
+        </button>
+        <div
+          class="ecl-carousel__pagination"
+        >
+          <span
+            class="ecl-carousel__current"
+          >
+            1
+          </span>
+           of 3
+      
+        </div>
+        <div
+          class="ecl-carousel__navigation"
+        />
+      </div>
+    </div>
+  </div>
+</jest>
+`;

--- a/src/implementations/twig/components/carousel/carousel.html.twig
+++ b/src/implementations/twig/components/carousel/carousel.html.twig
@@ -1,0 +1,95 @@
+{% spaceless %}
+
+{#
+  Parameters:
+    - "items" (array) (default: []): List of page-banner compatible with EC page-banner component structure
+    - "counter_label" (string) (default: 'of')
+    - "icon_path" (string) (default: '') Path to the icons file
+    - "extra_classes" (string) (default: '')
+    - "extra_attributes" (array) (default: []): format: [
+        {
+          "name" (string) (default: ''),
+          "value" (optional) (string)
+        ...
+      ]
+#}
+
+{# Internal properties #}
+
+{% set _css_class = 'ecl-carousel' %}
+{% set _extra_attributes = 'data-ecl-auto-init="Carousel"' %}
+{% set _items = items|default('') %}
+{% set _counter_label = counter_label|default('of') %}
+{% set _icon_path = icon_path|default('') %}
+
+{# Internal logic - Process properties #}
+
+{% if extra_classes is defined and extra_classes is not empty %}
+  {% set _css_class = _css_class ~ ' ' ~ extra_classes %}
+{% endif %}
+
+{% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
+  {% for attr in extra_attributes %}
+    {% if attr.value is defined %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+    {% else %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+{# Print the result #}
+{% if _items is not empty and _items is iterable %}
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+  <div class="ecl-carousel__slider">
+  {% for item in _items %}
+    <div>
+      {% include '@ecl/page-banner/page-banner.html.twig' with item only %}
+    </div>
+  {% endfor %}
+  </div>
+  <div class="ecl-carousel__controls">
+    <button class="ecl-carousel__prev">
+      {% include '@ecl/icon/icon.html.twig' with {
+        icon: {
+          path: _icon_path,
+          name: 'corner-arrow',
+          size: 'm',
+          transform: 'rotate-270',
+          color: 'inverted',
+        },
+        extra_classes: 'ecl-u-d-block',
+      } only %}
+    </button>
+    <button class="ecl-carousel__next">
+      {% include '@ecl/icon/icon.html.twig' with {
+        icon: {
+          path: _icon_path,
+          name: 'corner-arrow',
+          size: 'm',
+          transform: 'rotate-90',
+          color: 'inverted',
+        },
+        extra_classes: 'ecl-u-d-block',
+      } only %}
+    </button>
+    <div class="ecl-container">
+      <button class="ecl-carousel__autoplay">
+        {% include '@ecl/icon/icon.html.twig' with {
+        icon: {
+          path: _icon_path,
+          name: 'pause',
+          size: 'm',
+          color: 'inverted',
+        },
+      } only %}
+      </button>
+      <div class="ecl-carousel__pagination">
+        <span class="ecl-carousel__current">1</span>&nbsp;{{ _counter_label }} {{_items|length}}
+      </div>
+      <div class="ecl-carousel__navigation"></div>
+    </div>
+  </div>
+</div>
+{% endif %}
+{% endspaceless %}

--- a/src/implementations/twig/components/carousel/carousel.story.js
+++ b/src/implementations/twig/components/carousel/carousel.story.js
@@ -1,0 +1,21 @@
+import { withNotes } from '@ecl/storybook-addon-notes';
+import withCode from '@ecl/storybook-addon-code';
+import { correctSvgPath } from '@ecl/story-utils';
+
+import dataDefault from '@ecl/specs-component-carousel/demo/data';
+import carousel from './carousel.html.twig';
+import notes from './README.md';
+
+const prepareData = (data, args) => {
+  return Object.assign(correctSvgPath(data), args);
+};
+
+export default {
+  title: 'Components/Carousel',
+};
+
+export const Default = (args) => carousel(prepareData(dataDefault, args));
+
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes, json: dataDefault } };
+Default.decorators = [withNotes, withCode];

--- a/src/implementations/twig/components/carousel/carousel.test.js
+++ b/src/implementations/twig/components/carousel/carousel.test.js
@@ -1,0 +1,39 @@
+import { merge, renderTwigFileAsNode } from '@ecl/test-utils';
+
+import data from '@ecl/specs-component-carousel/demo/data';
+
+describe('Carousel', () => {
+  const template = '@ecl/carousel/carousel.html.twig';
+  const render = (params) => renderTwigFileAsNode(template, params);
+
+  describe('Default', () => {
+    test('renders correctly', () => {
+      expect.assertions(1);
+
+      return expect(render(data)).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra class names', () => {
+      expect.assertions(1);
+
+      const optionsWithExtraClasses = merge(data, {
+        extra_classes: 'custom-class custom-class--test',
+      });
+
+      return expect(render(optionsWithExtraClasses)).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra attributes', () => {
+      expect.assertions(1);
+
+      const optionsWithExtraClasses = merge(data, {
+        extra_attributes: [
+          { name: 'data-test', value: 'data-test-value' },
+          { name: 'data-test-1', value: 'data-test-value-1' },
+        ],
+      });
+
+      return expect(render(optionsWithExtraClasses)).resolves.toMatchSnapshot();
+    });
+  });
+});

--- a/src/implementations/twig/components/carousel/package.json
+++ b/src/implementations/twig/components/carousel/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@ecl/twig-component-carousel",
+  "author": "European Commission",
+  "license": "EUPL-1.2",
+  "version": "3.1.2",
+  "description": "ECL Carousel",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@ecl/twig-component-icon": "^3.1.2",
+    "@ecl/vanilla-component-page-banner": "^3.1.2"
+  },
+  "devDependencies": {
+    "@ecl/specs-component-carousel": "^3.1.2",
+    "@ecl/vanilla-component-carousel": "^3.1.2"
+  }
+}

--- a/src/implementations/vanilla/components/carousel/README.md
+++ b/src/implementations/vanilla/components/carousel/README.md
@@ -1,0 +1,1 @@
+# Carousel

--- a/src/implementations/vanilla/components/carousel/_carousel.scss
+++ b/src/implementations/vanilla/components/carousel/_carousel.scss
@@ -166,7 +166,7 @@ $_outline-width: null !default;
       .ecl-page-banner__content {
         margin: 0;
       }
-  
+
       &.tns-slide-active {
         .ecl-page-banner__content {
           margin: 0;

--- a/src/implementations/vanilla/components/carousel/_carousel.scss
+++ b/src/implementations/vanilla/components/carousel/_carousel.scss
@@ -1,0 +1,172 @@
+/* stylelint-disable max-nesting-depth, no-descending-specificity */
+
+@use 'sass:map';
+@use '@ecl/theme-dev/theme';
+@use '@ecl/vanilla-layout-grid/mixins/breakpoints';
+
+/* stylelint-disable-next-line scss/at-import-partial-extension-blacklist, no-invalid-position-at-import-rule */
+@import 'tiny-slider/dist/tiny-slider';
+
+$_button-arrows-background: null !default;
+$_controls-background: null !default;
+$_outline-color: null !default;
+$_outline-width: null !default;
+
+.ecl-carousel {
+  overflow: hidden;
+  position: relative;
+
+  .ecl-page-banner,
+  .ecl-page-banner__image::before {
+    border-radius: 0;
+    box-shadow: none;
+    padding-right: map.get(theme.$spacing, 'l');
+  }
+}
+
+.ecl-carousel__slider {
+  display: flex;
+  position: relative;
+
+  .tns-item {
+    position: relative;
+    &::before {
+      background: map.get(theme.$color, 'white-100');
+      content: '';
+      display: block;
+      height: 100%;
+      left: -#{map.get(theme.$spacing, '2xs')};
+      position: absolute;
+      top: 0;
+      width: map.get(theme.$spacing, '2xs');
+    }
+
+    &.tns-slide-active {
+      margin-right: -#{map.get(theme.$spacing, 'l')};
+    }
+
+    .ecl-page-banner {
+      box-shadow: inset -10px 0 0 -6px map.get(theme.$color, 'white-100');
+    }
+  }
+}
+
+.ecl-carousel__controls {
+  background-color: $_controls-background;
+  padding: map.get(theme.$spacing, 's') 0;
+
+  .ecl-container {
+    display: flex;
+  }
+}
+
+.ecl-carousel__prev,
+.ecl-carousel__next {
+  background: $_button-arrows-background;
+  border: 0;
+  cursor: pointer;
+  display: none;
+  padding: map.get(theme.$spacing, 's');
+  position: absolute;
+  top: calc(50% - 22px);
+  transform: translateY(-50%);
+  &:focus {
+    outline: $_outline-width solid $_outline-color;
+  }
+
+  li:hover {
+    cursor: pointer;
+  }
+}
+
+.ecl-carousel__prev {
+  left: 0;
+  &:focus {
+    margin-left: $_outline-width;
+    padding-left: calc(#{map.get(theme.$spacing, 's')} - #{$_outline-width});
+  }
+}
+
+.ecl-carousel__next {
+  right: 0;
+  &:focus {
+    margin-right: $_outline-width;
+    padding-right: calc(#{map.get(theme.$spacing, 's')} - #{$_outline-width});
+  }
+}
+
+.ecl-carousel__autoplay {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  margin-right: map.get(theme.$spacing, 'l');
+  padding: 0;
+
+  &:focus {
+    outline: $_outline-width solid $_outline-color;
+  }
+}
+
+.ecl-carousel__pagination {
+  align-items: center;
+  color: map.get(theme.$color, 'white-100');
+  display: flex;
+  font: map.get(theme.$font, 'm');
+  font-weight: map.get(theme.$font-weight, 'bold');
+  margin-right: map.get(theme.$spacing, 'l');
+}
+
+.ecl-carousel__navigation {
+  align-items: center;
+  display: flex;
+}
+
+.ecl-carousel__pagination--item {
+  background-color: transparent;
+  border: 2px solid map.get(theme.$color, 'white-100');
+  border-radius: 50%;
+  cursor: pointer;
+  height: 1rem;
+  margin-right: map.get(theme.$spacing, 'xs');
+  width: 1rem;
+
+  &:focus {
+    outline: $_outline-width solid $_outline-color;
+  }
+
+  &.tns-nav-active {
+    background-color: map.get(theme.$color, 'white-100');
+  }
+}
+
+/* stylelint-disable-next-line order/order */
+@include breakpoints.up('l') {
+  .ecl-carousel {
+    .ecl-page-banner,
+    .ecl-page-banner__image::before {
+      padding-right: 0;
+    }
+  }
+
+  .ecl-carousel__slider {
+    .tns-item {
+      &::before {
+        content: none;
+      }
+      &.tns-slide-active {
+        margin: 0;
+      }
+      .ecl-page-banner {
+        box-shadow: none;
+      }
+    }
+  }
+
+  .ecl-carousel__prev,
+  .ecl-carousel__next {
+    display: block;
+  }
+}

--- a/src/implementations/vanilla/components/carousel/_carousel.scss
+++ b/src/implementations/vanilla/components/carousel/_carousel.scss
@@ -42,14 +42,13 @@ $_outline-width: null !default;
     }
 
     .ecl-page-banner__content {
-      margin-right: map.get(theme.$spacing, 'l');
-      transition: all 0.2s;
+      padding-right: map.get(theme.$spacing, 'l');
     }
 
     &.tns-slide-active {
       .ecl-page-banner__content {
-        margin-left: map.get(theme.$spacing, 'l');
-        margin-right: 0;
+        padding-left: map.get(theme.$spacing, 'l');
+        padding-right: 0;
       }
     }
   }

--- a/src/implementations/vanilla/components/carousel/_carousel.scss
+++ b/src/implementations/vanilla/components/carousel/_carousel.scss
@@ -20,12 +20,12 @@ $_outline-width: null !default;
   .ecl-page-banner__image::before {
     border-radius: 0;
     box-shadow: none;
-    padding-right: map.get(theme.$spacing, 'l');
   }
 }
 
 .ecl-carousel__slider {
   display: flex;
+  margin-left: -#{map.get(theme.$spacing, 'l')};
   position: relative;
 
   .tns-item {
@@ -41,12 +41,16 @@ $_outline-width: null !default;
       width: map.get(theme.$spacing, '2xs');
     }
 
-    &.tns-slide-active {
-      margin-right: -#{map.get(theme.$spacing, 'l')};
+    .ecl-page-banner__content {
+      margin-right: map.get(theme.$spacing, 'l');
+      transition: all 0.2s;
     }
 
-    .ecl-page-banner {
-      box-shadow: inset -10px 0 0 -6px map.get(theme.$color, 'white-100');
+    &.tns-slide-active {
+      .ecl-page-banner__content {
+        margin-left: map.get(theme.$spacing, 'l');
+        margin-right: 0;
+      }
     }
   }
 }
@@ -142,25 +146,31 @@ $_outline-width: null !default;
   }
 }
 
-/* stylelint-disable-next-line order/order */
-@include breakpoints.up('l') {
-  .ecl-carousel {
-    .ecl-page-banner,
-    .ecl-page-banner__image::before {
-      padding-right: 0;
+@include breakpoints.down('l') {
+  .ecl-carousel__controls,
+  .ecl-carousel__slider .ecl-page-banner {
+    .ecl-container {
+      width: 100%;
     }
   }
+}
 
+/* stylelint-disable-next-line order/order */
+@include breakpoints.up('l') {
   .ecl-carousel__slider {
+    margin: 0;
     .tns-item {
       &::before {
         content: none;
       }
-      &.tns-slide-active {
+      .ecl-page-banner__content {
         margin: 0;
       }
-      .ecl-page-banner {
-        box-shadow: none;
+  
+      &.tns-slide-active {
+        .ecl-page-banner__content {
+          margin: 0;
+        }
       }
     }
   }

--- a/src/implementations/vanilla/components/carousel/carousel-ec.scss
+++ b/src/implementations/vanilla/components/carousel/carousel-ec.scss
@@ -1,0 +1,9 @@
+@use 'sass:map';
+@use '@ecl/theme-dev/theme';
+@use 'carousel' with
+  (
+    $_button_arrows-background: map.get(theme.$color, 'blue-130'),
+    $_controls-background: map.get(theme.$color, 'blue-130'),
+    $_outline-color: map.get(theme.$color, 'yellow-100'),
+    $_outline-width: 3px
+  );

--- a/src/implementations/vanilla/components/carousel/carousel-eu.scss
+++ b/src/implementations/vanilla/components/carousel/carousel-eu.scss
@@ -1,0 +1,9 @@
+@use 'sass:map';
+@use '@ecl/theme-dev/theme';
+@use 'carousel' with
+  (
+    $_button-arrows-background: rgba(map.get(theme.$color, 'blue-140'), 0.5),
+    $_controls-background: map.get(theme.$color, 'blue-140'),
+    $_outline-color: map.get(theme.$color, 'accent-blue-100'),
+    $_outline-width: 2px
+  );

--- a/src/implementations/vanilla/components/carousel/carousel-print.scss
+++ b/src/implementations/vanilla/components/carousel/carousel-print.scss
@@ -1,0 +1,3 @@
+.ecl-carousel__controls {
+  display: none;
+}

--- a/src/implementations/vanilla/components/carousel/carousel.js
+++ b/src/implementations/vanilla/components/carousel/carousel.js
@@ -112,6 +112,8 @@ export class Carousel {
       autoplayTimeout: 7000,
       autoplayButtonOutput: false,
       arrowKeys: true,
+      slideBy: 'page',
+      swipeAngle: false,
     });
 
     // Bind events

--- a/src/implementations/vanilla/components/carousel/carousel.js
+++ b/src/implementations/vanilla/components/carousel/carousel.js
@@ -1,0 +1,175 @@
+/* eslint-disable class-methods-use-this */
+import { queryOne } from '@ecl/dom-utils';
+import { tns } from 'tiny-slider/src/tiny-slider';
+
+/**
+ * @param {HTMLElement} element DOM element for component instantiation and scope
+ * @param {Object} options
+ * @param {String} options.sliderSelector Selector for carousel
+ * @param {String} options.prevSelector Selector for prev button
+ * @param {String} options.nextSelector Selector for next button
+ * @param {String} options.toggleAutoplaySelector Selector for autoPlay button
+ * @param {String} options.navigationContainer Selector for navigation container
+ * @param {String} options.paginationContainer Selector for pagination container
+ * @param {String} options.currentSlideSelector Selector for the counter current slide number
+ */
+export class Carousel {
+  /**
+   * @static
+   * Shorthand for instance creation and initialisation.
+   *
+   * @param {HTMLElement} root DOM element for component instantiation and scope
+   *
+   * @return {Carousel} An instance of Carousel.
+   */
+  static autoInit(root, { CAROUSEL: defaultOptions = {} } = {}) {
+    const carousel = new Carousel(root, defaultOptions);
+    carousel.init();
+    root.ECLCarousel = carousel;
+    return carousel;
+  }
+
+  constructor(
+    element,
+    {
+      sliderSelector = '.ecl-carousel__slider',
+      prevSelector = '.ecl-carousel__prev',
+      nextSelector = '.ecl-carousel__next',
+      toggleAutoplaySelector = '.ecl-carousel__autoplay',
+      currentSlideSelector = '.ecl-carousel__current',
+      navigationContainer = '.ecl-carousel__navigation',
+      paginationContainer = '.ecl-carousel__pagination',
+      attachClickListener = true,
+    } = {}
+  ) {
+    // Check element
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+      throw new TypeError(
+        'DOM element should be given to initialize this widget.'
+      );
+    }
+
+    this.element = element;
+
+    // Options
+    this.sliderSelector = sliderSelector;
+    this.prevSelector = prevSelector;
+    this.nextSelector = nextSelector;
+    this.toggleAutoplaySelector = toggleAutoplaySelector;
+    this.currentSlideSelector = currentSlideSelector;
+    this.navigationContainer = navigationContainer;
+    this.paginationContainer = paginationContainer;
+    this.attachClickListener = attachClickListener;
+
+    // Private
+    this.slider = null;
+    this.tnsSlider = null;
+    this.prev = null;
+    this.next = null;
+    this.toggleAutoPlay = null;
+    this.currentSlide = null;
+    this.navigation = null;
+    this.pagination = null;
+    this.autoPlay = true;
+
+    // Bind `this` for use in callbacks
+    this.slideChanged = this.slideChanged.bind(this);
+    this.handleAutoPlay = this.handleAutoPlay.bind(this);
+  }
+
+  /**
+   * Initialise component.
+   */
+  init() {
+    this.slider = queryOne(this.sliderSelector, this.element);
+    this.prev = queryOne(this.prevSelector, this.element);
+    this.next = queryOne(this.nextSelector, this.element);
+    this.toggleAutoPlay = queryOne(this.toggleAutoplaySelector, this.element);
+    this.navigation = queryOne(this.navigationContainer, this.element);
+    this.pagination = queryOne(this.paginationContainer, this.element);
+    this.currentSlide = queryOne(this.currentSlideSelector, this.element);
+
+    const slideCount = this.slider.childElementCount;
+    if (this.navigation) {
+      for (let i = 0; i < slideCount; i += 1) {
+        const btn = document.createElement('button');
+        btn.classList.add('ecl-carousel__pagination--item');
+        this.navigation.appendChild(btn);
+      }
+    }
+
+    this.tnsSlider = tns({
+      container: this.slider,
+      prevButton: this.prev,
+      nextButton: this.next,
+      navContainer: this.navigation,
+      controls: !!(this.prev && this.next),
+      nav: !!this.navigation,
+      items: 1,
+      speed: 400,
+      autoplay: !!this.autoPlay,
+      autoplayHoverPause: true,
+      autoplayTimeout: 7000,
+      autoplayButtonOutput: false,
+      arrowKeys: true,
+    });
+
+    // Bind events
+    if (this.currentSlide) {
+      this.tnsSlider.events.on('indexChanged', this.slideChanged);
+    }
+    if (this.attachClickListener && this.toggleAutoPlay) {
+      this.toggleAutoPlay.addEventListener('click', this.handleAutoPlay);
+    }
+
+    return this.tnsSlider;
+  }
+
+  /**
+   * Destroy component.
+   */
+  destroy() {
+    if (this.attachClickListener && this.toggleAutoPlay) {
+      this.toggleAutoPlay.removeEventListener('click', this.handleAutoPlay);
+    }
+    if (this.currentSlide) {
+      this.tnsSlider.events.off('indexChanged', this.slideChanged);
+    }
+    if (this.tnsSlider) {
+      this.tnsSlider.destroy();
+    }
+  }
+
+  /**
+   * Slider index change callback.
+   * @param {Object} info
+   */
+  slideChanged(info) {
+    this.currentSlide.textContent = info.displayIndex;
+  }
+
+  /**
+   * Toggles play/pause slides.
+   */
+  handleAutoPlay() {
+    const useNode = queryOne(
+      `${this.toggleAutoplaySelector} .ecl-icon use`,
+      this.element
+    );
+    const originalXlinkHref = useNode.getAttribute('xlink:href');
+    let newXlinkHref = '';
+
+    if (!this.autoPlay) {
+      this.tnsSlider.play();
+      this.autoPlay = true;
+      newXlinkHref = originalXlinkHref.replace('play', 'pause');
+    } else {
+      this.tnsSlider.pause();
+      this.autoPlay = false;
+      newXlinkHref = originalXlinkHref.replace('pause', 'play');
+    }
+    useNode.setAttribute('xlink:href', newXlinkHref);
+  }
+}
+
+export default Carousel;

--- a/src/implementations/vanilla/components/carousel/package.json
+++ b/src/implementations/vanilla/components/carousel/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@ecl/vanilla-component-carousel",
+  "author": "European Commission",
+  "license": "EUPL-1.2",
+  "version": "3.1.2",
+  "description": "ECL Carousel",
+  "main": "carousel.js",
+  "module": "carousel.js",
+  "style": "carousel.scss",
+  "sass": "carousel.scss",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@ecl/dom-utils": "^3.1.2",
+    "@ecl/theme-dev": "^3.1.2",
+    "@ecl/vanilla-component-page-banner": "^3.1.2",
+    "@ecl/vanilla-layout-grid": "^3.1.2",
+    "tiny-slider": "2.9.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}

--- a/src/presets/dev/package.json
+++ b/src/presets/dev/package.json
@@ -18,6 +18,7 @@
     "@ecl/vanilla-component-breadcrumb-standardised": "^3.1.2",
     "@ecl/vanilla-component-button": "^3.1.2",
     "@ecl/vanilla-component-card": "^3.1.2",
+    "@ecl/vanilla-component-carousel": "^3.1.2",
     "@ecl/vanilla-component-checkbox": "^3.1.2",
     "@ecl/vanilla-component-date-block": "^3.1.2",
     "@ecl/vanilla-component-datepicker": "^3.1.2",

--- a/src/presets/dev/src/dev.js
+++ b/src/presets/dev/src/dev.js
@@ -2,6 +2,7 @@ import '@ecl/dom-utils/polyfills';
 
 export * from '@ecl/dom-utils/autoinit';
 export * from '@ecl/vanilla-component-accordion';
+export * from '@ecl/vanilla-component-carousel';
 export * from '@ecl/vanilla-component-datepicker';
 export * from '@ecl/vanilla-component-breadcrumb-core';
 export * from '@ecl/vanilla-component-breadcrumb-standardised';

--- a/src/presets/dev/src/dev.scss
+++ b/src/presets/dev/src/dev.scss
@@ -40,6 +40,7 @@
 
 // Organisms
 @use '@ecl/vanilla-component-accordion/accordion';
+@use '@ecl/vanilla-component-carousel/carousel';
 @use '@ecl/vanilla-component-gallery/gallery';
 @use '@ecl/vanilla-component-inpage-navigation/inpage-navigation';
 @use '@ecl/vanilla-component-page-header-core/page-header-core';

--- a/src/presets/ec/src/ec-print.scss
+++ b/src/presets/ec/src/ec-print.scss
@@ -51,6 +51,7 @@
 
 // Organisms
 @use '@ecl/vanilla-component-accordion/accordion-print';
+@use '@ecl/vanilla-component-carousel/carousel-print';
 @use '@ecl/vanilla-component-gallery/gallery-print';
 @use '@ecl/vanilla-component-page-header-core/page-header-core-print';
 @use '@ecl/vanilla-component-page-header-harmonised/page-header-harmonised-print';

--- a/src/presets/ec/src/ec.scss
+++ b/src/presets/ec/src/ec.scss
@@ -52,6 +52,7 @@
 
 // Organisms
 @use '@ecl/vanilla-component-accordion/accordion-ec';
+@use '@ecl/vanilla-component-carousel/carousel-ec';
 @use '@ecl/vanilla-component-gallery/gallery-ec';
 @use '@ecl/vanilla-component-page-header-core/page-header-core-ec';
 @use '@ecl/vanilla-component-page-header-harmonised/page-header-harmonised';

--- a/src/presets/eu/src/eu-print.scss
+++ b/src/presets/eu/src/eu-print.scss
@@ -51,6 +51,7 @@
 
 // Organisms
 @use '@ecl/vanilla-component-accordion/accordion-print';
+@use '@ecl/vanilla-component-carousel/carousel-print';
 @use '@ecl/vanilla-component-gallery/gallery-print';
 @use '@ecl/vanilla-component-page-header-core/page-header-core-print';
 @use '@ecl/vanilla-component-page-header-harmonised/page-header-harmonised-print';

--- a/src/presets/eu/src/eu.scss
+++ b/src/presets/eu/src/eu.scss
@@ -52,6 +52,7 @@
 
 // Organisms
 @use '@ecl/vanilla-component-accordion/accordion-eu';
+@use '@ecl/vanilla-component-carousel/carousel-eu';
 @use '@ecl/vanilla-component-gallery/gallery-eu';
 @use '@ecl/vanilla-component-page-header-core/page-header-core-eu';
 @use '@ecl/vanilla-component-page-header-harmonised/page-header-harmonised';

--- a/src/specs/components/carousel/demo/data.js
+++ b/src/specs/components/carousel/demo/data.js
@@ -1,0 +1,75 @@
+const publicUrl = process.env.PUBLIC_URL || '';
+const exampleLink = `${publicUrl}/example`;
+
+module.exports = {
+  items: [
+    {
+      title: 'EU Budget for the future',
+      description: 'Innovation, economy, environment and geopolitics',
+      link: {
+        link: {
+          label: 'Subscribe',
+          path: exampleLink,
+          aria_label: 'Subscribe',
+          icon_position: 'after',
+        },
+        icon: {
+          path: '/icons.svg',
+          name: 'corner-arrow',
+          size: 'xs',
+          transform: 'rotate-90',
+        },
+      },
+      image:
+        'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
+      variant: 'image',
+      centered: false,
+    },
+    {
+      title: 'EU Budget for the future',
+      description: 'Innovation, economy, environment and geopolitics',
+      link: {
+        link: {
+          label: 'Subscribe',
+          path: exampleLink,
+          aria_label: 'Subscribe',
+          icon_position: 'after',
+        },
+        icon: {
+          path: '/icons.svg',
+          name: 'corner-arrow',
+          size: 'xs',
+          transform: 'rotate-90',
+        },
+      },
+      image:
+        'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
+      variant: 'image-gradient',
+      centered: false,
+    },
+    {
+      title: 'EU Budget for the future',
+      description: 'Innovation, economy, environment and geopolitics',
+      link: {
+        link: {
+          label: 'Subscribe',
+          path: exampleLink,
+          aria_label: 'Subscribe',
+          icon_position: 'after',
+        },
+        icon: {
+          path: '/icons.svg',
+          name: 'corner-arrow',
+          size: 'xs',
+          transform: 'rotate-90',
+        },
+      },
+      image:
+        'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
+      variant: 'image-shade',
+      centered: false,
+    },
+  ],
+  icon_path: '/icons.svg',
+  counter_label: 'of',
+};

--- a/src/specs/components/carousel/package.json
+++ b/src/specs/components/carousel/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ecl/specs-component-carousel",
+  "author": "European Commission",
+  "license": "EUPL-1.2",
+  "version": "3.1.2",
+  "description": "ECL Carousel Specs",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -23064,6 +23064,11 @@ tiny-lr@^1.1.0:
     object-assign "^4.1.0"
     qs "^6.4.0"
 
+tiny-slider@2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/tiny-slider/-/tiny-slider-2.9.4.tgz#dd5cbf3065f1688ade8383ea6342aefcba22ccc4"
+  integrity sha512-LAs2kldWcY+BqCKw4kxd4CMx2RhWrHyEePEsymlOIISTlOVkjfK40sSD7ay73eKXBLg/UkluAZpcfCstimHXew==
+
 tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"


### PR DESCRIPTION
Tiny-slider is used for the realisation of the carousel: https://www.npmjs.com/package/tiny-slider
this offers several advantages such as swipe/touch or keyboard events. It's possible to add more options such as drag, or a reverse when you get to the last slide, I opted for the loop version: https://github.com/ganlanyuan/tiny-slider#options

Remaining points:
- remove autoPlay on mobile
- prev/next button overlapping banner content on in the middle of desktop breakpoints
- full-width in a container?
- what controls is needed?
  - autoplay 
  - show/hide navigation
  - show/hide pagination
 - autoHeight? what happen if a slide is higher than the rest
 - documentation with lib?