### PR TITLE
chore(svg): Fixing svg optimization scripts - FRONT-3556

### DIFF
--- a/src/resources/icons-ec/scripts/clean-svg.js
+++ b/src/resources/icons-ec/scripts/clean-svg.js
@@ -11,7 +11,7 @@ const out = path.resolve(__dirname, '../dist/svg');
 glob.sync('**/*.svg', { cwd: src }).forEach(async (file) => {
   const filepath = path.resolve(src, file);
   const outputPath = path.resolve(out, file);
-  await loadConfig('./scripts/config/svgo');
+  const config = await loadConfig('./scripts/config/svgo');
 
   fs.readFile(filepath, 'utf8', (err, data) => {
     if (err) {
@@ -29,7 +29,7 @@ glob.sync('**/*.svg', { cwd: src }).forEach(async (file) => {
       const xml = builder.buildObject(clone);
 
       // Clean SVG
-      const svg = optimize(xml, { path: filepath });
+      const svg = optimize(xml, { ...config, path: filepath });
       const optimizedSvgString = svg.data;
       mkdirp.sync(path.dirname(outputPath));
       fs.writeFileSync(outputPath, optimizedSvgString, 'utf8');

--- a/src/resources/icons-ec/scripts/config/svgo.js
+++ b/src/resources/icons-ec/scripts/config/svgo.js
@@ -1,15 +1,18 @@
 module.exports = {
   plugins: [
     {
-      removeViewBox: false,
-    },
-    {
-      cleanupIDs: {
-        prefix: {
-          toString() {
-            this.counter = this.counter || 0;
-            const id = `id-${(this.counter += 1)}`;
-            return id;
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeViewBox: false,
+          cleanupIDs: {
+            prefix: {
+              toString() {
+                this.counter = this.counter || 0;
+                const id = `id-${(this.counter += 1)}`;
+                return id;
+              },
+            },
           },
         },
       },

--- a/src/resources/icons-eu/scripts/clean-svg.js
+++ b/src/resources/icons-eu/scripts/clean-svg.js
@@ -11,7 +11,7 @@ const out = path.resolve(__dirname, '../dist/svg');
 glob.sync('**/*.svg', { cwd: src }).forEach(async (file) => {
   const filepath = path.resolve(src, file);
   const outputPath = path.resolve(out, file);
-  await loadConfig('./scripts/config/svgo');
+  const config = await loadConfig('./scripts/config/svgo');
 
   fs.readFile(filepath, 'utf8', (err, data) => {
     if (err) {
@@ -29,7 +29,7 @@ glob.sync('**/*.svg', { cwd: src }).forEach(async (file) => {
       const xml = builder.buildObject(clone);
 
       // Clean SVG
-      const svg = optimize(xml, { path: filepath });
+      const svg = optimize(xml, { ...config, path: filepath });
       const optimizedSvgString = svg.data;
       mkdirp.sync(path.dirname(outputPath));
       fs.writeFileSync(outputPath, optimizedSvgString, 'utf8');

--- a/src/resources/icons-eu/scripts/config/svgo.js
+++ b/src/resources/icons-eu/scripts/config/svgo.js
@@ -1,15 +1,18 @@
 module.exports = {
   plugins: [
     {
-      removeViewBox: false,
-    },
-    {
-      cleanupIDs: {
-        prefix: {
-          toString() {
-            this.counter = this.counter || 0;
-            const id = `id-${(this.counter += 1)}`;
-            return id;
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeViewBox: false,
+          cleanupIDs: {
+            prefix: {
+              toString() {
+                this.counter = this.counter || 0;
+                const id = `id-${(this.counter += 1)}`;
+                return id;
+              },
+            },
           },
         },
       },

--- a/src/resources/icons-flag/scripts/clean-svg.js
+++ b/src/resources/icons-flag/scripts/clean-svg.js
@@ -11,7 +11,7 @@ const out = path.resolve(__dirname, '../dist/svg');
 glob.sync('**/*.svg', { cwd: src }).forEach(async (file) => {
   const filepath = path.resolve(src, file);
   const outputPath = path.resolve(out, file);
-  await loadConfig('./scripts/config/svgo');
+  const config = await loadConfig('./scripts/config/svgo');
 
   fs.readFile(filepath, 'utf8', (err, data) => {
     if (err) {
@@ -29,7 +29,7 @@ glob.sync('**/*.svg', { cwd: src }).forEach(async (file) => {
       const xml = builder.buildObject(clone);
 
       // Clean SVG
-      const svg = optimize(xml, { path: filepath });
+      const svg = optimize(xml, { ...config, path: filepath });
       const optimizedSvgString = svg.data;
       mkdirp.sync(path.dirname(outputPath));
       fs.writeFileSync(outputPath, optimizedSvgString, 'utf8');

--- a/src/resources/icons-flag/scripts/config/svgo.js
+++ b/src/resources/icons-flag/scripts/config/svgo.js
@@ -9,7 +9,7 @@ module.exports = {
             prefix: {
               toString() {
                 this.counter = this.counter || 0;
-                const id = `id-${(this.counter += 1)}`;
+                const id = `id-flag-${(this.counter += 1)}`;
                 return id;
               },
             },

--- a/src/resources/icons-flag/scripts/config/svgo.js
+++ b/src/resources/icons-flag/scripts/config/svgo.js
@@ -1,15 +1,18 @@
 module.exports = {
   plugins: [
     {
-      removeViewBox: false,
-    },
-    {
-      cleanupIDs: {
-        prefix: {
-          toString() {
-            this.counter = this.counter || 0;
-            const id = `id-flag-${(this.counter += 1)}`;
-            return id;
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeViewBox: false,
+          cleanupIDs: {
+            prefix: {
+              toString() {
+                this.counter = this.counter || 0;
+                const id = `id-${(this.counter += 1)}`;
+                return id;
+              },
+            },
           },
         },
       },

--- a/src/resources/icons-social-media/scripts/clean-svg.js
+++ b/src/resources/icons-social-media/scripts/clean-svg.js
@@ -11,7 +11,7 @@ const out = path.resolve(__dirname, '../dist/svg');
 glob.sync('**/*.svg', { cwd: src }).forEach(async (file) => {
   const filepath = path.resolve(src, file);
   const outputPath = path.resolve(out, file);
-  await loadConfig('./scripts/config/svgo');
+  const config = await loadConfig('./scripts/config/svgo');
 
   fs.readFile(filepath, 'utf8', (err, data) => {
     if (err) {
@@ -29,7 +29,7 @@ glob.sync('**/*.svg', { cwd: src }).forEach(async (file) => {
       const xml = builder.buildObject(clone);
 
       // Clean SVG
-      const svg = optimize(xml, { path: filepath });
+      const svg = optimize(xml, { ...config, path: filepath });
       const optimizedSvgString = svg.data;
       mkdirp.sync(path.dirname(outputPath));
       fs.writeFileSync(outputPath, optimizedSvgString, 'utf8');

--- a/src/resources/icons-social-media/scripts/config/svgo.js
+++ b/src/resources/icons-social-media/scripts/config/svgo.js
@@ -9,7 +9,7 @@ module.exports = {
             prefix: {
               toString() {
                 this.counter = this.counter || 0;
-                const id = `id-${(this.counter += 1)}`;
+                const id = `id-social-${(this.counter += 1)}`;
                 return id;
               },
             },

--- a/src/resources/icons-social-media/scripts/config/svgo.js
+++ b/src/resources/icons-social-media/scripts/config/svgo.js
@@ -1,15 +1,18 @@
 module.exports = {
   plugins: [
     {
-      removeViewBox: false,
-    },
-    {
-      cleanupIDs: {
-        prefix: {
-          toString() {
-            this.counter = this.counter || 0;
-            const id = `id-social-${(this.counter += 1)}`;
-            return id;
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeViewBox: false,
+          cleanupIDs: {
+            prefix: {
+              toString() {
+                this.counter = this.counter || 0;
+                const id = `id-${(this.counter += 1)}`;
+                return id;
+              },
+            },
           },
         },
       },

--- a/src/resources/social-icons/scripts/clean-svg.js
+++ b/src/resources/social-icons/scripts/clean-svg.js
@@ -10,14 +10,14 @@ const out = path.resolve(__dirname, '../dist/svg');
 glob.sync('**/*.svg', { cwd: src }).forEach(async (file) => {
   const filepath = path.resolve(src, file);
   const outputPath = path.resolve(out, file);
-  await loadConfig('./scripts/config/svgo');
+  const config = await loadConfig('./scripts/config/svgo');
 
   fs.readFile(filepath, 'utf8', (err, data) => {
     if (err) {
       throw err;
     }
 
-    const svg = optimize(data, { path: filepath });
+    const svg = optimize(data, { ...config, path: filepath });
     const optimizedSvgString = svg.data;
     mkdirp.sync(path.dirname(outputPath));
     fs.writeFileSync(outputPath, optimizedSvgString, 'utf8');

--- a/src/resources/social-icons/scripts/config/svgo.js
+++ b/src/resources/social-icons/scripts/config/svgo.js
@@ -1,3 +1,7 @@
 module.exports = {
-  // use the default config
+  plugins: [
+    {
+      name: 'preset-default',
+    },
+  ],
 };


### PR DESCRIPTION
Quick explanation, in this issue https://github.com/ec-europa/europa-component-library/issues/2335 a visual regression was identified in the multiselect component. It turned out that the svg optimization configuration we were using was not applied anymore.
The scripts have been fixed, a way to test this is to look at the multiselect in storybook, the icons were broken in EC, now they are ok.