### PR TITLE
fix(form): fix checkbox and radio display on multiple lines - FRONT-3562

### DIFF
--- a/src/implementations/twig/components/checkbox/__snapshots__/checkbox.test.js.snap
+++ b/src/implementations/twig/components/checkbox/__snapshots__/checkbox.test.js.snap
@@ -145,6 +145,52 @@ exports[`Checkbox EC default renders correctly 1`] = `
         Helper text for an option
       </div>
     </div>
+    <div
+      class="ecl-checkbox"
+    >
+      <input
+        class="ecl-checkbox__input"
+        id="checkbox-default-4"
+        name="checkbox-default"
+        type="checkbox"
+        value="lorem"
+      />
+      <label
+        class="ecl-checkbox__label"
+        for="checkbox-default-4"
+      >
+        <span
+          class="ecl-checkbox__box"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-checkbox__icon"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#check"
+            />
+          </svg>
+        </span>
+        <span
+          class="ecl-checkbox__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-checkbox__help"
+        id="helper-default-4"
+      >
+        Helper text for an option
+      </div>
+    </div>
   </fieldset>
 </jest>
 `;
@@ -296,6 +342,52 @@ exports[`Checkbox EC default renders correctly with extra attributes 1`] = `
         Helper text for an option
       </div>
     </div>
+    <div
+      class="ecl-checkbox"
+    >
+      <input
+        class="ecl-checkbox__input"
+        id="checkbox-default-4"
+        name="checkbox-default"
+        type="checkbox"
+        value="lorem"
+      />
+      <label
+        class="ecl-checkbox__label"
+        for="checkbox-default-4"
+      >
+        <span
+          class="ecl-checkbox__box"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-checkbox__icon"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#check"
+            />
+          </svg>
+        </span>
+        <span
+          class="ecl-checkbox__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-checkbox__help"
+        id="helper-default-4"
+      >
+        Helper text for an option
+      </div>
+    </div>
   </fieldset>
 </jest>
 `;
@@ -441,6 +533,52 @@ exports[`Checkbox EC default renders correctly with extra class names 1`] = `
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
         id="helper-default-3"
+      >
+        Helper text for an option
+      </div>
+    </div>
+    <div
+      class="ecl-checkbox"
+    >
+      <input
+        class="ecl-checkbox__input"
+        id="checkbox-default-4"
+        name="checkbox-default"
+        type="checkbox"
+        value="lorem"
+      />
+      <label
+        class="ecl-checkbox__label"
+        for="checkbox-default-4"
+      >
+        <span
+          class="ecl-checkbox__box"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-checkbox__icon"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#check"
+            />
+          </svg>
+        </span>
+        <span
+          class="ecl-checkbox__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-checkbox__help"
+        id="helper-default-4"
       >
         Helper text for an option
       </div>
@@ -603,6 +741,53 @@ exports[`Checkbox EC renders correctly when invalid 1`] = `
         Helper text for an option
       </div>
     </div>
+    <div
+      class="ecl-checkbox ecl-checkbox--invalid"
+    >
+      <input
+        class="ecl-checkbox__input"
+        id="checkbox-default-4"
+        name="checkbox-default"
+        required=""
+        type="checkbox"
+        value="lorem"
+      />
+      <label
+        class="ecl-checkbox__label"
+        for="checkbox-default-4"
+      >
+        <span
+          class="ecl-checkbox__box ecl-checkbox__box--invalid"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-checkbox__icon"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#check"
+            />
+          </svg>
+        </span>
+        <span
+          class="ecl-checkbox__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-checkbox__help"
+        id="helper-default-4"
+      >
+        Helper text for an option
+      </div>
+    </div>
   </fieldset>
 </jest>
 `;
@@ -751,6 +936,53 @@ exports[`Checkbox EC renders correctly when required 1`] = `
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
         id="helper-default-3"
+      >
+        Helper text for an option
+      </div>
+    </div>
+    <div
+      class="ecl-checkbox"
+    >
+      <input
+        class="ecl-checkbox__input"
+        id="checkbox-default-4"
+        name="checkbox-default"
+        required=""
+        type="checkbox"
+        value="lorem"
+      />
+      <label
+        class="ecl-checkbox__label"
+        for="checkbox-default-4"
+      >
+        <span
+          class="ecl-checkbox__box"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-checkbox__icon"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#check"
+            />
+          </svg>
+        </span>
+        <span
+          class="ecl-checkbox__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-checkbox__help"
+        id="helper-default-4"
       >
         Helper text for an option
       </div>
@@ -979,6 +1211,52 @@ exports[`Checkbox EU default renders correctly 1`] = `
         Helper text for an option
       </div>
     </div>
+    <div
+      class="ecl-checkbox"
+    >
+      <input
+        class="ecl-checkbox__input"
+        id="checkbox-default-4"
+        name="checkbox-default"
+        type="checkbox"
+        value="lorem"
+      />
+      <label
+        class="ecl-checkbox__label"
+        for="checkbox-default-4"
+      >
+        <span
+          class="ecl-checkbox__box"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-checkbox__icon"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#check"
+            />
+          </svg>
+        </span>
+        <span
+          class="ecl-checkbox__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-checkbox__help"
+        id="helper-default-4"
+      >
+        Helper text for an option
+      </div>
+    </div>
   </fieldset>
 </jest>
 `;
@@ -1138,6 +1416,52 @@ exports[`Checkbox EU invalid renders correctly 1`] = `
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
         id="helper-default-3"
+      >
+        Helper text for an option
+      </div>
+    </div>
+    <div
+      class="ecl-checkbox ecl-checkbox--invalid"
+    >
+      <input
+        class="ecl-checkbox__input"
+        id="checkbox-default-4"
+        name="checkbox-default"
+        type="checkbox"
+        value="lorem"
+      />
+      <label
+        class="ecl-checkbox__label"
+        for="checkbox-default-4"
+      >
+        <span
+          class="ecl-checkbox__box ecl-checkbox__box--invalid"
+        >
+          <svg
+            aria-hidden="true"
+            class="ecl-icon ecl-icon--m ecl-checkbox__icon"
+            focusable="false"
+          >
+            <use
+              xlink:href="/icons.svg#check"
+            />
+          </svg>
+        </span>
+        <span
+          class="ecl-checkbox__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-checkbox__help"
+        id="helper-default-4"
       >
         Helper text for an option
       </div>

--- a/src/implementations/twig/components/checkbox/__snapshots__/checkbox.test.js.snap
+++ b/src/implementations/twig/components/checkbox/__snapshots__/checkbox.test.js.snap
@@ -51,7 +51,11 @@ exports[`Checkbox EC default renders correctly 1`] = `
             />
           </svg>
         </span>
-        Spain
+        <span
+          class="ecl-checkbox__text"
+        >
+          Spain
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -87,7 +91,11 @@ exports[`Checkbox EC default renders correctly 1`] = `
             />
           </svg>
         </span>
-        Belgium
+        <span
+          class="ecl-checkbox__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -124,7 +132,11 @@ exports[`Checkbox EC default renders correctly 1`] = `
             />
           </svg>
         </span>
-        France (disabled)
+        <span
+          class="ecl-checkbox__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
@@ -190,7 +202,11 @@ exports[`Checkbox EC default renders correctly with extra attributes 1`] = `
             />
           </svg>
         </span>
-        Spain
+        <span
+          class="ecl-checkbox__text"
+        >
+          Spain
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -226,7 +242,11 @@ exports[`Checkbox EC default renders correctly with extra attributes 1`] = `
             />
           </svg>
         </span>
-        Belgium
+        <span
+          class="ecl-checkbox__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -263,7 +283,11 @@ exports[`Checkbox EC default renders correctly with extra attributes 1`] = `
             />
           </svg>
         </span>
-        France (disabled)
+        <span
+          class="ecl-checkbox__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
@@ -327,7 +351,11 @@ exports[`Checkbox EC default renders correctly with extra class names 1`] = `
             />
           </svg>
         </span>
-        Spain
+        <span
+          class="ecl-checkbox__text"
+        >
+          Spain
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -363,7 +391,11 @@ exports[`Checkbox EC default renders correctly with extra class names 1`] = `
             />
           </svg>
         </span>
-        Belgium
+        <span
+          class="ecl-checkbox__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -400,7 +432,11 @@ exports[`Checkbox EC default renders correctly with extra class names 1`] = `
             />
           </svg>
         </span>
-        France (disabled)
+        <span
+          class="ecl-checkbox__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
@@ -471,7 +507,11 @@ exports[`Checkbox EC renders correctly when invalid 1`] = `
             />
           </svg>
         </span>
-        Spain
+        <span
+          class="ecl-checkbox__text"
+        >
+          Spain
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -508,7 +548,11 @@ exports[`Checkbox EC renders correctly when invalid 1`] = `
             />
           </svg>
         </span>
-        Belgium
+        <span
+          class="ecl-checkbox__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -546,7 +590,11 @@ exports[`Checkbox EC renders correctly when invalid 1`] = `
             />
           </svg>
         </span>
-        France (disabled)
+        <span
+          class="ecl-checkbox__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
@@ -611,7 +659,11 @@ exports[`Checkbox EC renders correctly when required 1`] = `
             />
           </svg>
         </span>
-        Spain
+        <span
+          class="ecl-checkbox__text"
+        >
+          Spain
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -648,7 +700,11 @@ exports[`Checkbox EC renders correctly when required 1`] = `
             />
           </svg>
         </span>
-        Belgium
+        <span
+          class="ecl-checkbox__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -686,7 +742,11 @@ exports[`Checkbox EC renders correctly when required 1`] = `
             />
           </svg>
         </span>
-        France (disabled)
+        <span
+          class="ecl-checkbox__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
@@ -751,7 +811,11 @@ exports[`Checkbox EC single checkbox renders correctly when invalid 1`] = `
             />
           </svg>
         </span>
-        Spain
+        <span
+          class="ecl-checkbox__text"
+        >
+          Spain
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -821,7 +885,11 @@ exports[`Checkbox EU default renders correctly 1`] = `
             />
           </svg>
         </span>
-        Spain
+        <span
+          class="ecl-checkbox__text"
+        >
+          Spain
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -857,7 +925,11 @@ exports[`Checkbox EU default renders correctly 1`] = `
             />
           </svg>
         </span>
-        Belgium
+        <span
+          class="ecl-checkbox__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -894,7 +966,11 @@ exports[`Checkbox EU default renders correctly 1`] = `
             />
           </svg>
         </span>
-        France (disabled)
+        <span
+          class="ecl-checkbox__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
@@ -972,7 +1048,11 @@ exports[`Checkbox EU invalid renders correctly 1`] = `
             />
           </svg>
         </span>
-        Spain
+        <span
+          class="ecl-checkbox__text"
+        >
+          Spain
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -1008,7 +1088,11 @@ exports[`Checkbox EU invalid renders correctly 1`] = `
             />
           </svg>
         </span>
-        Belgium
+        <span
+          class="ecl-checkbox__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"
@@ -1045,7 +1129,11 @@ exports[`Checkbox EU invalid renders correctly 1`] = `
             />
           </svg>
         </span>
-        France (disabled)
+        <span
+          class="ecl-checkbox__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-checkbox__help ecl-checkbox__help--disabled"
@@ -1109,7 +1197,11 @@ exports[`Checkbox EU single checkbox renders correctly when invalid 1`] = `
             />
           </svg>
         </span>
-        Spain
+        <span
+          class="ecl-checkbox__text"
+        >
+          Spain
+        </span>
       </label>
       <div
         class="ecl-checkbox__help"

--- a/src/implementations/twig/components/checkbox/checkbox-item.html.twig
+++ b/src/implementations/twig/components/checkbox/checkbox-item.html.twig
@@ -101,9 +101,9 @@
       } only %}
     </span>
     {% if _label is not empty %}
-    <div class="ecl-checkbox__text">
+    <span class="ecl-checkbox__text">
       {%- block label _label -%}
-    </div>
+    </span>
     {% endif %}
   </label>
 

--- a/src/implementations/twig/components/checkbox/checkbox-item.html.twig
+++ b/src/implementations/twig/components/checkbox/checkbox-item.html.twig
@@ -100,7 +100,11 @@
         extra_classes: 'ecl-checkbox__icon',
       } only %}
     </span>
-    {%- block label _label -%}
+    {% if _label is not empty %}
+    <div class="ecl-checkbox__text">
+      {%- block label _label -%}
+    </div>
+    {% endif %}
   </label>
 
   {% if _helper_text is not empty %}

--- a/src/implementations/twig/components/radio/__snapshots__/radio.test.js.snap
+++ b/src/implementations/twig/components/radio/__snapshots__/radio.test.js.snap
@@ -59,7 +59,11 @@ exports[`Radio Binary invalid renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Yes
+        <span
+          class="ecl-radio__text"
+        >
+          Yes
+        </span>
       </label>
     </div>
     <div
@@ -84,7 +88,11 @@ exports[`Radio Binary invalid renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        No
+        <span
+          class="ecl-radio__text"
+        >
+          No
+        </span>
       </label>
     </div>
   </fieldset>
@@ -136,7 +144,11 @@ exports[`Radio Binary renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Yes
+        <span
+          class="ecl-radio__text"
+        >
+          Yes
+        </span>
       </label>
     </div>
     <div
@@ -161,7 +173,11 @@ exports[`Radio Binary renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        No
+        <span
+          class="ecl-radio__text"
+        >
+          No
+        </span>
       </label>
     </div>
   </fieldset>
@@ -214,7 +230,11 @@ exports[`Radio Default renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Luxembourg
+        <span
+          class="ecl-radio__text"
+        >
+          Luxembourg
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -246,7 +266,11 @@ exports[`Radio Default renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Belgium
+        <span
+          class="ecl-radio__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -279,7 +303,11 @@ exports[`Radio Default renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        France (disabled)
+        <span
+          class="ecl-radio__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-radio__help ecl-radio__help--disabled"
@@ -340,7 +368,11 @@ exports[`Radio Default renders correctly with extra attributes 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Luxembourg
+        <span
+          class="ecl-radio__text"
+        >
+          Luxembourg
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -372,7 +404,11 @@ exports[`Radio Default renders correctly with extra attributes 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Belgium
+        <span
+          class="ecl-radio__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -405,7 +441,11 @@ exports[`Radio Default renders correctly with extra attributes 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        France (disabled)
+        <span
+          class="ecl-radio__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-radio__help ecl-radio__help--disabled"
@@ -464,7 +504,11 @@ exports[`Radio Default renders correctly with extra class names 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Luxembourg
+        <span
+          class="ecl-radio__text"
+        >
+          Luxembourg
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -496,7 +540,11 @@ exports[`Radio Default renders correctly with extra class names 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Belgium
+        <span
+          class="ecl-radio__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -529,7 +577,11 @@ exports[`Radio Default renders correctly with extra class names 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        France (disabled)
+        <span
+          class="ecl-radio__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-radio__help ecl-radio__help--disabled"
@@ -602,7 +654,11 @@ exports[`Radio Invalid renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Luxembourg
+        <span
+          class="ecl-radio__text"
+        >
+          Luxembourg
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -634,7 +690,11 @@ exports[`Radio Invalid renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Belgium
+        <span
+          class="ecl-radio__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -667,7 +727,11 @@ exports[`Radio Invalid renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        France (disabled)
+        <span
+          class="ecl-radio__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-radio__help ecl-radio__help--disabled"
@@ -725,7 +789,11 @@ exports[`Radio Optional renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Luxembourg
+        <span
+          class="ecl-radio__text"
+        >
+          Luxembourg
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -756,7 +824,11 @@ exports[`Radio Optional renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        Belgium
+        <span
+          class="ecl-radio__text"
+        >
+          Belgium
+        </span>
       </label>
       <div
         class="ecl-radio__help"
@@ -788,7 +860,11 @@ exports[`Radio Optional renders correctly 1`] = `
             class="ecl-radio__box-inner"
           />
         </span>
-        France (disabled)
+        <span
+          class="ecl-radio__text"
+        >
+          France (disabled)
+        </span>
       </label>
       <div
         class="ecl-radio__help ecl-radio__help--disabled"

--- a/src/implementations/twig/components/radio/__snapshots__/radio.test.js.snap
+++ b/src/implementations/twig/components/radio/__snapshots__/radio.test.js.snap
@@ -316,6 +316,48 @@ exports[`Radio Default renders correctly 1`] = `
         Help text for an option
       </div>
     </div>
+    <div
+      class="ecl-radio"
+    >
+      <input
+        aria-describedby="helper-4"
+        class="ecl-radio__input"
+        id="radio-default-4"
+        name="radio-group-1"
+        required=""
+        type="radio"
+        value="lorem"
+      />
+      <label
+        class="ecl-radio__label"
+        for="radio-default-4"
+      >
+        <span
+          class="ecl-radio__box"
+        >
+          <span
+            class="ecl-radio__box-inner"
+          />
+        </span>
+        <span
+          class="ecl-radio__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-radio__help"
+        id="helper-4"
+      >
+        Help text for an option
+      </div>
+    </div>
   </fieldset>
 </jest>
 `;
@@ -454,6 +496,48 @@ exports[`Radio Default renders correctly with extra attributes 1`] = `
         Help text for an option
       </div>
     </div>
+    <div
+      class="ecl-radio"
+    >
+      <input
+        aria-describedby="helper-4"
+        class="ecl-radio__input"
+        id="radio-default-4"
+        name="radio-group-1"
+        required=""
+        type="radio"
+        value="lorem"
+      />
+      <label
+        class="ecl-radio__label"
+        for="radio-default-4"
+      >
+        <span
+          class="ecl-radio__box"
+        >
+          <span
+            class="ecl-radio__box-inner"
+          />
+        </span>
+        <span
+          class="ecl-radio__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-radio__help"
+        id="helper-4"
+      >
+        Help text for an option
+      </div>
+    </div>
   </fieldset>
 </jest>
 `;
@@ -586,6 +670,48 @@ exports[`Radio Default renders correctly with extra class names 1`] = `
       <div
         class="ecl-radio__help ecl-radio__help--disabled"
         id="helper-3"
+      >
+        Help text for an option
+      </div>
+    </div>
+    <div
+      class="ecl-radio"
+    >
+      <input
+        aria-describedby="helper-4"
+        class="ecl-radio__input"
+        id="radio-default-4"
+        name="radio-group-1"
+        required=""
+        type="radio"
+        value="lorem"
+      />
+      <label
+        class="ecl-radio__label"
+        for="radio-default-4"
+      >
+        <span
+          class="ecl-radio__box"
+        >
+          <span
+            class="ecl-radio__box-inner"
+          />
+        </span>
+        <span
+          class="ecl-radio__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-radio__help"
+        id="helper-4"
       >
         Help text for an option
       </div>
@@ -740,6 +866,48 @@ exports[`Radio Invalid renders correctly 1`] = `
         Help text for an option
       </div>
     </div>
+    <div
+      class="ecl-radio"
+    >
+      <input
+        aria-describedby="helper-4"
+        class="ecl-radio__input"
+        id="radio-default-4"
+        name="radio-group-1"
+        required=""
+        type="radio"
+        value="lorem"
+      />
+      <label
+        class="ecl-radio__label"
+        for="radio-default-4"
+      >
+        <span
+          class="ecl-radio__box ecl-radio__box--invalid"
+        >
+          <span
+            class="ecl-radio__box-inner"
+          />
+        </span>
+        <span
+          class="ecl-radio__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-radio__help"
+        id="helper-4"
+      >
+        Help text for an option
+      </div>
+    </div>
   </fieldset>
 </jest>
 `;
@@ -869,6 +1037,47 @@ exports[`Radio Optional renders correctly 1`] = `
       <div
         class="ecl-radio__help ecl-radio__help--disabled"
         id="helper-3"
+      >
+        Help text for an option
+      </div>
+    </div>
+    <div
+      class="ecl-radio"
+    >
+      <input
+        aria-describedby="helper-4"
+        class="ecl-radio__input"
+        id="radio-default-4"
+        name="radio-group-1"
+        type="radio"
+        value="lorem"
+      />
+      <label
+        class="ecl-radio__label"
+        for="radio-default-4"
+      >
+        <span
+          class="ecl-radio__box"
+        >
+          <span
+            class="ecl-radio__box-inner"
+          />
+        </span>
+        <span
+          class="ecl-radio__text"
+        >
+          Lorem ipsum dolor sit amet, 
+          <a
+            href="#"
+          >
+            consectetur adipiscing elit
+          </a>
+          . Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.
+        </span>
+      </label>
+      <div
+        class="ecl-radio__help"
+        id="helper-4"
       >
         Help text for an option
       </div>

--- a/src/implementations/twig/components/radio/radio-button.html.twig
+++ b/src/implementations/twig/components/radio/radio-button.html.twig
@@ -106,9 +106,9 @@
       <span class="ecl-radio__box-inner"></span>
     </span>
     {% if _label is not empty %}
-    <div class="ecl-radio__text">
+    <span class="ecl-radio__text">
       {%- block label _label -%}
-    </div>
+    </span>
     {% endif %}
   </label>
 

--- a/src/implementations/twig/components/radio/radio-button.html.twig
+++ b/src/implementations/twig/components/radio/radio-button.html.twig
@@ -105,7 +105,11 @@
     <span class="{{ _box_css_class }}">
       <span class="ecl-radio__box-inner"></span>
     </span>
-    {%- block label _label -%}
+    {% if _label is not empty %}
+    <div class="ecl-radio__text">
+      {%- block label _label -%}
+    </div>
+    {% endif %}
   </label>
 
   {% if _helper_text is not empty %}

--- a/src/implementations/vanilla/components/checkbox/_checkbox.scss
+++ b/src/implementations/vanilla/components/checkbox/_checkbox.scss
@@ -43,7 +43,6 @@ $_outline-width: null !default;
 }
 
 .ecl-checkbox__label {
-  align-items: center;
   color: $_label-color;
   display: inline-flex;
   font: map.get(theme.$font-prolonged, 'm');
@@ -60,6 +59,7 @@ $_outline-width: null !default;
   height: $_box-size;
   justify-content: center;
   margin-right: map.get(theme.$spacing, 'xs');
+  margin-top: 0.125rem; // align box with text
   user-select: none;
   width: $_box-size;
 }

--- a/src/implementations/vanilla/components/checkbox/_checkbox.scss
+++ b/src/implementations/vanilla/components/checkbox/_checkbox.scss
@@ -10,6 +10,7 @@ $_border-width: 2px;
 $_border-color: null !default;
 $_border-radius: null !default;
 $_box-size: null !default;
+$_box-margin-top: null !default;
 $_box-background-disabled: map.get(theme.$color, 'grey-5');
 $_box-background-checked: map.get(theme.$color, 'blue-100');
 $_box-background-checked-hover: null !default;
@@ -59,7 +60,7 @@ $_outline-width: null !default;
   height: $_box-size;
   justify-content: center;
   margin-right: map.get(theme.$spacing, 'xs');
-  margin-top: 0.125rem; // align box with text
+  margin-top: $_box-margin-top;
   user-select: none;
   width: $_box-size;
 }

--- a/src/implementations/vanilla/components/checkbox/_checkbox.scss
+++ b/src/implementations/vanilla/components/checkbox/_checkbox.scss
@@ -47,7 +47,7 @@ $_outline-width: null !default;
   color: $_label-color;
   display: inline-flex;
   font: map.get(theme.$font-prolonged, 'm');
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 .ecl-checkbox__box {

--- a/src/implementations/vanilla/components/checkbox/checkbox-ec.scss
+++ b/src/implementations/vanilla/components/checkbox/checkbox-ec.scss
@@ -6,6 +6,7 @@
   $_box-background-checked-hover: map.get(theme.$color, 'blue-100'),
   $_box-border-color-hover: map.get(theme.$color, 'blue-100'),
   $_box-size: 1.25rem,
+  $_box-margin-top: 0.125rem,
   $_help-text-font: map.get(theme.$font-prolonged, 's'),
   $_help-text-color: map.get(theme.$color, 'grey'),
   $_invalid-border-color: map.get(theme.$color, 'red'),

--- a/src/implementations/vanilla/components/checkbox/checkbox-eu.scss
+++ b/src/implementations/vanilla/components/checkbox/checkbox-eu.scss
@@ -6,6 +6,7 @@
   $_box-background-checked-hover: map.get(theme.$color, 'blue-80'),
   $_box-border-color-hover: map.get(theme.$color, 'blue-80'),
   $_box-size: 1.5rem,
+  $_box-margin-top: 0,
   $_help-text-color: map.get(theme.$color, 'grey-80'),
   $_help-text-font: map.get(theme.$font-prolonged, 'm'),
   $_invalid-border-color: map.get(theme.$color, 'red-120'),

--- a/src/implementations/vanilla/components/radio/_radio.scss
+++ b/src/implementations/vanilla/components/radio/_radio.scss
@@ -49,10 +49,11 @@ $_outline-color: null !default;
 }
 
 .ecl-radio__label {
+  align-items: center;
   color: $_label-color;
   display: inline-flex;
   font: map.get(theme.$font-prolonged, 'm');
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 .ecl-radio--disabled .ecl-radio__label {
@@ -65,6 +66,7 @@ $_outline-color: null !default;
   border-radius: 50%;
   box-sizing: border-box;
   display: block;
+  flex-shrink: 0;
   height: $_box-size;
   margin-right: map.get(theme.$spacing, 'xs');
   position: relative;

--- a/src/implementations/vanilla/components/radio/_radio.scss
+++ b/src/implementations/vanilla/components/radio/_radio.scss
@@ -49,7 +49,6 @@ $_outline-color: null !default;
 }
 
 .ecl-radio__label {
-  align-items: center;
   color: $_label-color;
   display: inline-flex;
   font: map.get(theme.$font-prolonged, 'm');
@@ -69,6 +68,7 @@ $_outline-color: null !default;
   flex-shrink: 0;
   height: $_box-size;
   margin-right: map.get(theme.$spacing, 'xs');
+  margin-top: 0.125rem; // align box with text
   position: relative;
   width: $_box-size;
 }

--- a/src/implementations/vanilla/components/radio/_radio.scss
+++ b/src/implementations/vanilla/components/radio/_radio.scss
@@ -14,6 +14,7 @@ $_box-border-width: 2px;
 $_box-border-width-checked: null !default;
 $_box-inner-display: null !default;
 $_box-size: 1.25rem;
+$_box-margin-top: null !default;
 $_help-text-color: null !default;
 $_help-text-font: null !default;
 $_invalid-border-color: null !default;
@@ -68,7 +69,7 @@ $_outline-color: null !default;
   flex-shrink: 0;
   height: $_box-size;
   margin-right: map.get(theme.$spacing, 'xs');
-  margin-top: 0.125rem; // align box with text
+  margin-top: $_box-margin-top;
   position: relative;
   width: $_box-size;
 }

--- a/src/implementations/vanilla/components/radio/radio-ec.scss
+++ b/src/implementations/vanilla/components/radio/radio-ec.scss
@@ -6,6 +6,7 @@
   $_box-border-color-hover: map.get(theme.$color, 'blue-100'),
   $_box-border-width-checked: 7px,
   $_box-inner-display: none,
+  $_box-margin-top: 0.125rem,
   $_help-text-color: map.get(theme.$color, 'grey'),
   $_help-text-font: map.get(theme.$font-prolonged, 's'),
   $_invalid-border-color: map.get(theme.$color, 'red-100'),

--- a/src/implementations/vanilla/components/radio/radio-eu.scss
+++ b/src/implementations/vanilla/components/radio/radio-eu.scss
@@ -6,6 +6,7 @@
   $_box-border-color-hover: map.get(theme.$color, 'blue-80'),
   $_box-border-width-checked: 2px,
   $_box-inner-display: flex,
+  $_box-margin-top: 0.0625rem,
   $_help-text-color: map.get(theme.$color, 'grey-80'),
   $_help-text-font: map.get(theme.$font-prolonged, 'm'),
   $_invalid-border-color: map.get(theme.$color, 'red-120'),

--- a/src/specs/components/checkbox/demo/data--ec.js
+++ b/src/specs/components/checkbox/demo/data--ec.js
@@ -34,5 +34,14 @@ module.exports = {
       value: 'fr',
       icon_path: '/icons.svg',
     },
+    {
+      helper_id: 'helper-default-4',
+      id: 'checkbox-default-4',
+      label:
+        'Lorem ipsum dolor sit amet, <a href="#">consectetur adipiscing elit</a>. Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.',
+      value: 'lorem',
+      helper_text: 'Helper text for an option',
+      icon_path: '/icons.svg',
+    },
   ],
 };

--- a/src/specs/components/checkbox/demo/data--eu.js
+++ b/src/specs/components/checkbox/demo/data--eu.js
@@ -39,5 +39,14 @@ module.exports = {
       value: 'fr',
       icon_path: '/icons.svg',
     },
+    {
+      helper_id: 'helper-default-4',
+      id: 'checkbox-default-4',
+      label:
+        'Lorem ipsum dolor sit amet, <a href="#">consectetur adipiscing elit</a>. Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.',
+      value: 'lorem',
+      helper_text: 'Helper text for an option',
+      icon_path: '/icons.svg',
+    },
   ],
 };

--- a/src/specs/components/radio/demo/data--default.js
+++ b/src/specs/components/radio/demo/data--default.js
@@ -36,5 +36,13 @@ module.exports = {
       helper_text: 'Help text for an option',
       disabled: true,
     },
+    {
+      id: 'radio-default-4',
+      value: 'lorem',
+      label:
+        'Lorem ipsum dolor sit amet, <a href="#">consectetur adipiscing elit</a>. Nullam suscipit eros gravida arcu aliquet, sed finibus nisl egestas. Cras sed purus nec turpis eleifend dignissim a in massa.',
+      helper_id: 'helper-4',
+      helper_text: 'Help text for an option',
+    },
   ],
 };


### PR DESCRIPTION
Fix display of checkboxes and radios when the label takes multiple lines (it didn't wrap correctly)
I also ensured that the fix we did for https://citnet.tech.ec.europa.eu/CITnet/jira/browse/FRONT-3190 was still working.
I had to add an extra span in the label to achieve this, so markup is slightly altered.
Here is the result
![image](https://user-images.githubusercontent.com/25579221/156370035-5f1eca7f-da17-4491-94df-5b09762d21f1.png)
