### PR TITLE
fix(site-header): hide double logo - FRONT-3590

### DIFF
--- a/src/implementations/vanilla/components/site-header-core/site-header-core-print.scss
+++ b/src/implementations/vanilla/components/site-header-core/site-header-core-print.scss
@@ -22,3 +22,7 @@
 .ecl-site-header-core__logo-link::after {
   display: none;
 }
+
+.ecl-site-header-core__logo-image-mobile {
+  display: none;
+}

--- a/src/implementations/vanilla/components/site-header-harmonised/site-header-harmonised-print.scss
+++ b/src/implementations/vanilla/components/site-header-harmonised/site-header-harmonised-print.scss
@@ -47,3 +47,7 @@
 .ecl-site-header-harmonised--group3 .ecl-site-header-harmonised__logo-image {
   width: auto;
 }
+
+.ecl-site-header-core__logo-image-mobile {
+  display: none;
+}

--- a/src/implementations/vanilla/components/site-header-standardised/site-header-standardised-print.scss
+++ b/src/implementations/vanilla/components/site-header-standardised/site-header-standardised-print.scss
@@ -42,3 +42,7 @@
 .ecl-site-header-standardised__logo-link::after {
   display: none;
 }
+
+.ecl-site-header-core__logo-image-mobile {
+  display: none;
+}


### PR DESCRIPTION
hide mobile logo when printing EU site header