### PR TITLE
chore(destroy): Review destroy method for JS components - FRONT-3610

### DIFF
--- a/src/implementations/vanilla/components/accordion/accordion.js
+++ b/src/implementations/vanilla/components/accordion/accordion.js
@@ -88,7 +88,7 @@ export class Accordion {
   destroy() {
     if (this.attachClickListener && this.toggles) {
       this.toggles.forEach((toggle) => {
-        toggle.removeEventListener('click', this.handleClickOnToggle);
+        toggle.replaceWith(toggle.cloneNode(true));
       });
     }
     if (this.element) {

--- a/src/implementations/vanilla/components/carousel/carousel.js
+++ b/src/implementations/vanilla/components/carousel/carousel.js
@@ -186,14 +186,14 @@ export class Carousel {
       this.cloneFirstSLide.remove();
       this.cloneLastSLide.remove();
     }
-    if (this.attachClickListener && this.toggle) {
-      this.toggle.removeEventListener('click', this.handleClickOnToggle);
+    if (this.toggle) {
+      this.toggle.replaceWith(this.toggle.cloneNode(true));
     }
-    if (this.attachClickListener && this.btnNext) {
-      this.btnNext.removeEventListener('click', this.shiftSlide);
+    if (this.btnNext) {
+      this.btnNext.replaceWith(this.btnNext.cloneNode(true));
     }
-    if (this.attachClickListener && this.btnPrev) {
-      this.btnPrev.removeEventListener('click', this.shiftSlide);
+    if (this.btnPrev) {
+      this.btnPrev.replaceWith(this.btnPrev.cloneNode(true));
     }
     if (this.slidesContainer) {
       this.slidesContainer.removeEventListener('touchstart', this.dragStart);
@@ -206,7 +206,7 @@ export class Carousel {
     }
     if (this.navigationItems) {
       this.navigationItems.forEach((nav) => {
-        nav.removeEventListener('click', this.shiftSlide);
+        nav.replaceWith(nav.cloneNode(true));
       });
     }
     if (this.attachResizeListener) {

--- a/src/implementations/vanilla/components/news-ticker/news-ticker.js
+++ b/src/implementations/vanilla/components/news-ticker/news-ticker.js
@@ -152,14 +152,14 @@ export class NewsTicker {
    * Destroy component.
    */
   destroy() {
-    if (this.attachClickListener && this.toggle) {
-      this.toggle.removeEventListener('click', this.handleClickOnToggle);
+    if (this.toggle) {
+      this.toggle.replaceWith(this.toggle.cloneNode(true));
     }
-    if (this.attachClickListener && this.btnNext) {
-      this.btnNext.removeEventListener('click', this.shiftSlide);
+    if (this.btnNext) {
+      this.btnNext.replaceWith(this.btnNext.cloneNode(true));
     }
-    if (this.attachClickListener && this.btnPrev) {
-      this.btnPrev.removeEventListener('click', this.shiftSlide);
+    if (this.btnPrev) {
+      this.btnPrev.replaceWith(this.btnPrev.cloneNode(true));
     }
     if (this.slidesContainer) {
       this.slidesContainer.removeEventListener(

--- a/src/playground/ec/.storybook/manager-head.html
+++ b/src/playground/ec/.storybook/manager-head.html
@@ -30,7 +30,7 @@
   // Re-initialize component in the preview frame when changing #ecl-rtl CSS resource checkbox.
   window.onload = function (event) {
     var inputRtlCss = document.getElementById('ecl-rtl');
-    inputRtlCss.addEventListener('change', function (event) {
+    inputRtlCss.addEventListener('change', (event) => {
       setTimeout(() => {
         const iframePreview = document.getElementById(
           'storybook-preview-iframe'

--- a/src/playground/ec/.storybook/manager-head.html
+++ b/src/playground/ec/.storybook/manager-head.html
@@ -26,6 +26,22 @@
       );
     }
   }
+
+  // Re-initialize component in the preview frame when changing #ecl-rtl CSS resource checkbox.
+  window.onload = function (event) {
+    var inputRtlCss = document.getElementById('ecl-rtl');
+    inputRtlCss.addEventListener('change', function (event) {
+      setTimeout(() => {
+        const iframePreview = document.getElementById(
+          'storybook-preview-iframe'
+        ).contentWindow;
+        if (iframePreview) {
+          iframePreview.ECL.autoInit().destroy();
+          iframePreview.ECL.autoInit();
+        }
+      }, 100);
+    });
+  };
 </script>
 <script
   src="https://ec.europa.eu/wel/cookie-consent/consent.js"

--- a/src/playground/ec/.storybook/preview.js
+++ b/src/playground/ec/.storybook/preview.js
@@ -40,7 +40,7 @@ addParameters({
     },
     {
       id: 'ecl-rtl',
-      code: `<link rel="stylesheet" type="text/css" href="./styles/optional/ecl-rtl.css" onload="ECL.autoInit().destroy(); ECL.autoInit();" />`,
+      code: `<link rel="stylesheet" type="text/css" href="./styles/optional/ecl-rtl.css" />`,
       picked: false,
       hideCode: true,
     },

--- a/src/playground/eu/.storybook/manager-head.html
+++ b/src/playground/eu/.storybook/manager-head.html
@@ -26,6 +26,22 @@
       );
     }
   }
+
+  // Re-initialize component in the preview frame when changing #ecl-rtl CSS resource checkbox.
+  window.onload = function (event) {
+    var inputRtlCss = document.getElementById('ecl-rtl');
+    inputRtlCss.addEventListener('change', (event) => {
+      setTimeout(() => {
+        const iframePreview = document.getElementById(
+          'storybook-preview-iframe'
+        ).contentWindow;
+        if (iframePreview) {
+          iframePreview.ECL.autoInit().destroy();
+          iframePreview.ECL.autoInit();
+        }
+      }, 100);
+    });
+  };
 </script>
 <script
   src="https://ec.europa.eu/wel/cookie-consent/consent.js"

--- a/src/playground/eu/.storybook/preview.js
+++ b/src/playground/eu/.storybook/preview.js
@@ -40,7 +40,7 @@ addParameters({
     },
     {
       id: 'ecl-rtl',
-      code: `<link rel="stylesheet" type="text/css" href="./styles/optional/ecl-rtl.css" onload="ECL.autoInit().destroy(); ECL.autoInit();" />`,
+      code: `<link rel="stylesheet" type="text/css" href="./styles/optional/ecl-rtl.css" />`,
       picked: false,
       hideCode: true,
     },


### PR DESCRIPTION
The purpose of this PR is to review the destroy method for JavaScript components. After testing each component, I fixed the remove of some listeners for the following components:

- Accordion
- Carousel
- News ticker

I also changed the way to re-initialize the components when adding/changing the ecl-rtl CSS resource. 
In the current state, it does only work for the first addition of the resource. When you click the checkbox, the CSS `<link>` tag is added in the DOM and the onload function is executed. By clicking again the checkbox, the CSS resource remain (only `media="max-width: 1px"` is added to the `<link>` tag) and nothing happens.

I changed the logic by accessing the checkbox at manager level and resetting the component through the iframe preview.