### PR TITLE
feat(featured-item): Remove heading - FRONT-3649

### DIFF
--- a/src/implementations/twig/components/featured-item/README.md
+++ b/src/implementations/twig/components/featured-item/README.md
@@ -9,7 +9,6 @@ npm install --save @ecl/twig-component-featured-item
 ### Parameters
 
 - **"type"** (string) (default: '') - Featured item type ('extended'),
-- **"heading"** (string) (default: '') - Main heading of the feature item,
 - **"title"** (string) (default: '') - Title of the content opposite the media container,
 - **"description"** (string) (default: '') - Description of the content opposite the media container,
 - **"link"** (associative array) (default: predefined structure) predefined structure for the Link component

--- a/src/implementations/twig/components/featured-item/__snapshots__/featured-item.test.js.snap
+++ b/src/implementations/twig/components/featured-item/__snapshots__/featured-item.test.js.snap
@@ -5,11 +5,6 @@ exports[`Featured item Default renders correctly 1`] = `
   <article
     class="ecl-featured-item"
   >
-    <h1
-      class="ecl-featured-item__heading"
-    >
-      Heading
-    </h1>
     <div
       class="ecl-featured-item__container"
     >
@@ -79,11 +74,6 @@ exports[`Featured item Extended renders correctly 1`] = `
   <article
     class="ecl-featured-item ecl-featured-item--extended"
   >
-    <h1
-      class="ecl-featured-item__heading"
-    >
-      Heading
-    </h1>
     <div
       class="ecl-featured-item__container"
     >
@@ -155,11 +145,6 @@ exports[`Featured item renders correctly with extra attributes 1`] = `
     data-test="data-test-value"
     data-test-1="data-test-value-1"
   >
-    <h1
-      class="ecl-featured-item__heading"
-    >
-      Heading
-    </h1>
     <div
       class="ecl-featured-item__container"
     >
@@ -229,11 +214,6 @@ exports[`Featured item renders correctly with extra class names 1`] = `
   <article
     class="ecl-featured-item custom-class custom-class--test"
   >
-    <h1
-      class="ecl-featured-item__heading"
-    >
-      Heading
-    </h1>
     <div
       class="ecl-featured-item__container"
     >

--- a/src/implementations/twig/components/featured-item/featured-item.html.twig
+++ b/src/implementations/twig/components/featured-item/featured-item.html.twig
@@ -2,7 +2,6 @@
 {#
   Parameters:
   - "type" (optional) (can be 'extended'),
-  - "heading" (optional) (string) (default: ''),
   - "title" (string) (default: ''),
   - "description" (string) (default: ''),
   - "link" (object) (default: ''): object of type Link
@@ -23,7 +22,6 @@
 {% set _css_class = 'ecl-featured-item' %}
 {% set _css_container_class = 'ecl-featured-item__container' %}
 {% set _type = type|default('') %}
-{% set _heading = heading|default('') %}
 {% set _title = title|default(false) %}
 {% set _description = description|default('') %}
 {% set _link = link|default({}) %}
@@ -60,9 +58,6 @@
 {# Print the result #}
 
 <article class="{{ _css_class }}"{{ _extra_attributes|raw }}>
-  {% if _heading is defined and _heading is not empty %}
-    <h1 class="ecl-featured-item__heading">{{ _heading }}</h1>
-  {% endif %}
   <div class="{{ _css_container_class }}">
     <div class="ecl-featured-item__item">
     {% include '@ecl/media-container/media-container.html.twig' with _media_container|merge({

--- a/src/implementations/twig/components/featured-item/featured-item.story.js
+++ b/src/implementations/twig/components/featured-item/featured-item.story.js
@@ -9,7 +9,6 @@ import notes from './README.md';
 
 const getArgs = (data) => {
   const args = {
-    heading: data.heading,
     title: data.title,
     description: data.description,
     position: 'left',
@@ -26,16 +25,6 @@ const getArgs = (data) => {
 
 const getArgTypes = (data) => {
   const argTypes = {};
-
-  argTypes.heading = {
-    type: 'string',
-    description: 'Featured item heading',
-    table: {
-      type: { summary: 'string' },
-      defaultValue: { summary: '' },
-      category: 'Content',
-    },
-  };
 
   argTypes.title = {
     type: 'string',

--- a/src/specs/components/featured-item/demo/data--extended.js
+++ b/src/specs/components/featured-item/demo/data--extended.js
@@ -3,7 +3,6 @@ const exampleLink = `${publicUrl}/example`;
 
 module.exports = {
   type: 'extended',
-  heading: 'Heading',
   title: 'Title',
   description:
     '<p class="ecl-u-type-paragraph-m">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>',


### PR DESCRIPTION
COMM made the decision to remove the heading for this component, taking the same approach as other components that don't have any. For the Platform, this will involve managing the title separately, as is already the case for other paragraphs.