### PR TITLE
fix(icon): Removing default, unneded but harmful transformation - FRONT-3702

### DIFF
--- a/src/implementations/twig/components/menu/__snapshots__/menu.test.js.snap
+++ b/src/implementations/twig/components/menu/__snapshots__/menu.test.js.snap
@@ -179,19 +179,10 @@ exports[`Menu Default renders correctly 1`] = `
                   data-ecl-menu-subitem=""
                 >
                   <a
-                    class="ecl-menu__sublink ecl-link--icon-after"
+                    class="ecl-menu__sublink"
                     href="/example"
                   >
                     Item 2.4
-                    <svg
-                      aria-hidden="true"
-                      class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                      focusable="false"
-                    >
-                      <use
-                        xlink:href="/icons.svg#external"
-                      />
-                    </svg>
                   </a>
                 </li>
                 <li
@@ -221,10 +212,19 @@ exports[`Menu Default renders correctly 1`] = `
                   data-ecl-menu-subitem=""
                 >
                   <a
-                    class="ecl-menu__sublink"
+                    class="ecl-menu__sublink ecl-link--icon-after"
                     href="/example"
                   >
                     Item 2.7
+                    <svg
+                      aria-hidden="true"
+                      class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                      focusable="false"
+                    >
+                      <use
+                        xlink:href="/icons.svg#external"
+                      />
+                    </svg>
                   </a>
                 </li>
               </ul>
@@ -1057,19 +1057,10 @@ exports[`Menu Default renders correctly with extra attributes 1`] = `
                   data-ecl-menu-subitem=""
                 >
                   <a
-                    class="ecl-menu__sublink ecl-link--icon-after"
+                    class="ecl-menu__sublink"
                     href="/example"
                   >
                     Item 2.4
-                    <svg
-                      aria-hidden="true"
-                      class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                      focusable="false"
-                    >
-                      <use
-                        xlink:href="/icons.svg#external"
-                      />
-                    </svg>
                   </a>
                 </li>
                 <li
@@ -1099,10 +1090,19 @@ exports[`Menu Default renders correctly with extra attributes 1`] = `
                   data-ecl-menu-subitem=""
                 >
                   <a
-                    class="ecl-menu__sublink"
+                    class="ecl-menu__sublink ecl-link--icon-after"
                     href="/example"
                   >
                     Item 2.7
+                    <svg
+                      aria-hidden="true"
+                      class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                      focusable="false"
+                    >
+                      <use
+                        xlink:href="/icons.svg#external"
+                      />
+                    </svg>
                   </a>
                 </li>
               </ul>
@@ -1933,19 +1933,10 @@ exports[`Menu Default renders correctly with extra class names 1`] = `
                   data-ecl-menu-subitem=""
                 >
                   <a
-                    class="ecl-menu__sublink ecl-link--icon-after"
+                    class="ecl-menu__sublink"
                     href="/example"
                   >
                     Item 2.4
-                    <svg
-                      aria-hidden="true"
-                      class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                      focusable="false"
-                    >
-                      <use
-                        xlink:href="/icons.svg#external"
-                      />
-                    </svg>
                   </a>
                 </li>
                 <li
@@ -1975,10 +1966,19 @@ exports[`Menu Default renders correctly with extra class names 1`] = `
                   data-ecl-menu-subitem=""
                 >
                   <a
-                    class="ecl-menu__sublink"
+                    class="ecl-menu__sublink ecl-link--icon-after"
                     href="/example"
                   >
                     Item 2.7
+                    <svg
+                      aria-hidden="true"
+                      class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                      focusable="false"
+                    >
+                      <use
+                        xlink:href="/icons.svg#external"
+                      />
+                    </svg>
                   </a>
                 </li>
               </ul>
@@ -2809,19 +2809,10 @@ exports[`Menu Translated renders correctly 1`] = `
                   data-ecl-menu-subitem=""
                 >
                   <a
-                    class="ecl-menu__sublink ecl-link--icon-after"
+                    class="ecl-menu__sublink"
                     href="/example"
                   >
                     Item 2.4
-                    <svg
-                      aria-hidden="true"
-                      class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                      focusable="false"
-                    >
-                      <use
-                        xlink:href="/icons.svg#external"
-                      />
-                    </svg>
                   </a>
                 </li>
                 <li
@@ -2851,10 +2842,19 @@ exports[`Menu Translated renders correctly 1`] = `
                   data-ecl-menu-subitem=""
                 >
                   <a
-                    class="ecl-menu__sublink"
+                    class="ecl-menu__sublink ecl-link--icon-after"
                     href="/example"
                   >
                     Item 2.7
+                    <svg
+                      aria-hidden="true"
+                      class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                      focusable="false"
+                    >
+                      <use
+                        xlink:href="/icons.svg#external"
+                      />
+                    </svg>
                   </a>
                 </li>
               </ul>

--- a/src/implementations/twig/deprecated/site-header-core/__snapshots__/site-header-core.test.js.snap
+++ b/src/implementations/twig/deprecated/site-header-core/__snapshots__/site-header-core.test.js.snap
@@ -331,19 +331,10 @@ exports[`EC Site Header Core Default renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -373,10 +364,19 @@ exports[`EC Site Header Core Default renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -1894,19 +1894,10 @@ exports[`EC Site Header Core Default renders correctly when logged in 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -1936,10 +1927,19 @@ exports[`EC Site Header Core Default renders correctly when logged in 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -3427,19 +3427,10 @@ exports[`EC Site Header Core Default renders correctly with extra attributes 1`]
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -3469,10 +3460,19 @@ exports[`EC Site Header Core Default renders correctly with extra attributes 1`]
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -4958,19 +4958,10 @@ exports[`EC Site Header Core Default renders correctly with extra class names 1`
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -5000,10 +4991,19 @@ exports[`EC Site Header Core Default renders correctly with extra class names 1`
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -6489,19 +6489,10 @@ exports[`EC Site Header Core Translated renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -6531,10 +6522,19 @@ exports[`EC Site Header Core Translated renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -8197,19 +8197,10 @@ exports[`EC Site Header Core Translated renders correctly with extra attributes 
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -8239,10 +8230,19 @@ exports[`EC Site Header Core Translated renders correctly with extra attributes 
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -9903,19 +9903,10 @@ exports[`EC Site Header Core Translated renders correctly with extra class names
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -9945,10 +9936,19 @@ exports[`EC Site Header Core Translated renders correctly with extra class names
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -11609,19 +11609,10 @@ exports[`EU Site Header Core Default renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -11651,10 +11642,19 @@ exports[`EU Site Header Core Default renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -13172,19 +13172,10 @@ exports[`EU Site Header Core Default renders correctly when logged in 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -13214,10 +13205,19 @@ exports[`EU Site Header Core Default renders correctly when logged in 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -14705,19 +14705,10 @@ exports[`EU Site Header Core Default renders correctly with extra attributes 1`]
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -14747,10 +14738,19 @@ exports[`EU Site Header Core Default renders correctly with extra attributes 1`]
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -16236,19 +16236,10 @@ exports[`EU Site Header Core Default renders correctly with extra class names 1`
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -16278,10 +16269,19 @@ exports[`EU Site Header Core Default renders correctly with extra class names 1`
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -17767,19 +17767,10 @@ exports[`EU Site Header Core Translated renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -17809,10 +17800,19 @@ exports[`EU Site Header Core Translated renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -19475,19 +19475,10 @@ exports[`EU Site Header Core Translated renders correctly with extra attributes 
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -19517,10 +19508,19 @@ exports[`EU Site Header Core Translated renders correctly with extra attributes 
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -21181,19 +21181,10 @@ exports[`EU Site Header Core Translated renders correctly with extra class names
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -21223,10 +21214,19 @@ exports[`EU Site Header Core Translated renders correctly with extra class names
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>

--- a/src/implementations/twig/deprecated/site-header-standardised/__snapshots__/site-header-standardised.test.js.snap
+++ b/src/implementations/twig/deprecated/site-header-standardised/__snapshots__/site-header-standardised.test.js.snap
@@ -381,19 +381,10 @@ exports[`EC Site Header Standardised Default renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -423,10 +414,19 @@ exports[`EC Site Header Standardised Default renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -1994,19 +1994,10 @@ exports[`EC Site Header Standardised Default renders correctly when logged in 1`
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -2036,10 +2027,19 @@ exports[`EC Site Header Standardised Default renders correctly when logged in 1`
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -3577,19 +3577,10 @@ exports[`EC Site Header Standardised Default renders correctly with extra attrib
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -3619,10 +3610,19 @@ exports[`EC Site Header Standardised Default renders correctly with extra attrib
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -5158,19 +5158,10 @@ exports[`EC Site Header Standardised Default renders correctly with extra class 
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -5200,10 +5191,19 @@ exports[`EC Site Header Standardised Default renders correctly with extra class 
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -6739,19 +6739,10 @@ exports[`EC Site Header Standardised Translated renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -6781,10 +6772,19 @@ exports[`EC Site Header Standardised Translated renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -8497,19 +8497,10 @@ exports[`EC Site Header Standardised Translated renders correctly with extra att
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -8539,10 +8530,19 @@ exports[`EC Site Header Standardised Translated renders correctly with extra att
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -10253,19 +10253,10 @@ exports[`EC Site Header Standardised Translated renders correctly with extra cla
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -10295,10 +10286,19 @@ exports[`EC Site Header Standardised Translated renders correctly with extra cla
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -12009,19 +12009,10 @@ exports[`EU Site Header Standardised Default renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -12051,10 +12042,19 @@ exports[`EU Site Header Standardised Default renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -13622,19 +13622,10 @@ exports[`EU Site Header Standardised Default renders correctly when logged in 1`
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -13664,10 +13655,19 @@ exports[`EU Site Header Standardised Default renders correctly when logged in 1`
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -15205,19 +15205,10 @@ exports[`EU Site Header Standardised Default renders correctly with extra attrib
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -15247,10 +15238,19 @@ exports[`EU Site Header Standardised Default renders correctly with extra attrib
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -16786,19 +16786,10 @@ exports[`EU Site Header Standardised Default renders correctly with extra class 
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -16828,10 +16819,19 @@ exports[`EU Site Header Standardised Default renders correctly with extra class 
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -18367,19 +18367,10 @@ exports[`EU Site Header Standardised Translated renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -18409,10 +18400,19 @@ exports[`EU Site Header Standardised Translated renders correctly 1`] = `
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -20125,19 +20125,10 @@ exports[`EU Site Header Standardised Translated renders correctly with extra att
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -20167,10 +20158,19 @@ exports[`EU Site Header Standardised Translated renders correctly with extra att
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>
@@ -21881,19 +21881,10 @@ exports[`EU Site Header Standardised Translated renders correctly with extra cla
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink ecl-link--icon-after"
+                      class="ecl-menu__sublink"
                       href="/example"
                     >
                       Item 2.4
-                      <svg
-                        aria-hidden="true"
-                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
-                        focusable="false"
-                      >
-                        <use
-                          xlink:href="/icons.svg#external"
-                        />
-                      </svg>
                     </a>
                   </li>
                   <li
@@ -21923,10 +21914,19 @@ exports[`EU Site Header Standardised Translated renders correctly with extra cla
                     data-ecl-menu-subitem=""
                   >
                     <a
-                      class="ecl-menu__sublink"
+                      class="ecl-menu__sublink ecl-link--icon-after"
                       href="/example"
                     >
                       Item 2.7
+                      <svg
+                        aria-hidden="true"
+                        class="ecl-icon ecl-icon--2xs ecl-menu__sublink-icon ecl-link__icon"
+                        focusable="false"
+                      >
+                        <use
+                          xlink:href="/icons.svg#external"
+                        />
+                      </svg>
                     </a>
                   </li>
                 </ul>

--- a/src/implementations/vanilla/components/icon/_icon.scss
+++ b/src/implementations/vanilla/components/icon/_icon.scss
@@ -11,7 +11,6 @@ $_primary-color: null !default;
 .ecl-icon {
   fill: currentcolor;
   margin: 0;
-  transform: scaleX(1) scaleY(1) rotateZ(0deg);
   transition: transform 300ms ease-in-out;
 }
 

--- a/src/specs/components/menu/demo/data--en.js
+++ b/src/specs/components/menu/demo/data--en.js
@@ -18,10 +18,10 @@ module.exports = {
         { label: 'Item 2.1', path: exampleLink },
         { label: 'Item 2.2', path: exampleLink },
         { label: 'Item 2.3', path: exampleLink, is_current: true },
-        { label: 'Item 2.4', path: exampleLink, external: true },
+        { label: 'Item 2.4', path: exampleLink },
         { label: 'Item 2.5', path: exampleLink },
         { label: 'Item 2.6', path: exampleLink },
-        { label: 'Item 2.7', path: exampleLink },
+        { label: 'Item 2.7', path: exampleLink, external: true },
       ],
     },
     {

--- a/src/specs/components/menu/demo/data--fr.js
+++ b/src/specs/components/menu/demo/data--fr.js
@@ -18,10 +18,10 @@ module.exports = {
         { label: 'Item 2.1', path: exampleLink },
         { label: 'Item 2.2', path: exampleLink },
         { label: 'Item 2.3', path: exampleLink, is_current: true },
-        { label: 'Item 2.4', path: exampleLink, external: true },
+        { label: 'Item 2.4', path: exampleLink },
         { label: 'Item 2.5', path: exampleLink },
         { label: 'Item 2.6', path: exampleLink },
-        { label: 'Item 2.7', path: exampleLink },
+        { label: 'Item 2.7', path: exampleLink, external: true },
       ],
     },
     {


### PR DESCRIPTION
Really surprising, personally i don't have an explanation, feels like this is a chrome bug. Any item in one of the "additional" columns in the menu set as external would get the external icon "transformed" in Chrome. It was enough to remove the default transformation set in the css, scale 0 rotate 0, which looks pretty useless, to get it fixed. Examples in the menu have been updated to "prove" this, to test it you can clone one item in production and put it in a column which is not the first.