### PR TITLE
fix(rating-field): Fix focus for safari - FRONT-3706

### DIFF
--- a/src/implementations/vanilla/components/rating-field/_rating-field.scss
+++ b/src/implementations/vanilla/components/rating-field/_rating-field.scss
@@ -50,7 +50,7 @@
 }
 
 // Focus, active state
-.ecl-rating-field__input:focus-visible,
+.ecl-rating-field__input:focus,
 .ecl-rating-field__input:active {
   + .ecl-rating-field__label {
     outline: 2px solid map.get(theme.$color, 'blue');


### PR DESCRIPTION
`focus-visible` style is not supported on radio elements when navigating with keyboard arrows on safari