### PR TITLE
fix(carousel): allow click on cta - FRONT-3747

### DIFF
--- a/src/implementations/vanilla/components/carousel/carousel.js
+++ b/src/implementations/vanilla/components/carousel/carousel.js
@@ -291,6 +291,7 @@ export class Carousel {
     e = e || window.event;
 
     if (e.type === 'touchmove') {
+      e.preventDefault();
       this.posX2 = this.posX1 - e.touches[0].clientX;
       this.posX1 = e.touches[0].clientX;
     }

--- a/src/implementations/vanilla/components/carousel/carousel.js
+++ b/src/implementations/vanilla/components/carousel/carousel.js
@@ -275,7 +275,7 @@ export class Carousel {
    */
   dragStart(e) {
     e = e || window.event;
-    e.preventDefault();
+
     this.posInitial = this.slidesContainer.offsetLeft;
 
     if (e.type === 'touchstart') {


### PR DESCRIPTION
Fixes the carousel, to allow click on the call to action; on current version is is not possible to click on it because of the drag function.

Can be tested on storybook (fullscreen), with responsive display of the inspector