### PR TITLE
fix(card): fix image display on firefox - FRONT-3788

### DIFF
--- a/src/implementations/vanilla/components/card/_card.scss
+++ b/src/implementations/vanilla/components/card/_card.scss
@@ -32,6 +32,7 @@ $_body-padding: null !default;
 
 .ecl-card__image {
   background-position: center;
+  background-repeat: no-repeat;
   background-size: cover;
   border: $_image-border-width solid $_image-border-color;
   display: block;


### PR DESCRIPTION
Fix a small display issue when using background image + a border in card (only on firefox)