### PR TITLE
fix(link): fix underline for link with icons - FRONT-3865

### DIFF
--- a/src/implementations/vanilla/components/link/_link.scss
+++ b/src/implementations/vanilla/components/link/_link.scss
@@ -62,6 +62,10 @@ $_negative: null !default;
     top: -1px;
     vertical-align: middle;
   }
+
+  &:not(.ecl-link--standalone) .ecl-link__label {
+    text-decoration: underline;
+  }
 }
 
 .ecl-link--icon-before .ecl-link__icon {


### PR DESCRIPTION
Apply the same logic that we have on print (probably removed by mistake)