### PR TITLE
chore(print): Global font-family set in default-print css - FRONT-3861

### DIFF
--- a/src/presets/ec/src/ec-default-print.scss
+++ b/src/presets/ec/src/ec-default-print.scss
@@ -10,6 +10,10 @@
 @use '@ecl/vanilla-component-unordered-list/unordered-list-print';
 @use '@ecl/vanilla-utility-typography/typography-print-ec';
 
+html {
+  font-family: #{map.get(theme.$font-family, 'default')};
+}
+
 // stylelint-disable no-descending-specificity
 .ecl button:not([class*='ecl-'], [class*='wt-']),
 .ecl button:is([class*='ecl-u-']) {

--- a/src/presets/ec/src/ec-print.scss
+++ b/src/presets/ec/src/ec-print.scss
@@ -1,4 +1,5 @@
-@use '@ecl/theme-ec';
+@use 'sass:map';
+@use '@ecl/theme-ec' as theme;
 
 // Icons & Images
 @use '@ecl/vanilla-component-icon/icon-print';
@@ -93,3 +94,7 @@
 @use '@ecl/vanilla-utility-spacing/spacing-print';
 @use '@ecl/vanilla-utility-typography/typography-print-ec';
 @use '@ecl/vanilla-utility-z-index/z-index';
+
+html {
+  font-family: #{map.get(theme.$font-family, 'default')};
+}

--- a/src/presets/eu/src/eu-default-print.scss
+++ b/src/presets/eu/src/eu-default-print.scss
@@ -10,6 +10,10 @@
 @use '@ecl/vanilla-component-unordered-list/unordered-list-print';
 @use '@ecl/vanilla-utility-typography/typography-print-eu';
 
+html {
+  font-family: #{map.get(theme.$font-family, 'default')};
+}
+
 // stylelint-disable no-descending-specificity
 .ecl button:not([class*='ecl-'], [class*='wt-']),
 .ecl button:is([class*='ecl-u-']) {

--- a/src/presets/eu/src/eu-print.scss
+++ b/src/presets/eu/src/eu-print.scss
@@ -1,4 +1,5 @@
-@use '@ecl/theme-eu';
+@use 'sass:map';
+@use '@ecl/theme-eu' as theme;
 
 // Icons & Images
 @use '@ecl/vanilla-component-icon/icon-print';
@@ -93,3 +94,7 @@
 @use '@ecl/vanilla-utility-spacing/spacing-print';
 @use '@ecl/vanilla-utility-typography/typography-print-eu';
 @use '@ecl/vanilla-utility-z-index/z-index';
+
+html {
+  font-family: #{map.get(theme.$font-family, 'default')};
+}


### PR DESCRIPTION
Not sure this is really needed, the truth is that we should load the print css in the website, this is where the problem that originated this request was identified, this generic rule is not really going to be "fired", given ecl markup while it would affect "alien" markup, which is out of the scope of our stylesheets.
