### PR TITLE
feat(site-header): Using picture, keeping data structure unchanged - FRONT-3882

### DIFF
--- a/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
+++ b/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
@@ -4763,10 +4763,6 @@ exports[`Site Header EU renders correctly 1`] = `
                 media="(min-width: 996px)"
                 srcset="/standard-version/positive/logo-eu--en.svg"
               />
-              <source
-                media="(min-width: 480px)"
-                srcset="/condensed-version/positive/logo-eu--en.svg"
-              />
               <img
                 alt="European Union flag"
                 class="ecl-site-header__logo-image"

--- a/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
+++ b/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
@@ -25,9 +25,13 @@ exports[`Site Header EC renders correctly 1`] = `
               class="ecl-picture ecl-site-header__picture"
               title="European Commission"
             >
+              <source
+                media="(min-width: 996px)"
+                srcset="/logo-ec--en.svg"
+              />
               <img
                 alt="European Commission logo"
-                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
+                class="ecl-site-header__logo-image"
                 src="/logo-ec--en.svg"
               />
             </picture>
@@ -1196,9 +1200,13 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
               class="ecl-picture ecl-site-header__picture"
               title="European Commission"
             >
+              <source
+                media="(min-width: 996px)"
+                srcset="/logo-ec--en.svg"
+              />
               <img
                 alt="European Commission logo"
-                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
+                class="ecl-site-header__logo-image"
                 src="/logo-ec--en.svg"
               />
             </picture>
@@ -2401,9 +2409,13 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
               class="ecl-picture ecl-site-header__picture"
               title="European Commission"
             >
+              <source
+                media="(min-width: 996px)"
+                srcset="/logo-ec--en.svg"
+              />
               <img
                 alt="European Commission logo"
-                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
+                class="ecl-site-header__logo-image"
                 src="/logo-ec--en.svg"
               />
             </picture>
@@ -3572,9 +3584,13 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
               class="ecl-picture ecl-site-header__picture"
               title="European Commission"
             >
+              <source
+                media="(min-width: 996px)"
+                srcset="/logo-ec--en.svg"
+              />
               <img
                 alt="European Commission logo"
-                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
+                class="ecl-site-header__logo-image"
                 src="/logo-ec--en.svg"
               />
             </picture>
@@ -4743,20 +4759,18 @@ exports[`Site Header EU renders correctly 1`] = `
               class="ecl-picture ecl-site-header__picture"
               title="European Union"
             >
-              <img
-                alt="European Union flag"
-                class="ecl-site-header__logo-image ecl-site-header__logo-image-mobile"
-                src="/condensed-version/positive/logo-eu--en.svg"
+              <source
+                media="(min-width: 996px)"
+                srcset="/standard-version/positive/logo-eu--en.svg"
               />
-            </picture>
-            <picture
-              class="ecl-picture ecl-site-header__picture"
-              title="European Union"
-            >
+              <source
+                media="(min-width: 480px)"
+                srcset="/condensed-version/positive/logo-eu--en.svg"
+              />
               <img
                 alt="European Union flag"
-                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
-                src="/standard-version/positive/logo-eu--en.svg"
+                class="ecl-site-header__logo-image"
+                src="/condensed-version/positive/logo-eu--en.svg"
               />
             </picture>
           </a>

--- a/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
+++ b/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
@@ -21,12 +21,16 @@ exports[`Site Header EC renders correctly 1`] = `
             class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
             href="/example"
           >
-            <img
-              alt="European Commission logo"
-              class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
-              src="/logo-ec--en.svg"
+            <picture
+              class="ecl-picture ecl-site-header__picture"
               title="European Commission"
-            />
+            >
+              <img
+                alt="European Commission logo"
+                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
+                src="/logo-ec--en.svg"
+              />
+            </picture>
           </a>
           <div
             class="ecl-site-header__action"
@@ -1188,12 +1192,16 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
             class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
             href="/example"
           >
-            <img
-              alt="European Commission logo"
-              class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
-              src="/logo-ec--en.svg"
+            <picture
+              class="ecl-picture ecl-site-header__picture"
               title="European Commission"
-            />
+            >
+              <img
+                alt="European Commission logo"
+                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
+                src="/logo-ec--en.svg"
+              />
+            </picture>
           </a>
           <div
             class="ecl-site-header__action"
@@ -2389,12 +2397,16 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
             class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
             href="/example"
           >
-            <img
-              alt="European Commission logo"
-              class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
-              src="/logo-ec--en.svg"
+            <picture
+              class="ecl-picture ecl-site-header__picture"
               title="European Commission"
-            />
+            >
+              <img
+                alt="European Commission logo"
+                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
+                src="/logo-ec--en.svg"
+              />
+            </picture>
           </a>
           <div
             class="ecl-site-header__action"
@@ -3556,12 +3568,16 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
             class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
             href="/example"
           >
-            <img
-              alt="European Commission logo"
-              class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
-              src="/logo-ec--en.svg"
+            <picture
+              class="ecl-picture ecl-site-header__picture"
               title="European Commission"
-            />
+            >
+              <img
+                alt="European Commission logo"
+                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
+                src="/logo-ec--en.svg"
+              />
+            </picture>
           </a>
           <div
             class="ecl-site-header__action"
@@ -4723,18 +4739,26 @@ exports[`Site Header EU renders correctly 1`] = `
             class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
             href="/example"
           >
-            <img
-              alt="European Union flag"
-              class="ecl-site-header__logo-image ecl-site-header__logo-image-mobile"
-              src="/condensed-version/positive/logo-eu--en.svg"
+            <picture
+              class="ecl-picture ecl-site-header__picture"
               title="European Union"
-            />
-            <img
-              alt="European Union flag"
-              class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
-              src="/standard-version/positive/logo-eu--en.svg"
+            >
+              <img
+                alt="European Union flag"
+                class="ecl-site-header__logo-image ecl-site-header__logo-image-mobile"
+                src="/condensed-version/positive/logo-eu--en.svg"
+              />
+            </picture>
+            <picture
+              class="ecl-picture ecl-site-header__picture"
               title="European Union"
-            />
+            >
+              <img
+                alt="European Union flag"
+                class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
+                src="/standard-version/positive/logo-eu--en.svg"
+              />
+            </picture>
           </a>
           <div
             class="ecl-site-header__action"

--- a/src/implementations/twig/components/site-header/site-header.html.twig
+++ b/src/implementations/twig/components/site-header/site-header.html.twig
@@ -212,7 +212,6 @@
                   src: _logo.src_mobile,
                   alt: _logo.alt,
                 },
-                sources: _picture.sources|merge([{ src: _logo.src_mobile, media: 's' }]),
               }) %}
             {% else %}
               {% set _picture = _picture|merge({

--- a/src/implementations/twig/components/site-header/site-header.html.twig
+++ b/src/implementations/twig/components/site-header/site-header.html.twig
@@ -202,46 +202,43 @@
   <div class="ecl-site-header__header">
     <div class="ecl-site-header__container ecl-container">
       <div class="ecl-site-header__top" data-ecl-site-header-top>
-      {# Logo #}
-      {% if _logo is not empty %}
-        {% set _label %}
-          {% if _logo.src_mobile is defined and _logo.src_mobile is not empty %}
-            {% include '@ecl/picture/picture.html.twig' with {
-              picture: {
+        {# Logo #}
+        {% if _logo is not empty and _logo.src_desktop is not empty %}
+          {% set _label %}
+            {% set _picture = { sources: [{ src: _logo.src_desktop, media: 'l' }] } %}
+            {% if _logo.src_mobile is defined and _logo.src_mobile is not empty %}
+              {% set _picture = _picture|merge({
                 img: {
                   src: _logo.src_mobile,
                   alt: _logo.alt,
                 },
-              },
-              extra_classes: "ecl-site-header__picture",
-              extra_image_classes: 'ecl-site-header__logo-image ecl-site-header__logo-image-mobile',
-              extra_attributes: [{ name: 'title', value: _logo.title }],
-            } only %}
-          {% endif %}
-          {% if _logo.src_desktop is defined and _logo.src_desktop is not empty %}
-            {% include '@ecl/picture/picture.html.twig' with {
-              picture: {
+                sources: _picture.sources|merge([{ src: _logo.src_mobile, media: 's' }]),
+              }) %}
+            {% else %}
+              {% set _picture = _picture|merge({
                 img: {
                   src: _logo.src_desktop,
                   alt: _logo.alt,
                 },
-              },
-              extra_attributes: [{ name: 'title', value: _logo.title }],
+              }) %}
+            {% endif %}
+            {% include '@ecl/picture/picture.html.twig' with {
+              picture: _picture,
               extra_classes: "ecl-site-header__picture",
-              extra_image_classes: 'ecl-site-header__logo-image ecl-site-header__logo-image-desktop',
+              extra_image_classes: 'ecl-site-header__logo-image',
+              extra_attributes: [{ name: 'title', value: _logo.title }],
             } only %}
-          {% endif %}
-        {% endset %}
-        {% include '@ecl/link/link.html.twig' with {
-          link: {
-            path: _logo.path,
-            label: _label,
-            type: 'standalone',
-            aria_label: _logo.title
-          },
-          extra_classes: 'ecl-site-header__logo-link'
-        } only %}
-      {% endif %}
+          {% endset %}
+          {% include '@ecl/link/link.html.twig' with {
+            link: {
+              path: _logo.path,
+              label: _label,
+              type: 'standalone',
+              aria_label: _logo.title
+            },
+            extra_classes: 'ecl-site-header__logo-link'
+          } only %}
+        {% endif %}
 
         {# Header actions #}
         <div class="ecl-site-header__action">

--- a/src/implementations/twig/components/site-header/site-header.html.twig
+++ b/src/implementations/twig/components/site-header/site-header.html.twig
@@ -202,25 +202,35 @@
   <div class="ecl-site-header__header">
     <div class="ecl-site-header__container ecl-container">
       <div class="ecl-site-header__top" data-ecl-site-header-top>
-      {% if _logo is not empty %}
       {# Logo #}
+      {% if _logo is not empty %}
         {% set _label %}
-        {% if _logo.src_mobile is defined and _logo.src_mobile is not empty %}
-        <img
-          alt="{{ _logo.alt }}"
-          title="{{ _logo.title }}"
-          class="ecl-site-header__logo-image ecl-site-header__logo-image-mobile"
-          src="{{ _logo.src_mobile }}"
-        />
-        {% endif %}
-        {% if _logo.src_desktop is defined and _logo.src_desktop is not empty %}
-        <img
-          alt="{{ _logo.alt }}"
-          title="{{ _logo.title }}"
-          class="ecl-site-header__logo-image ecl-site-header__logo-image-desktop"
-          src="{{ _logo.src_desktop }}"
-        />
-        {% endif %}
+          {% if _logo.src_mobile is defined and _logo.src_mobile is not empty %}
+            {% include '@ecl/picture/picture.html.twig' with {
+              picture: {
+                img: {
+                  src: _logo.src_mobile,
+                  alt: _logo.alt,
+                },
+              },
+              extra_classes: "ecl-site-header__picture",
+              extra_image_classes: 'ecl-site-header__logo-image ecl-site-header__logo-image-mobile',
+              extra_attributes: [{ name: 'title', value: _logo.title }],
+            } only %}
+          {% endif %}
+          {% if _logo.src_desktop is defined and _logo.src_desktop is not empty %}
+            {% include '@ecl/picture/picture.html.twig' with {
+              picture: {
+                img: {
+                  src: _logo.src_desktop,
+                  alt: _logo.alt,
+                },
+              },
+              extra_attributes: [{ name: 'title', value: _logo.title }],
+              extra_classes: "ecl-site-header__picture",
+              extra_image_classes: 'ecl-site-header__logo-image ecl-site-header__logo-image-desktop',
+            } only %}
+          {% endif %}
         {% endset %}
         {% include '@ecl/link/link.html.twig' with {
           link: {

--- a/src/implementations/vanilla/components/site-header/site-header-eu.scss
+++ b/src/implementations/vanilla/components/site-header/site-header-eu.scss
@@ -1,6 +1,11 @@
 /**
  * Site Header
  * @define site-header; weak
+ *
+ *  => ECL v3.8 Deprecated selectors
+ *     .ecl-site-header__logo-image-mobile
+ *     .ecl-site-header__logo-image-desktop
+ *  Replaced by: .ecl-site-header__logo-image
  */
 
 @use 'sass:map';
@@ -78,10 +83,15 @@ $_search-width-xl: 31.5rem;
   flex-grow: 1;
 }
 
+.ecl-site-header__logo-image-mobile,
 .ecl-site-header__logo-image {
   display: block;
   max-height: $_logo-height-xs;
   max-width: 100%;
+}
+
+.ecl-site-header__logo-image-desktop {
+  display: none;
 }
 
 .ecl-site-header__action {
@@ -236,6 +246,7 @@ $_search-width-xl: 31.5rem;
     flex-grow: 0;
   }
 
+  .ecl-site-header__logo-image-mobile,
   .ecl-site-header__logo-image {
     height: $_logo-height-sm;
     max-height: 100%;
@@ -328,6 +339,11 @@ $_search-width-xl: 31.5rem;
     margin-bottom: 0;
   }
 
+  .ecl-site-header__logo-image-mobile {
+    display: none;
+  }
+
+  .ecl-site-header__logo-image-desktop,
   .ecl-site-header__logo-image {
     display: block;
     height: $_logo-height-lg;

--- a/src/implementations/vanilla/components/site-header/site-header-eu.scss
+++ b/src/implementations/vanilla/components/site-header/site-header-eu.scss
@@ -78,14 +78,10 @@ $_search-width-xl: 31.5rem;
   flex-grow: 1;
 }
 
-.ecl-site-header__logo-image-mobile {
+.ecl-site-header__logo-image {
   display: block;
   max-height: $_logo-height-xs;
   max-width: 100%;
-}
-
-.ecl-site-header__logo-image-desktop {
-  display: none;
 }
 
 .ecl-site-header__action {
@@ -240,7 +236,7 @@ $_search-width-xl: 31.5rem;
     flex-grow: 0;
   }
 
-  .ecl-site-header__logo-image-mobile {
+  .ecl-site-header__logo-image {
     height: $_logo-height-sm;
     max-height: 100%;
     max-width: 100%;
@@ -332,11 +328,7 @@ $_search-width-xl: 31.5rem;
     margin-bottom: 0;
   }
 
-  .ecl-site-header__logo-image-mobile {
-    display: none;
-  }
-
-  .ecl-site-header__logo-image-desktop {
+  .ecl-site-header__logo-image {
     display: block;
     height: $_logo-height-lg;
     width: $_logo-width-lg;


### PR DESCRIPTION
Use picture tag to handle logo

Note: for EU, the change of logo between mobile and desktop is now handled with the picture source