### PR TITLE
fix(menu): Avoiding escape of html attribute - FRONT-3951

### DIFF
--- a/src/implementations/twig/components/menu/README.md
+++ b/src/implementations/twig/components/menu/README.md
@@ -17,11 +17,13 @@ npm install --save @ecl/twig-component-menu
   "label": (string) (default: '')
   "path": (string) (default: '')
   "is_current": (boolean) (optional),
+  "trigger_aria_label" (string),
   "children": (associative array) (optional): [
   {
   "label": (string) (default: '')
   "path": (string) (default: '')
   "is_current": (boolean) (optional),
+  "external": (boolean)
   }
   ]
   }

--- a/src/implementations/twig/components/menu/menu-item.html.twig
+++ b/src/implementations/twig/components/menu/menu-item.html.twig
@@ -32,7 +32,7 @@
   {% set _menu_list_item_class = _menu_list_item_class ~ ' ecl-menu__item--has-children' %}
 {% endif %}
 
-<li class="{{ _menu_list_item_class }}" {{ _menu_list_item_attributes }}>
+<li class="{{ _menu_list_item_class }}" {{ _menu_list_item_attributes|raw }}>
   <a href="{{ item.path }}" class="{{ _menu_item_class }}" {{ _menu_item_attributes }}>
     {{- item.label -}}
     {%- if item.external -%}

--- a/src/implementations/twig/components/menu/menu.html.twig
+++ b/src/implementations/twig/components/menu/menu.html.twig
@@ -12,11 +12,13 @@
       "label": (string) (default: '')
       "path": (string) (default: '')
       "is_current": (boolean) (optional),
+      "trigger_aria_label" (string),
       "children": (associative array) (optional): [
         {
           "label": (string) (default: '')
           "path": (string) (default: '')
           "is_current": (boolean) (optional),
+          "external": (boolean)
         }
       ]
     }


### PR DESCRIPTION
Fix html escaping and add missing parameters in documentation (they were already part of the code)