### PR TITLE
fix(storybook): Fixing args in url when the value is from a select or a radio control - FRONT-3996

### DIFF
--- a/src/implementations/twig/components/banner/banner.story.js
+++ b/src/implementations/twig/components/banner/banner.story.js
@@ -74,6 +74,11 @@ const getArgTypes = (data) => {
           l: 'large',
         },
       },
+      mapping: {
+        s: 'small',
+        m: 'medium',
+        l: 'large',
+      },
       table: {
         type: 'string',
         defaultValue: { summary: 'm' },
@@ -101,6 +106,11 @@ const getArgTypes = (data) => {
           container: 'inside the grid container',
           inside: 'inside the grid container, with fullwidth class',
         },
+      },
+      mapping: {
+        outside: 'outside the grid container',
+        container: 'inside the grid container',
+        inside: 'inside the grid container, with fullwidth class',
       },
       table: {
         type: { summary: 'radio' },

--- a/src/implementations/twig/components/button/button.story.js
+++ b/src/implementations/twig/components/button/button.story.js
@@ -17,6 +17,11 @@ import notes from './README.md';
 const system = getSystem();
 const iconsAll = system === 'eu' ? iconsAllEu : iconsAllEc;
 
+const iconMapping = iconsAll.reduce((mapping, icon) => {
+  mapping[icon] = icon;
+  return mapping;
+}, {});
+
 // Create 'none' option.
 iconsAll.unshift('none');
 
@@ -46,6 +51,7 @@ const getArgTypes = () => {
     description: 'Button icon',
     type: { name: 'select' },
     options: iconsAll,
+    mapping: iconMapping,
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: '' },
@@ -63,6 +69,13 @@ const getArgTypes = () => {
       'flip-horizontal',
       'flip-vertical',
     ],
+    mapping: {
+      'rotate-90': 'rotate-90',
+      'rotate-180': 'rotate-180',
+      'rotate-270': 'rotate-270',
+      'flip-horizontal': 'flip-horizontal',
+      'flip-vertical': 'flip-vertical',
+    },
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: '' },
@@ -74,6 +87,10 @@ const getArgTypes = () => {
     type: { name: 'inline-radio' },
     description: 'Icon position inside the button',
     options: ['before', 'after'],
+    mapping: {
+      before: 'before',
+      after: 'after',
+    },
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: 'after' },

--- a/src/implementations/twig/components/carousel/carousel.story.js
+++ b/src/implementations/twig/components/carousel/carousel.story.js
@@ -31,6 +31,11 @@ const getArgTypes = () => {
           inside: 'inside the grid container, with fullwidth class',
         },
       },
+      mapping: {
+        outside: 'outside the grid container',
+        container: 'inside the grid container',
+        inside: 'inside the grid container, with fullwidth class',
+      },
       table: {
         defaultValue: '',
         category: 'Display',

--- a/src/implementations/twig/components/content-item/content-item.story.js
+++ b/src/implementations/twig/components/content-item/content-item.story.js
@@ -156,6 +156,10 @@ const getArgTypes = (data) => {
           large: 'large (landscape)',
         },
       },
+      mapping: {
+        small: 'small (square)',
+        large: 'large (landscape)',
+      },
       table: {
         type: 'string',
         defaultValue: { summary: '' },
@@ -167,6 +171,10 @@ const getArgTypes = (data) => {
       type: 'select',
       description: "Possible image position ('left' or 'right')",
       options: ['left', 'right'],
+      mapping: {
+        left: 'left',
+        right: 'right',
+      },
       table: {
         type: 'string',
         defaultValue: { summary: '' },

--- a/src/implementations/twig/components/fact-figures/fact-figures.story.js
+++ b/src/implementations/twig/components/fact-figures/fact-figures.story.js
@@ -13,6 +13,11 @@ import notes from './README.md';
 const system = getSystem();
 const iconsAll = system === 'eu' ? iconsAllEu : iconsAllEc;
 
+const iconMapping = iconsAll.reduce((mapping, icon) => {
+  mapping[icon] = icon;
+  return mapping;
+}, {});
+
 const getArgs = (data) => ({
   show_view_all: true,
   show_icons: true,
@@ -57,6 +62,7 @@ const getArgTypes = () => ({
     description: 'Name of the icon',
     type: 'select',
     options: iconsAll,
+    mapping: iconMapping,
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: '' },

--- a/src/implementations/twig/components/featured-item/featured-item.story.js
+++ b/src/implementations/twig/components/featured-item/featured-item.story.js
@@ -72,6 +72,10 @@ const getArgTypes = (data) => {
     type: { name: 'select' },
     description: 'Alignment inside featured item',
     options: ['left', 'right'],
+    mapping: {
+      left: 'left',
+      right: 'right',
+    },
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: '' },

--- a/src/implementations/twig/components/icon/icon.story.js
+++ b/src/implementations/twig/components/icon/icon.story.js
@@ -13,6 +13,11 @@ import notes from './README.md';
 const system = getSystem();
 const iconsAll = system === 'eu' ? iconsAllEu : iconsAllEc;
 
+const iconMapping = iconsAll.reduce((mapping, iconName) => {
+  mapping[iconName] = iconName;
+  return mapping;
+}, {});
+
 const getArgs = (data) => ({
   name: data.icon.name,
   size: 'm',
@@ -20,7 +25,7 @@ const getArgs = (data) => ({
   transform: 'none',
 });
 
-const getArgTypes = (data, icons) => getIconControls(data, icons);
+const getArgTypes = (data, icons) => getIconControls(data, icons, iconMapping);
 
 const prepareData = (data, args) => {
   if (args.color === 'default') {
@@ -47,5 +52,5 @@ export const All = (args) => icon(prepareData(dataAll, args));
 
 All.storyName = 'all icons';
 All.args = getArgs(dataAll);
-All.argTypes = getArgTypes(dataAll, iconsAll);
+All.argTypes = getArgTypes(dataAll, iconsAll, iconMapping);
 All.parameters = { notes: { markdown: notes, json: dataAll } };

--- a/src/implementations/twig/components/link/link.story.js
+++ b/src/implementations/twig/components/link/link.story.js
@@ -22,6 +22,11 @@ const iconsAll = system === 'eu' ? iconsAllEu : iconsAllEc;
 // Create 'none' option.
 iconsAll.unshift('none');
 
+const iconMapping = iconsAll.reduce((mapping, icon) => {
+  mapping[icon] = icon;
+  return mapping;
+}, {});
+
 const withParagraph = (story) => {
   const demo = story();
   return `<p class="ecl-u-type-paragraph ecl-u-ma-none">The European Commission is the executive of ${demo} and promotes its general interest.</p>`;
@@ -99,6 +104,7 @@ const getArgTypes = () => ({
     name: 'icon name',
     type: { name: 'select', required: false },
     options: [...iconsAll],
+    mapping: iconMapping,
     description: 'Name of the icon',
     table: {
       type: { summary: 'string' },
@@ -116,6 +122,13 @@ const getArgTypes = () => ({
       'flip-horizontal',
       'flip-vertical',
     ],
+    mapping: {
+      'rotate-90': 'rotate-90',
+      'rotate-180': 'rotate-180',
+      'rotate-270': 'rotate-270',
+      'flip-horizontal': 'flip-horizontal',
+      'flip-vertical': 'flip-vertical',
+    },
     table: {
       type: { summary: 'string' },
       category: 'Icon',
@@ -126,6 +139,10 @@ const getArgTypes = () => ({
     type: { name: 'inline-radio' },
     description: 'Icon position inside the link',
     options: ['before', 'after'],
+    mapping: {
+      before: 'before',
+      after: 'after',
+    },
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: 'after' },

--- a/src/implementations/twig/components/list-illustration/list-illustration.story.js
+++ b/src/implementations/twig/components/list-illustration/list-illustration.story.js
@@ -22,6 +22,16 @@ const valueDefault = dataListIllustrationIcon.items[0].value;
 // Create 'none' option.
 iconsAll.unshift('none');
 
+const iconMapping = iconsAll.reduce((mapping, icon) => {
+  mapping[icon] = icon;
+  return mapping;
+}, {});
+
+const flagMapping = iconsFlag.reduce((mapping, icon) => {
+  mapping[icon] = icon;
+  return mapping;
+}, {});
+
 const getArgs = (data, variant) => {
   const args = {
     show_description: true,
@@ -198,6 +208,11 @@ const getArgTypes = (data, variant) => {
           l: 'large',
         },
       },
+      mapping: {
+        s: 'small',
+        m: 'medium',
+        l: 'large',
+      },
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: '' },
@@ -212,6 +227,7 @@ const getArgTypes = (data, variant) => {
       description: 'The generic icon used in the list item (first item)',
       type: { name: 'select' },
       options: iconsAll,
+      mapping: iconMapping,
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: '' },
@@ -223,6 +239,7 @@ const getArgTypes = (data, variant) => {
       description: 'The flag icon used in the list item (first item)',
       type: { name: 'select' },
       options: iconsFlag,
+      mapping: flagMapping,
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: '' },
@@ -239,6 +256,11 @@ const getArgTypes = (data, variant) => {
           s: 'small',
           l: 'large',
         },
+      },
+      mapping: {
+        s: 'small',
+        m: 'medium',
+        l: 'large',
       },
       table: {
         type: { summary: 'string' },

--- a/src/implementations/twig/components/media-container/media-container.story.js
+++ b/src/implementations/twig/components/media-container/media-container.story.js
@@ -72,6 +72,11 @@ const getArgTypes = (data) => {
         inside: 'inside the ecl-container, with fullwidth class',
       },
     },
+    mapping: {
+      outside: 'outside the ecl-container',
+      container: 'inside the ecl-container',
+      inside: 'inside the ecl-container, with fullwidth class',
+    },
   };
 
   return argTypes;
@@ -134,6 +139,13 @@ EmbeddedVideo.argTypes = {
     type: { name: 'select' },
     description: 'Media ratio (if empty the ratio will be set by the js)',
     options: {
+      auto: '',
+      '16/9': '16-9',
+      '4/3': '4-3',
+      '3/2': '3-2',
+      '1/1': '1-1',
+    },
+    mapping: {
       auto: '',
       '16/9': '16-9',
       '4/3': '4-3',

--- a/src/implementations/twig/components/modal/modal.story.js
+++ b/src/implementations/twig/components/modal/modal.story.js
@@ -25,6 +25,13 @@ const getArgTypes = () => ({
       warning: 'warning',
       error: 'error',
     },
+    mapping: {
+      default: '',
+      information: 'information',
+      success: 'success',
+      warning: 'warning',
+      error: 'error',
+    },
     table: {
       category: 'Display',
     },

--- a/src/implementations/twig/components/page-header/ec-page-header.story.js
+++ b/src/implementations/twig/components/page-header/ec-page-header.story.js
@@ -131,6 +131,11 @@ const getArgTypes = (data) => {
       type: 'select',
       description: 'Overlay on top on background image',
       options: ['none', 'dark', 'light'],
+      mapping: {
+        none: 'none',
+        dark: 'dark',
+        light: 'light',
+      },
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: '' },

--- a/src/implementations/twig/components/spinner/spinner.story.js
+++ b/src/implementations/twig/components/spinner/spinner.story.js
@@ -48,6 +48,11 @@ const getArgTypes = (variant) => ({
   size: {
     type: { name: 'select' },
     options: ['small', 'medium', 'large'],
+    mapping: {
+      small: 'small',
+      medium: 'medium',
+      large: 'large',
+    },
     description: 'Variant of the component',
     table: {
       type: { summary: 'string' },

--- a/src/playground/addons/story-utils/index.js
+++ b/src/playground/addons/story-utils/index.js
@@ -36,12 +36,13 @@ export const correctPaths = (data) => {
   return data;
 };
 
-export const getIconControls = (data, icons) => {
+export const getIconControls = (data, icons, mapping) => {
   const argTypes = {};
   argTypes.name = {
     type: { name: 'select', required: true },
     description: 'Name of the icon',
     options: icons,
+    mapping,
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: '' },
@@ -71,6 +72,16 @@ export const getIconControls = (data, icons) => {
         fluid: 'fluid',
       },
     },
+    mapping: {
+      'extra small 2': '2xs',
+      'extra small': 'xs',
+      small: 's',
+      medium: 'm',
+      large: 'l',
+      'extra large': 'xl',
+      'extra large 2': '2xl',
+      fluid: 'fluid',
+    },
   };
   argTypes.color = {
     name: 'color',
@@ -82,6 +93,11 @@ export const getIconControls = (data, icons) => {
       category: 'Icon',
     },
     options: ['default', 'inverted', 'primary'],
+    mapping: {
+      default: 'default',
+      inverted: 'inverted',
+      primary: 'primary',
+    },
   };
   argTypes.transform = {
     name: 'transformation',
@@ -100,6 +116,14 @@ export const getIconControls = (data, icons) => {
       'flip-horizontal',
       'flip-vertical',
     ],
+    mapping: {
+      none: 'none',
+      '90° rotation': 'rotate-90',
+      '180° rotation': 'rotate-180',
+      '270° rotation': 'rotate-270',
+      'horizontal flip': 'flip-horizontal',
+      'vertical flip': 'flip-vertical',
+    },
     control: {
       labels: {
         none: 'none',
@@ -234,6 +258,11 @@ export const getFormControls = (data, type) => {
       control: {
         type: 'select',
         label: { s: 'small', m: 'medium', l: 'large' },
+      },
+      mapping: {
+        s: 'small',
+        m: 'medium',
+        l: 'large',
       },
     };
   }


### PR DESCRIPTION
The solution was to add a mapping object in all the controls.
It can be tested on the featured-item, we currently have one link to the story where we try to set the image on the right and it doesn't work in production, it works in this pr, instead.
Other args can be tested by selecting a value, getting the url, load it in a different tab and see if the query string is still in place.

There is one single control where this cannot be applied, because we set the full url of images, this is not going to be in the query string for security reason.