### PR TITLE
chore(js): Storing instances in their init() in a Map object - FRONT-4130

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,9 @@ module.exports = {
   root: true,
   plugins: ['jest'],
   extends: ['airbnb-base', 'prettier'],
+  globals: {
+    ECL: 'writable',
+  },
   env: {
     node: true,
     browser: true,

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -13,13 +13,13 @@
   },
   {
     "path": "dist/packages/ec/scripts/ecl-ec.js",
-    "limit": "210 KB",
+    "limit": "215 KB",
     "webpack": false,
     "gzip": false
   },
   {
     "path": "dist/packages/eu/scripts/ecl-eu.js",
-    "limit": "210 KB",
+    "limit": "215 KB",
     "webpack": false,
     "gzip": false
   },

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -24,6 +24,22 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 ```
 
+Alternatively components can be manually initialised this way:
+
+```js
+var elt = document.querySelector('yourSelector');
+var accordion = new ECL.Accordion(elt);
+accordion.init();
+```
+
+In both cases the instance will be available in the main ECL object, in the components Map, from here an existing instance can be retrieved to further update it, for instance running `destroy()` and `init()` again.
+
+```js
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```
+
 For more details regarding ECL's autoInit method, follow the [package's README.md file](https://github.com/ec-europa/europa-component-library/blob/v3-dev/src/tools/dom-utils/autoinit/README.md).
 
 ## Settings

--- a/src/implementations/vanilla/components/accordion/accordion.js
+++ b/src/implementations/vanilla/components/accordion/accordion.js
@@ -63,6 +63,9 @@ export class Accordion {
    * Initialise component.
    */
   init() {
+    if (!ECL.components) {
+      ECL.components = new Map();
+    }
     this.toggles = queryAll(this.toggleSelector, this.element);
 
     // Get label, if any
@@ -80,6 +83,7 @@ export class Accordion {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -93,6 +97,7 @@ export class Accordion {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/accordion/accordion.js
+++ b/src/implementations/vanilla/components/accordion/accordion.js
@@ -63,9 +63,11 @@ export class Accordion {
    * Initialise component.
    */
   init() {
-    if (!ECL.components) {
-      ECL.components = new Map();
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
     }
+    ECL.components = ECL.components || new Map();
+
     this.toggles = queryAll(this.toggleSelector, this.element);
 
     // Get label, if any

--- a/src/implementations/vanilla/components/breadcrumb-core/breadcrumb-core.js
+++ b/src/implementations/vanilla/components/breadcrumb-core/breadcrumb-core.js
@@ -74,6 +74,11 @@ export class BreadcrumbCore {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.ellipsisButton = queryOne(this.ellipsisButtonSelector, this.element);
 
     // Bind click event on ellipsis
@@ -92,6 +97,7 @@ export class BreadcrumbCore {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -106,6 +112,7 @@ export class BreadcrumbCore {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/breadcrumb-harmonised/breadcrumb-harmonised.js
+++ b/src/implementations/vanilla/components/breadcrumb-harmonised/breadcrumb-harmonised.js
@@ -51,6 +51,11 @@ export class BreadcrumbHarmonised {
   }
 
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.ellipsisButton = queryOne(this.ellipsisButtonSelector, this.element);
 
     // Bind click event on ellipsis
@@ -69,6 +74,7 @@ export class BreadcrumbHarmonised {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   destroy() {
@@ -80,6 +86,7 @@ export class BreadcrumbHarmonised {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/breadcrumb-standardised/breadcrumb-standardised.js
+++ b/src/implementations/vanilla/components/breadcrumb-standardised/breadcrumb-standardised.js
@@ -54,6 +54,11 @@ export class BreadcrumbStandardised {
   }
 
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.ellipsisButton = queryOne(this.ellipsisButtonSelector, this.element);
 
     // Bind click event on ellipsis
@@ -72,6 +77,7 @@ export class BreadcrumbStandardised {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   destroy() {
@@ -83,6 +89,7 @@ export class BreadcrumbStandardised {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/breadcrumb/breadcrumb.js
+++ b/src/implementations/vanilla/components/breadcrumb/breadcrumb.js
@@ -74,6 +74,11 @@ export class Breadcrumb {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.ellipsisButton = queryOne(this.ellipsisButtonSelector, this.element);
 
     // Bind click event on ellipsis
@@ -89,6 +94,9 @@ export class Breadcrumb {
     );
 
     this.check();
+    // Set ecl initialized attribute
+    this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -100,6 +108,10 @@ export class Breadcrumb {
         'click',
         this.handleClickOnEllipsis,
       );
+    }
+    if (this.element) {
+      this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/carousel/carousel.js
+++ b/src/implementations/vanilla/components/carousel/carousel.js
@@ -117,6 +117,11 @@ export class Carousel {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.btnPlay = queryOne(this.playSelector, this.element);
     this.btnPause = queryOne(this.pauseSelector, this.element);
     this.btnPrev = queryOne(this.prevSelector, this.element);
@@ -224,6 +229,8 @@ export class Carousel {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
+
     return this;
   }
 
@@ -278,6 +285,7 @@ export class Carousel {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/category-filter/category-filter.js
+++ b/src/implementations/vanilla/components/category-filter/category-filter.js
@@ -53,6 +53,10 @@ export class CategoryFilter {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Query elementslur
     this.items = queryAll(this.itemSelector, this.element);
 
@@ -65,6 +69,7 @@ export class CategoryFilter {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -78,6 +83,7 @@ export class CategoryFilter {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/content-block/content-block.js
+++ b/src/implementations/vanilla/components/content-block/content-block.js
@@ -60,6 +60,11 @@ export class ContentBlock {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.picture = this.findElementInCommonAncestor(
       this.element,
       this.targetSelector,
@@ -88,6 +93,7 @@ export class ContentBlock {
     }
 
     this.element.setAttribute('data-ecl-auto-initialized', true);
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -147,6 +153,7 @@ export class ContentBlock {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 }

--- a/src/implementations/vanilla/components/datepicker/datepicker.js
+++ b/src/implementations/vanilla/components/datepicker/datepicker.js
@@ -87,6 +87,10 @@ export class Datepicker {
    * Initialise component.
    */
   init() {
+    if (!ECL.components) {
+      ECL.components = new Map();
+    }
+
     this.direction = getComputedStyle(this.element).direction;
 
     this.picker = new Pikaday({
@@ -124,6 +128,7 @@ export class Datepicker {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
 
     return this.picker;
   }
@@ -138,6 +143,7 @@ export class Datepicker {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 }

--- a/src/implementations/vanilla/components/datepicker/datepicker.js
+++ b/src/implementations/vanilla/components/datepicker/datepicker.js
@@ -87,9 +87,10 @@ export class Datepicker {
    * Initialise component.
    */
   init() {
-    if (!ECL.components) {
-      ECL.components = new Map();
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
     }
+    ECL.components = ECL.components || new Map();
 
     this.direction = getComputedStyle(this.element).direction;
 

--- a/src/implementations/vanilla/components/description-list/description-list.js
+++ b/src/implementations/vanilla/components/description-list/description-list.js
@@ -58,6 +58,11 @@ export class DescriptionList {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.moreItemLabel = this.element.getAttribute(this.moreItemLabelSelector);
     this.visibleItems = this.element.getAttribute(this.visibleItemsSelector);
     this.lists = queryAll(this.listsSelector, this.element);
@@ -83,6 +88,7 @@ export class DescriptionList {
 
       // Set ecl initialized attribute
       this.element.setAttribute('data-ecl-auto-initialized', 'true');
+      ECL.components.set(this.element, this);
     }
   }
 
@@ -129,6 +135,7 @@ export class DescriptionList {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/expandable/expandable.js
+++ b/src/implementations/vanilla/components/expandable/expandable.js
@@ -65,6 +65,11 @@ export class Expandable {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.toggle = queryOne(this.toggleSelector, this.element);
 
     // Get target element
@@ -89,6 +94,7 @@ export class Expandable {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -100,6 +106,7 @@ export class Expandable {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/file-upload/file-upload.js
+++ b/src/implementations/vanilla/components/file-upload/file-upload.js
@@ -68,6 +68,11 @@ export class FileUpload {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.fileUploadGroup = this.element.closest(this.groupSelector);
     this.fileUploadInput = this.element;
     this.fileUploadButton = queryOne(this.buttonSelector, this.fileUploadGroup);
@@ -80,6 +85,7 @@ export class FileUpload {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -91,6 +97,7 @@ export class FileUpload {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/file/file.js
+++ b/src/implementations/vanilla/components/file/file.js
@@ -57,6 +57,11 @@ export class FileDownload {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.translationToggle = queryOne(
       this.translationToggleSelector,
       this.element,
@@ -76,6 +81,7 @@ export class FileDownload {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -90,6 +96,7 @@ export class FileDownload {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/gallery/gallery.js
+++ b/src/implementations/vanilla/components/gallery/gallery.js
@@ -154,6 +154,10 @@ export class Gallery {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Query elements
     this.expandable = !this.element.hasAttribute(this.expandableSelector);
     this.visibleItems = this.element.getAttribute(this.itemsLimitSelector);
@@ -288,6 +292,7 @@ export class Gallery {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -338,6 +343,7 @@ export class Gallery {
 
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/inpage-navigation/inpage-navigation.js
+++ b/src/implementations/vanilla/components/inpage-navigation/inpage-navigation.js
@@ -291,6 +291,11 @@ export class InpageNavigation {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     const toggleElement = queryOne(this.toggleSelector, this.element);
     const navLinks = queryAll(this.linksSelector, this.element);
 
@@ -310,6 +315,7 @@ export class InpageNavigation {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -374,6 +380,7 @@ export class InpageNavigation {
 
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 }

--- a/src/implementations/vanilla/components/media-container/media-container.js
+++ b/src/implementations/vanilla/components/media-container/media-container.js
@@ -50,6 +50,10 @@ export class MediaContainer {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Check if a ratio has been set manually
     const media = queryOne('.ecl-media-container__media', this.element);
     if (media && !/ecl-media-container__media--ratio/.test(media.className)) {
@@ -62,6 +66,7 @@ export class MediaContainer {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -70,6 +75,7 @@ export class MediaContainer {
   destroy() {
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/menu/menu.js
+++ b/src/implementations/vanilla/components/menu/menu.js
@@ -147,6 +147,10 @@ export class Menu {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Check display
     this.direction = getComputedStyle(this.element).direction;
 
@@ -303,6 +307,7 @@ export class Menu {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -409,6 +414,7 @@ export class Menu {
 
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/message/message.js
+++ b/src/implementations/vanilla/components/message/message.js
@@ -53,6 +53,11 @@ export class Message {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.close = queryOne(this.closeSelector, this.element);
 
     // Bind click event on close
@@ -62,6 +67,7 @@ export class Message {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -73,6 +79,7 @@ export class Message {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/modal/modal.js
+++ b/src/implementations/vanilla/components/modal/modal.js
@@ -68,6 +68,10 @@ export class Modal {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Bind global events
     if (this.attachKeyListener) {
       document.addEventListener('keyup', this.handleKeyboardGlobal);
@@ -116,6 +120,7 @@ export class Modal {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -137,6 +142,7 @@ export class Modal {
     }
 
     this.element.removeAttribute('data-ecl-auto-initialized');
+    ECL.components.delete(this.element);
   }
 
   /**

--- a/src/implementations/vanilla/components/news-ticker/news-ticker.js
+++ b/src/implementations/vanilla/components/news-ticker/news-ticker.js
@@ -100,6 +100,11 @@ export class NewsTicker {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.btnPlay = queryOne(this.playSelector, this.element);
     this.btnPause = queryOne(this.pauseSelector, this.element);
     this.btnPrev = queryOne(this.prevSelector, this.element);
@@ -168,6 +173,8 @@ export class NewsTicker {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
+
     return this;
   }
 
@@ -214,6 +221,7 @@ export class NewsTicker {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/popover/popover.js
+++ b/src/implementations/vanilla/components/popover/popover.js
@@ -62,6 +62,11 @@ export class Popover {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.toggle = queryOne(this.toggleSelector, this.element);
 
     // Bind global events
@@ -91,6 +96,7 @@ export class Popover {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -110,6 +116,7 @@ export class Popover {
 
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/range/range.js
+++ b/src/implementations/vanilla/components/range/range.js
@@ -57,6 +57,11 @@ export class Range {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.rangeInput = queryOne(this.rangeInputSelector, this.element);
     this.currentValue = queryOne(this.currentValueSelector, this.element);
 
@@ -72,6 +77,7 @@ export class Range {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -83,6 +89,7 @@ export class Range {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/select/select.js
+++ b/src/implementations/vanilla/components/select/select.js
@@ -242,6 +242,11 @@ export class Select {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.select = this.element;
     const containerClasses = Array.from(this.select.parentElement.classList);
     this.textDefault =
@@ -459,6 +464,7 @@ export class Select {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -511,7 +517,16 @@ export class Select {
 
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
+  }
+
+  /**
+   * Update instance.
+   */
+  update() {
+    this.updateCurrentValue();
+    this.updateSelectionsCount();
   }
 
   /**

--- a/src/implementations/vanilla/components/site-header-core/site-header-core.js
+++ b/src/implementations/vanilla/components/site-header-core/site-header-core.js
@@ -80,6 +80,10 @@ export class SiteHeaderCore {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Language list management
     this.languageSelector = queryOne(this.languageLinkSelector);
     this.languageListOverlay = queryOne(this.languageListOverlaySelector);
@@ -115,6 +119,7 @@ export class SiteHeaderCore {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -142,6 +147,7 @@ export class SiteHeaderCore {
 
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/site-header-harmonised/site-header-harmonised.js
+++ b/src/implementations/vanilla/components/site-header-harmonised/site-header-harmonised.js
@@ -80,6 +80,10 @@ export class SiteHeaderHarmonised {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Language list management
     this.languageSelector = queryOne(this.languageLinkSelector);
     this.languageListOverlay = queryOne(this.languageListOverlaySelector);
@@ -115,6 +119,7 @@ export class SiteHeaderHarmonised {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -141,6 +146,7 @@ export class SiteHeaderHarmonised {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/site-header-standardised/site-header-standardised.js
+++ b/src/implementations/vanilla/components/site-header-standardised/site-header-standardised.js
@@ -83,6 +83,10 @@ export class SiteHeaderStandardised {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Language list management
     this.languageSelector = queryOne(this.languageLinkSelector);
     this.languageListOverlay = queryOne(this.languageListOverlaySelector);
@@ -118,6 +122,7 @@ export class SiteHeaderStandardised {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -145,6 +150,7 @@ export class SiteHeaderStandardised {
 
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/site-header/site-header.js
+++ b/src/implementations/vanilla/components/site-header/site-header.js
@@ -105,6 +105,10 @@ export class SiteHeader {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Bind global events
     if (this.attachKeyListener) {
       document.addEventListener('keyup', this.handleKeyboardGlobal);
@@ -163,6 +167,7 @@ export class SiteHeader {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -209,6 +214,7 @@ export class SiteHeader {
 
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/table/table.js
+++ b/src/implementations/vanilla/components/table/table.js
@@ -71,6 +71,11 @@ export class Table {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.sortHeadings = queryAll(this.sortSelector, this.element);
     // Add sort arrows and bind click event on toggles.
     if (this.sortHeadings) {
@@ -92,6 +97,7 @@ export class Table {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -105,6 +111,7 @@ export class Table {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/tabs/tabs.js
+++ b/src/implementations/vanilla/components/tabs/tabs.js
@@ -98,6 +98,11 @@ export class Tabs {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
+
     this.list = queryOne(this.listSelector, this.element);
     this.listItems = queryAll(this.listItemsSelector, this.element);
     this.moreItem = queryOne(this.moreItemSelector, this.element);
@@ -153,6 +158,7 @@ export class Tabs {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -185,6 +191,7 @@ export class Tabs {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/implementations/vanilla/components/timeline/timeline.js
+++ b/src/implementations/vanilla/components/timeline/timeline.js
@@ -63,6 +63,10 @@ export class Timeline {
    * Initialise component.
    */
   init() {
+    if (!ECL) {
+      throw new TypeError('Called init but ECL is not present');
+    }
+    ECL.components = ECL.components || new Map();
     // Query elements
     this.button = queryOne(this.buttonSelector, this.element);
 
@@ -76,6 +80,7 @@ export class Timeline {
 
     // Set ecl initialized attribute
     this.element.setAttribute('data-ecl-auto-initialized', 'true');
+    ECL.components.set(this.element, this);
   }
 
   /**
@@ -87,6 +92,7 @@ export class Timeline {
     }
     if (this.element) {
       this.element.removeAttribute('data-ecl-auto-initialized');
+      ECL.components.delete(this.element);
     }
   }
 

--- a/src/tools/dom-utils/autoinit/index.js
+++ b/src/tools/dom-utils/autoinit/index.js
@@ -5,12 +5,6 @@ export const autoInit = ({ root = document, ...options } = {}) => {
     throw new TypeError('Called autoInit but ECL is not present');
   }
 
-  const components = [];
-
-  if (!ECL.components) {
-    ECL.components = [];
-  }
-
   const nodes = queryAll('[data-ecl-auto-init]', root);
 
   const init = () => {
@@ -40,22 +34,19 @@ export const autoInit = ({ root = document, ...options } = {}) => {
           );
         }
 
-        const component = ctor.autoInit(node, options);
-
-        ECL.components.push(component);
-        components.push(component);
+        ctor.autoInit(node, options);
       });
   };
 
   // Destroy should not throw, in order to be non-blocking.
   const destroy = () => {
     if (ECL.components) {
-      for (let i = ECL.components.length - 1; i >= 0; i -= 1) {
-        if (ECL.components[i].destroy) {
-          ECL.components[i].destroy();
-          ECL.components.splice(i, 1);
+      ECL.components.forEach((component, node) => {
+        if (component.destroy) {
+          component.destroy();
+          ECL.components.delete(node);
         }
-      }
+      });
     }
   };
 
@@ -63,7 +54,7 @@ export const autoInit = ({ root = document, ...options } = {}) => {
 
   init();
 
-  return { update, destroy, components };
+  return { update, destroy };
 };
 
 export default autoInit;

--- a/src/website/src/pages/ec/components/accordion/docs/api.mdx
+++ b/src/website/src/pages/ec/components/accordion/docs/api.mdx
@@ -36,3 +36,19 @@ var elt = document.querySelector('[data-ecl-accordion]');
 var accordion = new ECL.Accordion(elt);
 accordion.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/accordion/docs/api.mdx
+++ b/src/website/src/pages/ec/components/accordion/docs/api.mdx
@@ -42,13 +42,13 @@ accordion.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-accordion]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/carousel/docs/api.mdx
+++ b/src/website/src/pages/ec/components/carousel/docs/api.mdx
@@ -36,3 +36,19 @@ var elt = document.querySelector('[data-ecl-carousel]');
 var carousel = new ECL.Carousel(elt);
 carousel.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/carousel/docs/api.mdx
+++ b/src/website/src/pages/ec/components/carousel/docs/api.mdx
@@ -42,13 +42,13 @@ carousel.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-carousel]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/category-filter/docs/api.mdx
+++ b/src/website/src/pages/ec/components/category-filter/docs/api.mdx
@@ -40,3 +40,19 @@ var elt = document.querySelector('[data-ecl-category-filter]');
 var categoryFilter = new ECL.CategoryFilter(elt);
 categoryFilter.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/category-filter/docs/api.mdx
+++ b/src/website/src/pages/ec/components/category-filter/docs/api.mdx
@@ -46,13 +46,13 @@ categoryFilter.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-category-filter]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/expandable/docs/api.mdx
+++ b/src/website/src/pages/ec/components/expandable/docs/api.mdx
@@ -42,13 +42,13 @@ expandable.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-expandable]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/expandable/docs/api.mdx
+++ b/src/website/src/pages/ec/components/expandable/docs/api.mdx
@@ -36,3 +36,19 @@ var elt = document.querySelector('[data-ecl-expandable]');
 var expandable = new ECL.Expandable(elt);
 expandable.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/file/docs/api.mdx
+++ b/src/website/src/pages/ec/components/file/docs/api.mdx
@@ -40,13 +40,13 @@ file.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-file]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/file/docs/api.mdx
+++ b/src/website/src/pages/ec/components/file/docs/api.mdx
@@ -34,3 +34,19 @@ var elt = document.querySelector('[data-ecl-file]');
 var file = new ECL.FileDownload(elt);
 file.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/media/gallery/docs/api.mdx
+++ b/src/website/src/pages/ec/components/media/gallery/docs/api.mdx
@@ -37,3 +37,19 @@ var gallery = new ECL.Gallery(elt);
 gallery.init();
 `
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/media/gallery/docs/api.mdx
+++ b/src/website/src/pages/ec/components/media/gallery/docs/api.mdx
@@ -43,13 +43,13 @@ gallery.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-gallery]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/message/docs/api.mdx
+++ b/src/website/src/pages/ec/components/message/docs/api.mdx
@@ -47,13 +47,13 @@ message.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-message]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/message/docs/api.mdx
+++ b/src/website/src/pages/ec/components/message/docs/api.mdx
@@ -41,3 +41,19 @@ var elt = document.querySelector('[data-ecl-message]');
 var message = new ECL.Message(elt);
 message.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/modal/docs/api.mdx
+++ b/src/website/src/pages/ec/components/modal/docs/api.mdx
@@ -34,3 +34,19 @@ var elt = document.querySelector('[data-ecl-modal]');
 var modal = new ECL.Modal(elt);
 modal.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/modal/docs/api.mdx
+++ b/src/website/src/pages/ec/components/modal/docs/api.mdx
@@ -40,13 +40,13 @@ modal.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-modal]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/news-ticker/docs/api.mdx
+++ b/src/website/src/pages/ec/components/news-ticker/docs/api.mdx
@@ -40,3 +40,19 @@ var elt = document.querySelector('[data-ecl-news-ticker]');
 var newsTicker = new ECL.NewsTicker(elt);
 newsTicker.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/news-ticker/docs/api.mdx
+++ b/src/website/src/pages/ec/components/news-ticker/docs/api.mdx
@@ -46,13 +46,13 @@ newsTicker.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-news-ticker]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/popover/docs/api.mdx
+++ b/src/website/src/pages/ec/components/popover/docs/api.mdx
@@ -34,3 +34,19 @@ var elt = document.querySelector('[data-ecl-popover]');
 var popover = new ECL.Popover(elt);
 popover.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/popover/docs/api.mdx
+++ b/src/website/src/pages/ec/components/popover/docs/api.mdx
@@ -40,13 +40,13 @@ popover.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-popover]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/table/docs/api.mdx
+++ b/src/website/src/pages/ec/components/table/docs/api.mdx
@@ -44,13 +44,13 @@ table.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-table]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/ec/components/table/docs/api.mdx
+++ b/src/website/src/pages/ec/components/table/docs/api.mdx
@@ -38,3 +38,19 @@ var elt = document.querySelector('[data-ecl-table]');
 var table = new ECL.Table(elt);
 table.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/timeline/docs/api.mdx
+++ b/src/website/src/pages/ec/components/timeline/docs/api.mdx
@@ -36,3 +36,19 @@ var elt = document.querySelector('[data-ecl-timeline]');
 var timeline = new ECL.Timeline(elt);
 timeline.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/ec/components/timeline/docs/api.mdx
+++ b/src/website/src/pages/ec/components/timeline/docs/api.mdx
@@ -42,13 +42,13 @@ timeline.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-timeline]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/accordion/docs/api.mdx
+++ b/src/website/src/pages/eu/components/accordion/docs/api.mdx
@@ -36,3 +36,19 @@ var elt = document.querySelector('[data-ecl-accordion]');
 var accordion = new ECL.Accordion(elt);
 accordion.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/accordion/docs/api.mdx
+++ b/src/website/src/pages/eu/components/accordion/docs/api.mdx
@@ -42,13 +42,13 @@ accordion.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-accordion]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/carousel/docs/api.mdx
+++ b/src/website/src/pages/eu/components/carousel/docs/api.mdx
@@ -36,3 +36,19 @@ var elt = document.querySelector('[data-ecl-carousel]');
 var carousel = new ECL.Carousel(elt);
 carousel.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/carousel/docs/api.mdx
+++ b/src/website/src/pages/eu/components/carousel/docs/api.mdx
@@ -42,13 +42,13 @@ carousel.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-carousel]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/category-filter/docs/api.mdx
+++ b/src/website/src/pages/eu/components/category-filter/docs/api.mdx
@@ -40,3 +40,19 @@ var elt = document.querySelector('[data-ecl-category-filter]');
 var categoryFilter = new ECL.CategoryFilter(elt);
 categoryFilter.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/category-filter/docs/api.mdx
+++ b/src/website/src/pages/eu/components/category-filter/docs/api.mdx
@@ -46,13 +46,13 @@ categoryFilter.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-category-filter]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/expandable/docs/api.mdx
+++ b/src/website/src/pages/eu/components/expandable/docs/api.mdx
@@ -42,13 +42,13 @@ expandable.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-expandable]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/expandable/docs/api.mdx
+++ b/src/website/src/pages/eu/components/expandable/docs/api.mdx
@@ -36,3 +36,19 @@ var elt = document.querySelector('[data-ecl-expandable]');
 var expandable = new ECL.Expandable(elt);
 expandable.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/file/docs/api.mdx
+++ b/src/website/src/pages/eu/components/file/docs/api.mdx
@@ -40,13 +40,13 @@ file.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-file]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/file/docs/api.mdx
+++ b/src/website/src/pages/eu/components/file/docs/api.mdx
@@ -34,3 +34,19 @@ var elt = document.querySelector('[data-ecl-file]');
 var file = new ECL.FileDownload(elt);
 file.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/media/gallery/docs/api.mdx
+++ b/src/website/src/pages/eu/components/media/gallery/docs/api.mdx
@@ -37,3 +37,19 @@ var gallery = new ECL.Gallery(elt);
 gallery.init();
 `
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/media/gallery/docs/api.mdx
+++ b/src/website/src/pages/eu/components/media/gallery/docs/api.mdx
@@ -43,13 +43,13 @@ gallery.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-gallery]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/message/docs/api.mdx
+++ b/src/website/src/pages/eu/components/message/docs/api.mdx
@@ -47,13 +47,13 @@ message.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-message]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/message/docs/api.mdx
+++ b/src/website/src/pages/eu/components/message/docs/api.mdx
@@ -41,3 +41,19 @@ var elt = document.querySelector('[data-ecl-message]');
 var message = new ECL.Message(elt);
 message.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/modal/docs/api.mdx
+++ b/src/website/src/pages/eu/components/modal/docs/api.mdx
@@ -34,3 +34,19 @@ var elt = document.querySelector('[data-ecl-modal]');
 var modal = new ECL.Modal(elt);
 modal.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run destroy() and init() on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/modal/docs/api.mdx
+++ b/src/website/src/pages/eu/components/modal/docs/api.mdx
@@ -40,13 +40,13 @@ modal.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-modal]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run destroy() and init() on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/news-ticker/docs/api.mdx
+++ b/src/website/src/pages/eu/components/news-ticker/docs/api.mdx
@@ -40,3 +40,19 @@ var elt = document.querySelector('[data-ecl-news-ticker]');
 var newsTicker = new ECL.NewsTicker(elt);
 newsTicker.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/news-ticker/docs/api.mdx
+++ b/src/website/src/pages/eu/components/news-ticker/docs/api.mdx
@@ -46,13 +46,13 @@ newsTicker.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-news-ticker]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/popover/docs/api.mdx
+++ b/src/website/src/pages/eu/components/popover/docs/api.mdx
@@ -34,3 +34,19 @@ var elt = document.querySelector('[data-ecl-popover]');
 var popover = new ECL.Popover(elt);
 popover.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/popover/docs/api.mdx
+++ b/src/website/src/pages/eu/components/popover/docs/api.mdx
@@ -40,13 +40,13 @@ popover.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-popover]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/table/docs/api.mdx
+++ b/src/website/src/pages/eu/components/table/docs/api.mdx
@@ -44,13 +44,13 @@ table.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-table]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```

--- a/src/website/src/pages/eu/components/table/docs/api.mdx
+++ b/src/website/src/pages/eu/components/table/docs/api.mdx
@@ -38,3 +38,19 @@ var elt = document.querySelector('[data-ecl-table]');
 var table = new ECL.Table(elt);
 table.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/timeline/docs/api.mdx
+++ b/src/website/src/pages/eu/components/timeline/docs/api.mdx
@@ -36,3 +36,19 @@ var elt = document.querySelector('[data-ecl-timeline]');
 var timeline = new ECL.Timeline(elt);
 timeline.init();
 ```
+
+### Retrieve an existing instance
+
+If an existing instance needs to be updated, it can be retrieved this way:
+
+```js
+var instance = ECL.components.get('yourElement');
+```
+
+To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
+
+```
+var instance = ECL.components.get('yourElement');
+instance.destroy();
+instance.init();
+```

--- a/src/website/src/pages/eu/components/timeline/docs/api.mdx
+++ b/src/website/src/pages/eu/components/timeline/docs/api.mdx
@@ -42,13 +42,13 @@ timeline.init();
 If an existing instance needs to be updated, it can be retrieved this way:
 
 ```js
-var instance = ECL.components.get('yourElement');
+var elt = document.querySelector('[data-ecl-timeline]');
+var instance = ECL.components.get(elt);
 ```
 
 To update an existing instance, you can run `destroy()` and `init()` on this instance, like this:
 
 ```
-var instance = ECL.components.get('yourElement');
 instance.destroy();
 instance.init();
 ```


### PR DESCRIPTION
Pretty straightforward:

- we are storing now the instances in a Map object that gives us an easier way to retrieve them
- the way the ECL.components Map is populated has changed, instead of being an operation performed by the autoInit() module it is delegated to the single component classes, so that it works both when using autoInit() and when instantiating manually
- An update method has been added in the select js, once the instance is retrieved this can be used instead of destroying and re-initing again.

To test this you can retrieve an instance in the console and then destroy it.
For instance in the accordion story it would be:
`const accordion = document.querySelector('.ecl-accordion'); const instance = ECL.components.get(accordion); instance.destroy(); `
The result should be a "broken" accordion :)