### PR TITLE
fix(clickable-images): Limiting the number of iterations, adding card expection - FRONT-4267

### DIFF
--- a/src/implementations/vanilla/components/content-block/content-block.js
+++ b/src/implementations/vanilla/components/content-block/content-block.js
@@ -30,7 +30,7 @@ export class ContentBlock {
       targetSelector = '[data-ecl-picture-link]',
       titleSelector = '[data-ecl-title-link]',
       attachClickListener = true,
-      maxIterations = 2,
+      maxIterations = 1,
       withTitleAttr = false,
     } = {},
   ) {
@@ -116,6 +116,10 @@ export class ContentBlock {
     const eureka = queryOne(selector, element);
     if (eureka) {
       return eureka;
+    }
+
+    if (element.classList.contains('ecl-card__body')) {
+      maxIterations += 1;
     }
 
     if (element === document.documentElement || maxIterations <= 0) {


### PR DESCRIPTION
Eh, we knew that traversing the dom could have been tricky, indeed with the number of iterations needed to find the picture from the content-block in the card, we were breaking all the cases with multiple content-items, for instance.
Now we reduced this number to 1 (meaning two iterations) and we apply an exception for the card, where we actually need another iteration.
I do no like it, but like this might be safe enough, while before it was not.