### PR TITLE
fix(blockquote): fix blockquote in wysiwyg - FRONT-4307

### DIFF
--- a/src/implementations/twig/utilities/html-tag/index.story.js
+++ b/src/implementations/twig/utilities/html-tag/index.story.js
@@ -73,7 +73,7 @@ export const Default = () => `
     <br />
     <div class="ecl">
       <blockquote>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed efficitur vulputate venenatis.
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed efficitur vulputate venenatis.</p>
         <cite>Someone</cite>
       </blockquote>
     </div>

--- a/src/implementations/vanilla/components/blockquote/blockquote.scss
+++ b/src/implementations/vanilla/components/blockquote/blockquote.scss
@@ -23,7 +23,7 @@ $blockquote: null !default;
 }
 
 .ecl-blockquote__citation,
-%ecl-blockquote {
+%ecl-blockquote__citation {
   color: map.get($blockquote, 'quote', 'color');
   font: map.get($blockquote, 'quote', 'font');
   margin: 0;
@@ -120,13 +120,16 @@ $blockquote: null !default;
 
 /* stylelint-disable-next-line order/order */
 @include breakpoints.up('l') {
+  .ecl-blockquote {
+    flex-direction: row;
+  }
+
   .ecl-blockquote,
   %ecl-blockquote {
     border-inline-start: map.get($blockquote, 'border-width') solid
       map.get($blockquote, 'border-color');
     border-radius: map.get($blockquote, 'border-radius');
     box-shadow: map.get($blockquote, 'shadow');
-    flex-direction: row;
     justify-content: flex-start;
     padding: map.get($blockquote, 'padding');
   }

--- a/src/presets/ec/src/ec-default.scss
+++ b/src/presets/ec/src/ec-default.scss
@@ -169,6 +169,17 @@
 .ecl blockquote:not([class*='ecl-'], [class*='wt-']),
 .ecl blockquote:is([class*='ecl-u-']) {
   @extend %ecl-blockquote;
+}
+
+.ecl blockquote p:not([class*='ecl-'], [class*='wt-']),
+.ecl blockquote p:is([class*='ecl-u-']) {
+  @extend %ecl-blockquote__citation;
+
+  margin-top: map.get(var.$blockquote, 'author', 'margin');
+
+  &:first-of-type {
+    margin-top: 0;
+  }
 
   &::before,
   &::after {

--- a/src/presets/ec/src/ec-default.scss
+++ b/src/presets/ec/src/ec-default.scss
@@ -175,7 +175,7 @@
 .ecl blockquote p:is([class*='ecl-u-']) {
   @extend %ecl-blockquote__citation;
 
-  margin-top: map.get(var.$blockquote, 'author', 'margin');
+  margin-top: var(--s-m);
 
   &:first-of-type {
     margin-top: 0;

--- a/src/presets/eu/src/eu-default.scss
+++ b/src/presets/eu/src/eu-default.scss
@@ -169,6 +169,11 @@
 .ecl blockquote:not([class*='ecl-'], [class*='wt-']),
 .ecl blockquote:is([class*='ecl-u-']) {
   @extend %ecl-blockquote;
+}
+
+.ecl blockquote p:not([class*='ecl-'], [class*='wt-']),
+.ecl blockquote p:is([class*='ecl-u-']) {
+  @extend %ecl-blockquote__citation;
 
   &::before,
   &::after {

--- a/src/presets/eu/src/eu-default.scss
+++ b/src/presets/eu/src/eu-default.scss
@@ -175,6 +175,12 @@
 .ecl blockquote p:is([class*='ecl-u-']) {
   @extend %ecl-blockquote__citation;
 
+  margin-top: map.get(var.$blockquote, 'author', 'margin');
+
+  &:first-of-type {
+    margin-top: 0;
+  }
+
   &::before,
   &::after {
     display: none;

--- a/src/presets/eu/src/eu-default.scss
+++ b/src/presets/eu/src/eu-default.scss
@@ -175,7 +175,7 @@
 .ecl blockquote p:is([class*='ecl-u-']) {
   @extend %ecl-blockquote__citation;
 
-  margin-top: map.get(var.$blockquote, 'author', 'margin');
+  margin-top: var(--s-m);
 
   &:first-of-type {
     margin-top: 0;


### PR DESCRIPTION
- fix display of the blockquote in ECL4; it was wrongly displayed horizontally and the font was not correct