### PR TITLE
feat(navigation-list): remove background when there is no border - FRONT-4309

### DIFF
--- a/src/implementations/vanilla/components/navigation-list/navigation-list.scss
+++ b/src/implementations/vanilla/components/navigation-list/navigation-list.scss
@@ -63,6 +63,7 @@ $navigation-list: null !default;
 
 // No border
 .ecl-navigation-list__item--no-border {
+  background-color: transparent;
   border-radius: 0;
   border-width: 0;
   box-shadow: none;

--- a/src/implementations/vanilla/components/navigation-list/navigation-list.scss
+++ b/src/implementations/vanilla/components/navigation-list/navigation-list.scss
@@ -68,10 +68,6 @@ $navigation-list: null !default;
   border-width: 0;
   box-shadow: none;
 
-  .ecl-navigation-list__image {
-    border: 1px solid map.get($navigation-list, 'image-border-color');
-  }
-
   .ecl-navigation-list__content-block {
     padding-inline-start: 0;
     padding-inline-end: 0;


### PR DESCRIPTION
- set the background to transparent when using the no-border variant
- remove border on navigation list image