### PR TITLE
feat(forms): add icon title for error message - FRONT-4330

### DIFF
--- a/src/implementations/twig/components/checkbox/__snapshots__/checkbox.test.js.snap
+++ b/src/implementations/twig/components/checkbox/__snapshots__/checkbox.test.js.snap
@@ -805,10 +805,14 @@ exports[`Checkbox Default single checkbox renders correctly when invalid 1`] = `
     class="ecl-feedback-message"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden="false"
       class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
       focusable="false"
+      role="img"
     >
+      <title>
+        Error
+      </title>
       <use
         xlink:href="/icons.svg#error"
       />

--- a/src/implementations/twig/components/checkbox/checkbox-group.html.twig
+++ b/src/implementations/twig/components/checkbox/checkbox-group.html.twig
@@ -6,6 +6,7 @@
   - "name" (string) (default: '')
   - "invalid" (boolean) (default: false)
   - "invalid_icon" (object of type "icon") (default: {})
+  - "sr_invalid_icon" (string) (default: ''): additional label for the invalid icon; for screen readers
   - "item_required_text" (string) (default: *)
   - "required" (boolean) (default: false)
   - "extra_classes" (optional) (string) (default: '')
@@ -22,6 +23,7 @@
 {% set _name = name|default('') %}
 {% set _invalid = invalid|default(false) %}
 {% set _invalid_icon = invalid_icon|default({}) %}
+{% set _sr_invalid_icon = sr_invalid_icon|default('') %}
 {% set _required = required|default(false) %}
 {% set _invalid_text = invalid_text|default('') %}
 {% set _extra_attributes = extra_attributes|default([{}]) %}
@@ -37,6 +39,10 @@
   {% if _invalid_icon is not empty and _invalid_text is not empty %}
     {% include '@ecl/icon/icon.html.twig' with {
       icon: _invalid_icon,
+      as_image: true,
+      extra_accessibility: not _sr_invalid_icon ? {} : {
+        title: _sr_invalid_icon,
+      },
       extra_classes: 'ecl-feedback-message__icon',
     } only %}
   {% endif %}

--- a/src/implementations/twig/components/form-group/__snapshots__/form-group.test.js.snap
+++ b/src/implementations/twig/components/form-group/__snapshots__/form-group.test.js.snap
@@ -354,10 +354,14 @@ exports[`Form group  with Checkbox renders correctly when invalid 1`] = `
       id="checkbox-default-invalid"
     >
       <svg
-        aria-hidden="true"
+        aria-hidden="false"
         class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
         focusable="false"
+        role="img"
       >
+        <title>
+          Error
+        </title>
         <use
           xlink:href="/icons.svg#error"
         />
@@ -1066,10 +1070,14 @@ exports[`Form group  with Datepicker renders correctly when invalid 1`] = `
       id="example-input-id-1-invalid"
     >
       <svg
-        aria-hidden="true"
+        aria-hidden="false"
         class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
         focusable="false"
+        role="img"
       >
+        <title>
+          Error
+        </title>
         <use
           xlink:href="/icons.svg#error"
         />
@@ -1455,10 +1463,14 @@ exports[`Form group  with File Upload renders correctly when invalid 1`] = `
       id="example-input-id-1-invalid"
     >
       <svg
-        aria-hidden="true"
+        aria-hidden="false"
         class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
         focusable="false"
+        role="img"
       >
+        <title>
+          Error
+        </title>
         <use
           xlink:href="/icons.svg#error"
         />
@@ -2133,10 +2145,14 @@ exports[`Form group  with Radio renders correctly when invalid 1`] = `
       id="radio-default-invalid"
     >
       <svg
-        aria-hidden="true"
+        aria-hidden="false"
         class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
         focusable="false"
+        role="img"
       >
+        <title>
+          Error
+        </title>
         <use
           xlink:href="/icons.svg#error"
         />
@@ -2758,10 +2774,14 @@ exports[`Form group  with Range field renders correctly when invalid 1`] = `
       id="example-range-id-invalid"
     >
       <svg
-        aria-hidden="true"
+        aria-hidden="false"
         class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
         focusable="false"
+        role="img"
       >
+        <title>
+          Error
+        </title>
         <use
           xlink:href="/icons.svg#error"
         />
@@ -3571,10 +3591,14 @@ exports[`Form group  with Rating field renders correctly when invalid 1`] = `
       id="rating-field-invalid"
     >
       <svg
-        aria-hidden="true"
+        aria-hidden="false"
         class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
         focusable="false"
+        role="img"
       >
+        <title>
+          Error
+        </title>
         <use
           xlink:href="/icons.svg#error"
         />
@@ -4659,10 +4683,14 @@ exports[`Form group  with Select renders correctly when invalid 1`] = `
       id="select-default-invalid"
     >
       <svg
-        aria-hidden="true"
+        aria-hidden="false"
         class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
         focusable="false"
+        role="img"
       >
+        <title>
+          Error
+        </title>
         <use
           xlink:href="/icons.svg#error"
         />
@@ -5215,10 +5243,14 @@ exports[`Form group  with Text field renders correctly when invalid 1`] = `
       id="example-input-id-1-invalid"
     >
       <svg
-        aria-hidden="true"
+        aria-hidden="false"
         class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
         focusable="false"
+        role="img"
       >
+        <title>
+          Error
+        </title>
         <use
           xlink:href="/icons.svg#error"
         />
@@ -5451,10 +5483,14 @@ exports[`Form group  with Textarea renders correctly when invalid 1`] = `
       id="example-textarea-id-1-invalid"
     >
       <svg
-        aria-hidden="true"
+        aria-hidden="false"
         class="ecl-icon ecl-icon--m ecl-feedback-message__icon"
         focusable="false"
+        role="img"
       >
+        <title>
+          Error
+        </title>
         <use
           xlink:href="/icons.svg#error"
         />

--- a/src/implementations/twig/components/form-group/form-group.html.twig
+++ b/src/implementations/twig/components/form-group/form-group.html.twig
@@ -6,6 +6,7 @@
   - "disabled" (boolean) (default: false)
   - "invalid" (boolean) (default: false)
   - "invalid_icon" (object of type "icon") (default: {})
+  - "sr_invalid_icon" (string) (default: ''): additional label for the invalid icon; for screen readers
   - "required" (boolean) (default: false)
   - "label_aria_required" (string) (default: ''): aria text for the required field label
   - "label_aria_optional" (string) (default: ''): aria text for the optional field label
@@ -32,6 +33,7 @@
 {% set _label_aria_required = label_aria_required|default('') %}
 {% set _label_aria_optional = label_aria_optional|default('') %}
 {% set _invalid_icon = invalid_icon|default({}) %}
+{% set _sr_invalid_icon = sr_invalid_icon|default('') %}
 {% set _helper_text = helper_text|default('') %}
 {% set _invalid_text = invalid_text|default('') %}
 {% set _label_class = 'ecl-form-label' %}
@@ -226,6 +228,7 @@
     {% include '@ecl/checkbox/checkbox-group.html.twig' with _input|merge({
       invalid_text: _invalid_text,
       invalid_icon: _invalid_icon,
+      sr_invalid_icon: _sr_invalid_icon
     }) only %}
   {%- endif -%}
 
@@ -251,6 +254,10 @@
       {%- if _invalid_icon is not empty -%}
       {% include '@ecl/icon/icon.html.twig' with {
         icon: _invalid_icon,
+        as_image: true,
+        extra_accessibility: not _sr_invalid_icon ? {} : {
+          title: _sr_invalid_icon,
+        },
         extra_classes: 'ecl-feedback-message__icon',
       } only %}
       {%- endif -%}

--- a/src/specs/components/checkbox/demo/data.js
+++ b/src/specs/components/checkbox/demo/data.js
@@ -18,6 +18,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   input: {
     id: 'checkbox-default',
     input_type: 'checkbox',
@@ -28,6 +29,7 @@ module.exports = {
       name: 'error',
       size: 'm',
     },
+    sr_invalid_icon: 'Error',
     items: [
       {
         checked: true,

--- a/src/specs/components/datepicker/demo/data.js
+++ b/src/specs/components/datepicker/demo/data.js
@@ -6,6 +6,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   invalid_text: 'This is the error message',
   optional_text: '(optional)',
   required_text: '*',

--- a/src/specs/components/file-upload/demo/data--multiple.js
+++ b/src/specs/components/file-upload/demo/data--multiple.js
@@ -9,6 +9,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   required_text: '*',
   optional_text: '(optional)',
   required: true,

--- a/src/specs/components/file-upload/demo/data.js
+++ b/src/specs/components/file-upload/demo/data.js
@@ -9,6 +9,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   required_text: '*',
   optional_text: '(optional)',
   required: true,

--- a/src/specs/components/radio/demo/data--binary.js
+++ b/src/specs/components/radio/demo/data--binary.js
@@ -14,6 +14,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   input: {
     id: 'radio-default',
     input_type: 'radio',

--- a/src/specs/components/radio/demo/data--default.js
+++ b/src/specs/components/radio/demo/data--default.js
@@ -17,6 +17,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   input: {
     id: 'radio-default',
     input_type: 'radio',

--- a/src/specs/components/range/demo/data.js
+++ b/src/specs/components/range/demo/data.js
@@ -15,6 +15,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   label: 'Range slider',
   helper_text: "This is the input's helper text.",
   optional_text: '(optional)',

--- a/src/specs/components/rating-field/demo/data.js
+++ b/src/specs/components/rating-field/demo/data.js
@@ -12,6 +12,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   input: {
     input_type: 'rating-field',
     id: 'rating-field',

--- a/src/specs/components/select/demo/data-multiple.js
+++ b/src/specs/components/select/demo/data-multiple.js
@@ -8,6 +8,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   required_text: '*',
   optional_text: '(optional)',
   icon_path: '/icons.svg',

--- a/src/specs/components/select/demo/data-single.js
+++ b/src/specs/components/select/demo/data-single.js
@@ -7,6 +7,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   required_text: '*',
   optional_text: '(optional)',
   required: true,

--- a/src/specs/components/text-area/demo/data.js
+++ b/src/specs/components/text-area/demo/data.js
@@ -7,6 +7,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   helper_text: "This is the input's helper text.",
   required: false,
   label_aria_required: 'required',

--- a/src/specs/components/text-input/demo/data.js
+++ b/src/specs/components/text-input/demo/data.js
@@ -7,6 +7,7 @@ module.exports = {
     name: 'error',
     size: 'm',
   },
+  sr_invalid_icon: 'Error',
   helper_text: "This is the input's helper text.",
   optional_text: '(optional)',
   required: false,


### PR DESCRIPTION
- add title to error icon, mostly for screen readers. New twig parameter `sr_invalid_icon` added to the form element data, to set the value