### PR TITLE
fix(modal): remove aria-hidden on the icon - FRONT-4356

### DIFF
--- a/src/implementations/twig/components/modal/__snapshots__/modal.test.js.snap
+++ b/src/implementations/twig/components/modal/__snapshots__/modal.test.js.snap
@@ -20,7 +20,7 @@ exports[`Modal Collapsed information, renders correctly 1`] = `
           class="ecl-modal__header"
         >
           <svg
-            aria-hidden="true"
+            aria-hidden="false"
             class="ecl-icon ecl-icon--l ecl-modal__icon"
             focusable="false"
             role="img"

--- a/src/implementations/twig/components/modal/modal.html.twig
+++ b/src/implementations/twig/components/modal/modal.html.twig
@@ -97,6 +97,7 @@
               name: _header_icon,
               size: 'l',
             },
+            as_image: true,
             extra_accessibility: not _sr_icon ? {} : {
               title: _sr_icon,
             },


### PR DESCRIPTION
- set aria-hidden=false on the icon, to allow screen reader to acess the textual indication