### PR TITLE
feat(gallery): add iframe title for video player - FRONT-4365

### DIFF
--- a/src/implementations/twig/components/gallery/README.md
+++ b/src/implementations/twig/components/gallery/README.md
@@ -27,6 +27,7 @@ npm install --save @ecl/twig-component-gallery
 - **"visible_items"** (integer) (default: 8) Number of visible items in an expandable gallery
 - **"expandable"** (boolean) (default: true) collapsible/expandable gallery
 - **"icon_path"** (string) (default: '') Path to the icon sprite
+- **"sr_video_player"** (string) (default: ''): additional label for the video player; for screen readers
 - **"footer"** (object) (default: {}) Footer link
 - **"view_all_label"** (string) (default: '') Label of the view all button
 - **"view_all_expanded_label"** (string) (default: '') Label when the gallery is expanded
@@ -48,6 +49,7 @@ npm install --save @ecl/twig-component-gallery
   counter_label: 'Media files in this gallery' , 
   visible_items: 6,
   disable_overlay: false,
+  sr_video_player: 'Video player',
   items: [ 
     { 
       picture: {

--- a/src/implementations/twig/components/gallery/__snapshots__/gallery.test.js.snap
+++ b/src/implementations/twig/components/gallery/__snapshots__/gallery.test.js.snap
@@ -6,6 +6,7 @@ exports[`Gallery Default renders correctly 1`] = `
     class="ecl-gallery"
     data-ecl-auto-init="Gallery"
     data-ecl-gallery=""
+    data-ecl-gallery-player-label="Video player"
     data-ecl-gallery-visible-items="8"
   >
     <ul
@@ -761,6 +762,7 @@ exports[`Gallery Default renders correctly with extra attributes 1`] = `
     class="ecl-gallery"
     data-ecl-auto-init="Gallery"
     data-ecl-gallery=""
+    data-ecl-gallery-player-label="Video player"
     data-ecl-gallery-visible-items="8"
     data-test="data-test-value"
     data-test-1="data-test-value-1"
@@ -1518,6 +1520,7 @@ exports[`Gallery Default renders correctly with extra class names 1`] = `
     class="ecl-gallery custom-class custom-class--test"
     data-ecl-auto-init="Gallery"
     data-ecl-gallery=""
+    data-ecl-gallery-player-label="Video player"
     data-ecl-gallery-visible-items="8"
   >
     <ul
@@ -2273,6 +2276,7 @@ exports[`Gallery Default renders correctly with old data 1`] = `
     class="ecl-gallery"
     data-ecl-auto-init="Gallery"
     data-ecl-gallery=""
+    data-ecl-gallery-player-label="Video player"
     data-ecl-gallery-visible-items="8"
   >
     <ul

--- a/src/implementations/twig/components/gallery/gallery.html.twig
+++ b/src/implementations/twig/components/gallery/gallery.html.twig
@@ -16,7 +16,7 @@
     - "counter_separator" (string) (default: '')
     - "full_screen_label" (string) (default: '')
     - "share" (object) (default: {}): object of type link
-  - "footer" (object) (default: {}): object 0f type link
+  - "footer" (object) (default: {}): object of type link
   - "items" (array) (default: [])
     - "description" (string) (default: '')
     - "meta" (string) (default: '')
@@ -26,6 +26,7 @@
     - "embedded_video" (optional) (object) (default: {})
     - "share_path" (optional) (string) (default: '')
   - "icon_path": (string) (default: '')
+  - "sr_video_player" (string) (default: ''): additional label for the video player; for screen readers
   - "selected_item_id" (int) (default: 0)
   - "extra_classes" (optional) (string) (default: '')
   - "extra_attributes" (optional) (array) (default: [])
@@ -52,6 +53,7 @@
 {% set _overlay_class = '' %}
 {% set _overlay_attrs = [] %}
 {% set _full_width = full_width|default(false) %}
+{% set _sr_video_player = sr_video_player|default('') %}
 
 {# Internal logic - Process properties #}
 
@@ -85,7 +87,7 @@
 
 {# Print the result #}
 
-<section class="{{ _css_class }}" {{ _extra_attributes|raw }} data-ecl-gallery>
+<section class="{{ _css_class }}" {{ _extra_attributes|raw }} data-ecl-gallery data-ecl-gallery-player-label="{{ _sr_video_player }}">
   <ul class="ecl-gallery__list">
     {% for _item in _items %}
       {% set _item_class = '' %}

--- a/src/implementations/vanilla/components/gallery/gallery.js
+++ b/src/implementations/vanilla/components/gallery/gallery.js
@@ -21,6 +21,7 @@ import { createFocusTrap } from 'focus-trap';
  * @param {String} options.overlayMetaSelector Selector for gallery overlay meta info element
  * @param {String} options.overlayPreviousSelector Selector for gallery overlay previous link element
  * @param {String} options.overlayNextSelector Selector for gallery overlay next link element
+ * @param {String} options.videoPlayerLabelSelector Selector for video player label
  * @param {Boolean} options.attachClickListener Whether or not to bind click events
  * @param {Boolean} options.attachKeyListener Whether or not to bind keyup events
  */
@@ -66,6 +67,7 @@ export class Gallery {
       overlayMetaSelector = '[data-ecl-gallery-overlay-meta]',
       overlayPreviousSelector = '[data-ecl-gallery-overlay-previous]',
       overlayNextSelector = '[data-ecl-gallery-overlay-next]',
+      videoPlayerLabelSelector = 'data-ecl-gallery-player-label',
       attachClickListener = true,
       attachKeyListener = true,
       attachResizeListener = true,
@@ -107,6 +109,7 @@ export class Gallery {
     this.viewAllLabelSelector = viewAllLabelSelector;
     this.viewAllExpandedLabelSelector = viewAllExpandedLabelSelector;
     this.expandableSelector = expandableSelector;
+    this.videoPlayerLabelSelector = videoPlayerLabelSelector;
 
     // Private variables
     this.galleryItems = null;
@@ -130,6 +133,7 @@ export class Gallery {
     this.focusTrap = null;
     this.isDesktop = false;
     this.resizeTimer = null;
+    this.videoPlayerLabel = null;
     this.visibleItems = 0;
     this.breakpointMd = 768;
     this.breakpointLg = 996;
@@ -174,6 +178,9 @@ export class Gallery {
         this.viewAllLabel;
     }
     this.count = queryOne(this.countSelector, this.element);
+    this.videoPlayerLabel = this.element.getAttribute(
+      this.videoPlayerLabelSelector,
+    );
     // Bind click event on view all (open first item)
     if (this.attachClickListener && this.viewAll) {
       this.viewAll.addEventListener('click', this.handleClickOnViewAll);
@@ -466,6 +473,10 @@ export class Gallery {
       const mediaIframe = document.createElement('iframe');
       mediaIframe.setAttribute('src', embeddedVideo);
       mediaIframe.setAttribute('frameBorder', '0');
+
+      if (this.videoPlayerLabel) {
+        mediaIframe.setAttribute('title', this.videoPlayerLabel);
+      }
 
       if (this.overlayMedia) {
         mediaElement.appendChild(mediaIframe);

--- a/src/specs/components/gallery/demo/data.js
+++ b/src/specs/components/gallery/demo/data.js
@@ -3,6 +3,7 @@ const exampleLink = `${publicUrl}/example`;
 
 module.exports = {
   icon_path: '/icons.svg',
+  sr_video_player: 'Video player',
   items: [
     {
       // Image


### PR DESCRIPTION
- add a title to the video player iframe (for embedded videos). It is done via a new twig parameter `sr_video_player`