### PR TITLE
feat(media-container): add html video title - FRONT-4359

### DIFF
--- a/src/implementations/twig/components/media-container/README.md
+++ b/src/implementations/twig/components/media-container/README.md
@@ -8,6 +8,7 @@ npm install --save @ecl/twig-component-media-container
 
 ### Parameters
 
+- **"title"** (string) (default: ''): Media title; only used for video currently
 - **"description"** (string) (default: '') - A caption to be shown under the media,
 - **"picture"** (associative array) (default: {}): Image for the media container, following ECL Picture structure
 - **"full_width"**: (bool) (default: false) Full width media container (inside the grid container)

--- a/src/implementations/twig/components/media-container/README.md
+++ b/src/implementations/twig/components/media-container/README.md
@@ -8,8 +8,9 @@ npm install --save @ecl/twig-component-media-container
 
 ### Parameters
 
-- **"title"** (string) (default: ''): Media title; only used for video currently
+- **"title"** (string) (default: ''): Media title
 - **"description"** (string) (default: '') - A caption to be shown under the media,
+- **"sr_video_label"** (string) (default: ''): additional label for the video items; for screen readers
 - **"picture"** (associative array) (default: {}): Image for the media container, following ECL Picture structure
 - **"full_width"**: (bool) (default: false) Full width media container (inside the grid container)
 - **"sources"** (array) (default: []) Array of Video sources with this structure:
@@ -39,6 +40,7 @@ npm install --save @ecl/twig-component-media-container
 ```twig
 {% include '@ecl/media-container/media-container.html.twig' with { 
   description: 'A description for this image', 
+  sr_video_label: 'Video',
   extra_classes: 'my-extra-class-1 my-extra-class-2', 
   picture: {
     img: {

--- a/src/implementations/twig/components/media-container/__snapshots__/media-container.test.js.snap
+++ b/src/implementations/twig/components/media-container/__snapshots__/media-container.test.js.snap
@@ -173,7 +173,7 @@ exports[`Media Container video renders correctly 1`] = `
       class="ecl-media-container__figure"
     >
       <video
-        aria-label="Big Buck Bunny video"
+        aria-label="Big Buck Bunny - Video"
         class="ecl-media-container__media"
         controls=""
         poster="https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg"

--- a/src/implementations/twig/components/media-container/__snapshots__/media-container.test.js.snap
+++ b/src/implementations/twig/components/media-container/__snapshots__/media-container.test.js.snap
@@ -173,6 +173,7 @@ exports[`Media Container video renders correctly 1`] = `
       class="ecl-media-container__figure"
     >
       <video
+        aria-label="Big Buck Bunny video"
         class="ecl-media-container__media"
         controls=""
         poster="https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg"

--- a/src/implementations/twig/components/media-container/media-container.html.twig
+++ b/src/implementations/twig/components/media-container/media-container.html.twig
@@ -20,6 +20,7 @@
       ...
     ],
   - "image" (string) (default: ''): Image to be used as the video placeholder 
+  - "title" (string) (default: ''): Media title; only used for video currently
   - "description" (string) (default: ''),
   - "ratio" (string) ('')
   - "expandable" (associative array) (default: {}): Optional expandable block, following ECL Expandable structure
@@ -45,6 +46,7 @@
 {% set _image = image|default('') %}
 {% set _full_width = full_width|default(false) %}
 {% set _description = description|default('') %}
+{% set _title = title|default('') %}
 {% set _embedded_media = embedded_media|default('') %}
 {% set _picture = picture|default({}) %}
 {% set _extra_attributes = embedded_media ? [
@@ -111,6 +113,9 @@
       class="ecl-media-container__media"
       controls
       poster="{{ _image }}"
+      {%- if _title is not empty -%}
+        aria-label="{{ _title }}"
+      {%- endif -%}
     >
   {% for source in _sources %}
     <source type="{{ source.type }}" src="{{ source.src }}" />

--- a/src/implementations/twig/components/media-container/media-container.html.twig
+++ b/src/implementations/twig/components/media-container/media-container.html.twig
@@ -20,8 +20,9 @@
       ...
     ],
   - "image" (string) (default: ''): Image to be used as the video placeholder 
-  - "title" (string) (default: ''): Media title; only used for video currently
+  - "title" (string) (default: ''): Media title
   - "description" (string) (default: ''),
+  - "sr_video_label" (string) (default: ''): additional label for the video items; for screen readers
   - "ratio" (string) ('')
   - "expandable" (associative array) (default: {}): Optional expandable block, following ECL Expandable structure
   - "extra_classes" (string) (default: ''),
@@ -47,6 +48,7 @@
 {% set _full_width = full_width|default(false) %}
 {% set _description = description|default('') %}
 {% set _title = title|default('') %}
+{% set _sr_video_label = sr_video_label|default('') %}
 {% set _embedded_media = embedded_media|default('') %}
 {% set _picture = picture|default({}) %}
 {% set _extra_attributes = embedded_media ? [
@@ -114,7 +116,8 @@
       controls
       poster="{{ _image }}"
       {%- if _title is not empty -%}
-        aria-label="{{ _title }}"
+        {% set _video_title = _title ~ ' - ' ~ _sr_video_label %}
+        aria-label="{{ _video_title }}"
       {%- endif -%}
     >
   {% for source in _sources %}

--- a/src/implementations/vanilla/components/gallery/gallery.js
+++ b/src/implementations/vanilla/components/gallery/gallery.js
@@ -491,6 +491,10 @@ export class Gallery {
       mediaElement.setAttribute('controls', 'controls');
       mediaElement.classList.add('ecl-gallery__slider-video');
 
+      if (this.videoPlayerLabel) {
+        mediaElement.setAttribute('aria-label', this.videoPlayerLabel);
+      }
+
       if (this.overlayMedia) {
         this.overlayMedia.innerHTML = '';
         this.overlayMedia.appendChild(mediaElement);

--- a/src/specs/components/media-container/demo/data--video.js
+++ b/src/specs/components/media-container/demo/data--video.js
@@ -2,7 +2,8 @@ module.exports = {
   image: 'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
   description:
     'The European Commission has put forward ambitious yet realistic proposals for a modern EU budget. It is time for an EU budget that reflects rapid developments in innovation, the economy, the environment and geopolitics, amongst others.',
-  title: 'Big Buck Bunny video',
+  title: 'Big Buck Bunny',
+  sr_video_label: 'Video',
   sources: [
     {
       src: 'https://inno-ecl.s3.amazonaws.com/media/videos/big_buck_bunny.mp4',

--- a/src/specs/components/media-container/demo/data--video.js
+++ b/src/specs/components/media-container/demo/data--video.js
@@ -2,6 +2,7 @@ module.exports = {
   image: 'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
   description:
     'The European Commission has put forward ambitious yet realistic proposals for a modern EU budget. It is time for an EU budget that reflects rapid developments in innovation, the economy, the environment and geopolitics, amongst others.',
+  title: 'Big Buck Bunny video',
   sources: [
     {
       src: 'https://inno-ecl.s3.amazonaws.com/media/videos/big_buck_bunny.mp4',


### PR DESCRIPTION
- add an optional title to HTML5 video. This is done via a new twig parameter `title`
- add textual information when an item is a video (HTML5 video only). Twig parameter `sr_video_label` added to handle this