### PR TITLE
fix(inpage): Renaming selector for active element - FRONT-4386

### DIFF
--- a/src/implementations/vanilla/components/inpage-navigation/inpage-navigation.js
+++ b/src/implementations/vanilla/components/inpage-navigation/inpage-navigation.js
@@ -60,7 +60,7 @@ export class InpageNavigation {
       spyClass = 'ecl-inpage-navigation__item--active',
       spyTrigger = '[data-ecl-inpage-navigation-trigger-current]',
       attachClickListener = true,
-      contentClass = 'ecl-inpage-navigation__heading--active',
+      contentClass = 'inpage-navigation__heading--active',
     } = {},
   ) {
     // Check element


### PR DESCRIPTION
This turn out to be a kind of conflict between the selector added to the active "heading element" and the default css which excludes h2s with a selector starting with ecl. So the fix is only renaming this selector to prevent this exclusion.