### PR TITLE
docs(typography): fix font size information - FRONT-4385

### DIFF
--- a/src/website/src/pages/ec/guidelines/typography/index.mdx
+++ b/src/website/src/pages/ec/guidelines/typography/index.mdx
@@ -130,7 +130,7 @@ Line-length is the number of characters displayed in a single line. Lines that a
 
 |                  | Font size                                    | Line height                          | Font weight   |
 | ---------------- | -------------------------------------------- | ------------------------------------ | ------------- |
-| mobile & desktop | L - 1.125rem - <RemToPixels rem="1.125" />px | L - 2rem - <RemToPixels rem="2" />px | 400 (regular) |
+| mobile & desktop | L - 1.25rem - <RemToPixels rem="1.25" />px | L - 2rem - <RemToPixels rem="2" />px | 400 (regular) |
 
 ### Medium paragraph
 


### PR DESCRIPTION
- fix wrong font size for the lead paragraph (documentation only)