### PR TITLE
fix(tabs): Setting z-index for the dropdown visibility - FRONT-4376

### DIFF
--- a/src/implementations/vanilla/components/tabs/tabs.scss
+++ b/src/implementations/vanilla/components/tabs/tabs.scss
@@ -18,6 +18,7 @@ $button-width: 44px;
   margin: 0 0 var(--s-xl);
   padding: 0;
   position: relative;
+  z-index: map.get($theme, 'z-index', 'dropdown');
 }
 
 .ecl-tabs__container {


### PR DESCRIPTION
This has been tested with:

- accordion
- card
- popover
- gallery
- carousel
- banner
- site-header
- inpage
- page header

There is one "potentially" problematic use case, it's with the inpage navigation that has z-index: 1, in mobile when the inpage is on top it can be covered by the tabs dropdown