### PR TITLE
fix(site-header): fix z-index - FRONT-4443

### DIFF
--- a/src/implementations/vanilla/components/site-header/site-header-ec.scss
+++ b/src/implementations/vanilla/components/site-header/site-header-ec.scss
@@ -317,8 +317,6 @@ $menu-top: calc(44px + 2 * var(--s-xs));
 
 @include breakpoints.up('l') {
   .ecl-site-header {
-    z-index: 3;
-
     .ecl-site-header__cta {
       align-self: center;
       margin: 0;

--- a/src/implementations/vanilla/components/site-header/site-header-eu.scss
+++ b/src/implementations/vanilla/components/site-header/site-header-eu.scss
@@ -232,8 +232,6 @@ $language-list: null !default;
 
 @include breakpoints.up('l') {
   .ecl-site-header {
-    z-index: 2;
-
     .ecl-site-header__cta {
       align-self: center;
       margin: var(--s-xs) 0;


### PR DESCRIPTION
- fix to prevent tabs from going on top of the language switcher