### PR TITLE
fix(mega-menu): fix link not clickable - FRONT-4444

### DIFF
--- a/src/implementations/vanilla/components/mega-menu/mega-menu.js
+++ b/src/implementations/vanilla/components/mega-menu/mega-menu.js
@@ -271,9 +271,10 @@ export class MegaMenu {
           item.hasAttribute('data-ecl-has-children') ||
           item.hasAttribute('data-ecl-has-container')
         ) {
-          // Bind click event on menu items
-          if (this.attachClickListener) {
-            item.addEventListener('click', this.handleClickOnItem);
+          // Bind click event on menu links
+          const link = queryOne(this.linkSelector, item);
+          if (this.attachClickListener && link) {
+            link.addEventListener('click', this.handleClickOnItem);
           }
         }
       });


### PR DESCRIPTION
- Fix an issue where the mega menu was closing when trying to click on "discover more"