### PR TITLE
feat(menu): update focus on mobile - FRONT-4403

### DIFF
--- a/src/implementations/vanilla/components/mega-menu/mega-menu.js
+++ b/src/implementations/vanilla/components/mega-menu/mega-menu.js
@@ -1364,6 +1364,11 @@ export class MegaMenu {
           }
         }
       }
+
+      // Focus on back item
+      if (this.back) {
+        this.back.focus();
+      }
     }
   }
 
@@ -1387,6 +1392,11 @@ export class MegaMenu {
         this.handleSecondPanel(menuItem, 'collapse');
       } else {
         this.handleSecondPanel(menuItem, 'expand');
+      }
+
+      // Focus on back item
+      if (this.back) {
+        this.back.focus();
       }
     }
   }

--- a/src/implementations/vanilla/components/menu/menu.js
+++ b/src/implementations/vanilla/components/menu/menu.js
@@ -1164,13 +1164,9 @@ export class Menu {
     });
     this.checkMegaMenu(menuItem);
 
-    // Focus first item
-    const firstItem = queryOne(
-      '.ecl-menu__subitem:first-of-type .ecl-menu__sublink',
-      menuItem,
-    );
-    if (firstItem) {
-      firstItem.focus();
+    // Focus back item
+    if (this.back) {
+      this.back.focus();
     }
   }
 


### PR DESCRIPTION
- when accessing a sub level, put the focus on the first element (the "back" link), to follow visual order