### PR TITLE
feat(gallery): add "no hover" variant - FRONT-4464

### DIFF
--- a/src/implementations/twig/components/gallery/README.md
+++ b/src/implementations/twig/components/gallery/README.md
@@ -38,6 +38,7 @@ npm install --save @ecl/twig-component-gallery
 - **"view_all_label"** (string) (default: '') Label of the view all button
 - **"view_all_expanded_label"** (string) (default: '') Label when the gallery is expanded
 - **"counter_label"** (string) (default: '') Label of the counter
+- **"disable_hover"** (boolean) (default: false) Disables the title display on hover
 - **"disable_overlay"** (boolean) (default: false) Disables the overlay functionality
 - **"full_width"** (boolean) (default: false) Full width gallery for desktop and tablet viewports
 - **"selected_item_id"** (int) (default: 0)

--- a/src/implementations/twig/components/gallery/gallery.html.twig
+++ b/src/implementations/twig/components/gallery/gallery.html.twig
@@ -12,6 +12,7 @@
   - "expandable": (boolean) (default: true) If false all items will be visible by default
   - "visible_items": (integer) (default: 8)
   - "full_width": (boolean) (default: false)
+  - "disable_hover": (boolean) (default: false)
   - "disable_overlay": (boolean) (default: false)
   - "overlay" (object) (default: {})
     - "close" (object) (default: {}): object of type button
@@ -55,6 +56,7 @@
 {% set _items = items|default([]) %}
 {% set _footer = footer|default({}) %}
 {% set _visible_items = visible_items|default(8) %}
+{% set _disable_hover = disable_hover|default(false) %}
 {% set _disable_overlay = disable_overlay|default(false) %}
 {% set _icon_path = icon_path|default('') %}
 {% set _sr_video_label = sr_video_label|default('') %}
@@ -86,6 +88,10 @@
 
 {% if _full_width %}
   {% set _css_class = _css_class ~ ' ecl-gallery--full-width' %}
+{% endif %}
+
+{% if _disable_hover %}
+  {% set _css_class = _css_class ~ ' ecl-gallery--no-hover' %}
 {% endif %}
 
 {% if not _expandable %}

--- a/src/implementations/twig/components/gallery/gallery.story.js
+++ b/src/implementations/twig/components/gallery/gallery.story.js
@@ -13,6 +13,7 @@ const getArgs = () => ({
   expandable: true,
   full_width: false,
   visible_items: 8,
+  disable_hover: false,
   disable_overlay: false,
 });
 
@@ -67,6 +68,15 @@ const getArgTypes = () => ({
     name: 'full width',
     control: { type: 'boolean' },
     description: 'full width gallery (desktop & tablet)',
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: 'false' },
+    },
+  },
+  disable_hover: {
+    name: 'without title',
+    control: { type: 'boolean' },
+    description: 'disable display of title on mouse hover',
     table: {
       type: { summary: 'boolean' },
       defaultValue: { summary: 'false' },

--- a/src/implementations/vanilla/components/gallery/gallery-print.scss
+++ b/src/implementations/vanilla/components/gallery/gallery-print.scss
@@ -87,6 +87,10 @@ $gallery: null !default;
   position: absolute;
 }
 
+.ecl-gallery--no-hover .ecl-gallery__description {
+  display: none;
+}
+
 .ecl-gallery__description-icon {
   display: none;
 }

--- a/src/implementations/vanilla/components/gallery/gallery.scss
+++ b/src/implementations/vanilla/components/gallery/gallery.scss
@@ -140,14 +140,12 @@ $_description-height-desktop: 108px;
   position: absolute;
 }
 
-.ecl-gallery__item-link:hover,
-.ecl-gallery__item-link:focus-visible {
-  .ecl-gallery__description {
-    display: block;
-  }
-
-  .ecl-gallery__image-icon {
-    display: none;
+.ecl-gallery:not(.ecl-gallery--no-hover) {
+  .ecl-gallery__item-link:hover,
+  .ecl-gallery__item-link:focus-visible {
+    .ecl-gallery__description {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
- add an option to not display the media title on hover. Twig parameter: `disable_hover`