### PR TITLE
feat(custom-properties): Adding custom props for font family, using them in the components - FRONT-4490

### DIFF
--- a/src/implementations/vanilla/components/banner/banner-print.scss
+++ b/src/implementations/vanilla/components/banner/banner-print.scss
@@ -21,7 +21,7 @@ $banner-print: null !default;
 .ecl-banner__title {
   font: map.get($theme, 'font-print', '4xl');
   font-weight: map.get($theme, 'font-weight', 'bold');
-  font-family: #{map.get($theme, 'font-family-print', 'alt')};
+  font-family: var(--ecl-font-family-print-alt);
   margin-bottom: 0;
 }
 

--- a/src/implementations/vanilla/components/date-block/date-block.scss
+++ b/src/implementations/vanilla/components/date-block/date-block.scss
@@ -61,7 +61,7 @@ $date-block: null !default;
 
 .ecl-date-block__day {
   color: map.get($date-block, 'text-color-inverted');
-  font-family: map.get($theme, 'font-family', 'default');
+  font-family: var(--ff-d);
   font-size: map.get($date-block, 'day', 'font-size');
   font-weight: map.get($theme, 'font-weight', 'bold');
   line-height: map.get($date-block, 'day', 'line-height');
@@ -71,7 +71,7 @@ $date-block: null !default;
 
 .ecl-date-block__month {
   color: map.get($date-block, 'text-color-inverted');
-  font-family: map.get($theme, 'font-family', 'default');
+  font-family: var(--ff-d);
   font-size: map.get($date-block, 'month', 'font-size');
   line-height: map.get($date-block, 'month', 'line-height');
   padding: map.get($date-block, 'month', 'padding');
@@ -83,7 +83,7 @@ $date-block: null !default;
 .ecl-date-block__year {
   background-color: map.get($date-block, 'year', 'background-color');
   color: map.get($date-block, 'year', 'text-color');
-  font-family: map.get($theme, 'font-family', 'default');
+  font-family: var(--ff-d);
   font-size: map.get($date-block, 'year', 'font-size');
   font-weight: map.get($date-block, 'year', 'font-weight');
   line-height: map.get($date-block, 'year', 'line-height');

--- a/src/implementations/vanilla/components/expandable/expandable-print.scss
+++ b/src/implementations/vanilla/components/expandable/expandable-print.scss
@@ -18,5 +18,5 @@ $theme: null !default;
 
 .ecl-expandable__content {
   display: block;
-  font-family: #{map.get($theme, 'font-family-print', 'default')};
+  font-family: var(--ecl-font-family-print-default);
 }

--- a/src/implementations/vanilla/components/expandable/expandable.scss
+++ b/src/implementations/vanilla/components/expandable/expandable.scss
@@ -27,7 +27,7 @@ $expandable: null !default;
 
 .ecl-expandable__content {
   color: map.get($expandable, 'content-color');
-  font-family: #{map.get($theme, 'font-family', 'default')};
+  font-family: var(--ff-d);
   margin-top: map.get($expandable, 'content-margin');
   padding-inline-start: map.get($expandable, 'content-padding');
 

--- a/src/implementations/vanilla/components/fact-figures/fact-figures-print.scss
+++ b/src/implementations/vanilla/components/fact-figures/fact-figures-print.scss
@@ -30,14 +30,14 @@ $fact-figures: null !default;
 
 .ecl-fact-figures__value {
   font: map.get($theme, 'font-print', '4xl');
-  font-family: #{map.get($theme, 'font-family-print', 'alt')};
+  font-family: var(--ecl-font-family-print-alt);
   font-weight: map.get($theme, 'font-weight', 'bold');
 }
 
 .ecl-fact-figures__title {
   clear: left;
   font: map.get($theme, 'font-prolonged-print', 'l');
-  font-family: #{map.get($theme, 'font-family-print', 'alt')};
+  font-family: var(--ecl-font-family-print-alt);
   font-weight: map.get($theme, 'font-weight', 'bold');
   margin-top: map.get($theme, 'spacing-print', 'xs');
 }

--- a/src/implementations/vanilla/components/file/file-print.scss
+++ b/src/implementations/vanilla/components/file/file-print.scss
@@ -33,7 +33,7 @@ $_image-width: 13.125rem;
 .ecl-file__title {
   color: map.get($theme, 'color', 'black');
   font: map.get($theme, 'font-print', 'm');
-  font-family: #{map.get($theme, 'font-family-print', 'alt')};
+  font-family: var(--ecl-font-family-print-alt);
   font-weight: map.get($theme, 'font-weight-print', 'bold');
   margin-bottom: map.get($theme, 'spacing-print', 's');
   width: 100%;

--- a/src/implementations/vanilla/components/link/link-print.scss
+++ b/src/implementations/vanilla/components/link/link-print.scss
@@ -60,7 +60,7 @@ $link: null !default;
 }
 
 .ecl-link--standalone {
-  font-family: #{map.get($theme, 'font-family-print', 'default')};
+  font-family: var(--ecl-font-family-print-default);
   display: inline-block;
   line-height: map.get($link, 'standalone-line-height');
 }

--- a/src/implementations/vanilla/components/link/link.scss
+++ b/src/implementations/vanilla/components/link/link.scss
@@ -16,7 +16,7 @@ $min-width: 44px; // According to COMM every interactive element should be at le
 .ecl-link,
 %ecl-link {
   color: map.get($link, 'color');
-  font-family: #{map.get($theme, 'font-family', 'default')};
+  font-family: var(--ff-d);
   margin: 0;
   text-decoration: underline;
 

--- a/src/implementations/vanilla/components/menu/menu-print.scss
+++ b/src/implementations/vanilla/components/menu/menu-print.scss
@@ -14,7 +14,7 @@ $theme: null !default;
 
 .ecl-menu__site-name {
   font: map.get($theme, 'font-print', '3xl');
-  font-family: #{map.get($theme, 'font-family-print', 'alt')};
+  font-family: var(--ecl-font-family-print-alt);
   font-weight: map.get($theme, 'font-weight-print', 'bold');
   margin-top: map.get($theme, 'spacing-print', 'xs');
 }

--- a/src/implementations/vanilla/components/ordered-list/ordered-list-print.scss
+++ b/src/implementations/vanilla/components/ordered-list/ordered-list-print.scss
@@ -12,7 +12,7 @@ $list: null !default;
 .ecl-ordered-list,
 %ecl-ordered-list {
   color: map.get($list, 'text-color');
-  font-family: map.get($theme, 'font-family-print', 'default');
+  font-family: var(--ecl-font-family-print-default);
   list-style-position: inside;
   margin: 0;
   padding: 0;

--- a/src/implementations/vanilla/components/page-header/page-header-print-eu.scss
+++ b/src/implementations/vanilla/components/page-header/page-header-print-eu.scss
@@ -49,7 +49,7 @@ $page-header-print: null !default;
 .ecl-page-header__title {
   color: map.get($page-header, 'title-color');
   font: map.get($page-header, 'title-font');
-  font-family: #{map.get($theme, 'font-family-print', 'alt')};
+  font-family: var(--ecl-font-family-print-alt);
   margin-bottom: 0;
   margin-top: map.get($theme, 'spacing-print', 'm');
 }

--- a/src/implementations/vanilla/components/site-header/site-header-print.scss
+++ b/src/implementations/vanilla/components/site-header/site-header-print.scss
@@ -34,7 +34,7 @@ $theme: null !default;
 
 .ecl-site-header__banner {
   font: map.get($theme, 'font-print', '3xl');
-  font-family: #{map.get($theme, 'font-family-print', 'alt')};
+  font-family: var(--ecl-font-family-print-alt);
   font-weight: map.get($theme, 'font-weight-print', 'bold');
   margin-top: map.get($theme, 'spacing-print', 'xs');
 }

--- a/src/implementations/vanilla/components/unordered-list/unordered-list-print.scss
+++ b/src/implementations/vanilla/components/unordered-list/unordered-list-print.scss
@@ -12,7 +12,7 @@ $list: null !default;
 .ecl-unordered-list,
 %ecl-unordered-list {
   color: map.get($list, 'text-color');
-  font-family: map.get($theme, 'font-family-print', 'default');
+  font-family: var(--ecl-font-family-print-default);
   list-style-position: inside;
   margin: 0;
   padding: 0;

--- a/src/themes/ec/_custom-properties.scss
+++ b/src/themes/ec/_custom-properties.scss
@@ -53,6 +53,9 @@
   --ecl-color-accent-80: #{map.get($color, 'accent-80')};
   --ecl-color-accent-60: #{map.get($color, 'accent-60')};
   --ecl-color-accent-40: #{map.get($color, 'accent-40')};
+  --ecl-font-family-default: #{map.get($font-family, 'default')};
+  --ecl-font-family-print-default: #{map.get($font-family-print, 'default')};
+  --ecl-font-family-print-alt: #{map.get($font-family-print, 'alt')};
   --ecl-font-xs: #{map.get($font, 'xs')};
   --ecl-font-s: #{map.get($font, 's')};
   --ecl-font-m: #{map.get($font, 'm')};
@@ -132,6 +135,7 @@
   --c-a-80: var(--ecl-color-accent-80);
   --c-a-60: var(--ecl-color-accent-60);
   --c-a-40: var(--ecl-color-accent-40);
+  --ff-d: var(--ecl-font-family-default);
   --f-xs: var(--ecl-font-xs);
   --f-s: var(--ecl-font-s);
   --f-m: var(--ecl-font-m);

--- a/src/themes/ec/variables/_description-list.scss
+++ b/src/themes/ec/variables/_description-list.scss
@@ -14,7 +14,7 @@ $description-list: (
 );
 $description-list-print: (
   definition-font: map.get($font-print, 'm'),
-  term-font-family: map.get($font-family-print, 'default'),
+  term-font-family: var(--ecl-font-family-print-default),
   term-width: 32%,
   definition-width: 68%,
 );

--- a/src/themes/eu/_custom-properties.scss
+++ b/src/themes/eu/_custom-properties.scss
@@ -49,6 +49,9 @@
   --ecl-color-accent-30: #{map.get($color, 'accent-30')};
   --ecl-color-overlay-light: color-mix(in srgb, var(--c-d) 70%, transparent);
   --ecl-color-overlay-dark: color-mix(in srgb, var(--c-d) 90%, transparent);
+  --ecl-font-family-default: #{map.get($font-family, 'default')};
+  --ecl-font-family-print-default: #{map.get($font-family-print, 'default')};
+  --ecl-font-family-print-alt: #{map.get($font-family-print, 'alt')};
   --ecl-font-xs: #{map.get($font, 'xs')};
   --ecl-font-s: #{map.get($font, 's')};
   --ecl-font-m: #{map.get($font, 'm')};
@@ -131,6 +134,7 @@
   --c-a-30: var(--ecl-color-accent-30);
   --c-ov-l: var(--ecl-color-overlay-light);
   --c-ov-d: var(--ecl-color-overlay-dark);
+  --ff-d: var(--ecl-font-family-default);
   --f-xs: var(--ecl-font-xs);
   --f-s: var(--ecl-font-s);
   --f-m: var(--ecl-font-m);

--- a/src/themes/eu/variables/_description-list.scss
+++ b/src/themes/eu/variables/_description-list.scss
@@ -14,7 +14,7 @@ $description-list: (
 );
 $description-list-print: (
   definition-font: map.get($font-prolonged-print, 'm'),
-  term-font-family: map.get($font-family-print, 'default'),
+  term-font-family: var(--ecl-font-family-print-default),
   term-width: 32%,
   definition-width: 68%,
 );


### PR DESCRIPTION
Didn't make sense to apply this only to the link component, so all the usage of font-family in our sass are now using the custom-properties for the font-family added in this pr.