### PR TITLE
fix(footer): fix accessibility issue in link - FRONT-4496

### DIFF
--- a/src/implementations/twig/components/site-footer/__snapshots__/site-footer.test.js.snap
+++ b/src/implementations/twig/components/site-footer/__snapshots__/site-footer.test.js.snap
@@ -1898,17 +1898,20 @@ exports[`Site Footer Harmonised EU renders correctly 1`] = `
                 />
               </picture>
             </a>
-            <div
-              class="ecl-site-footer__description"
+            <ul
+              class="ecl-site-footer__list"
             >
-              Discover more on 
-              <a
-                class="ecl-link ecl-link--standalone"
-                href="/example"
+              <li
+                class="ecl-site-footer__list-item"
               >
-                europa.eu
-              </a>
-            </div>
+                <a
+                  class="ecl-link ecl-link--standalone ecl-site-footer__link"
+                  href="/example"
+                >
+                  Discover more on europa.eu
+                </a>
+              </li>
+            </ul>
           </div>
         </div>
         <div

--- a/src/implementations/vanilla/components/site-footer/site-footer-eu.scss
+++ b/src/implementations/vanilla/components/site-footer/site-footer-eu.scss
@@ -101,6 +101,10 @@ $site-footer: null !default;
 .ecl-site-footer__logo-link {
   display: inline-block;
   vertical-align: bottom; // Fix to prevent extra vertical spacing
+
+  & + .ecl-site-footer__list {
+    margin-top: var(--s-m);
+  }
 }
 
 .ecl-site-footer__logo-image {

--- a/src/specs/components/site-footer/demo/data-harmonised--eu.js
+++ b/src/specs/components/site-footer/demo/data-harmonised--eu.js
@@ -117,7 +117,6 @@ module.exports = {
     [
       [
         {
-          description: `Discover more on <a href="${exampleLink}" class="ecl-link ecl-link--standalone">europa.eu</a>`,
           logo: {
             title: 'European Union',
             alt: 'European Union logo',
@@ -126,6 +125,14 @@ module.exports = {
             src_desktop: '/logo-eu.svg',
             src_mobile: '/logo-mobile-eu.svg',
           },
+          links: [
+            {
+              link: {
+                label: 'Discover more on europa.eu',
+                path: exampleLink,
+              },
+            },
+          ],
         },
       ],
       [


### PR DESCRIPTION
- update link below the logo to make it take the full text. It is now using the same data structure and markup as any other link in the footer.

Note: previous data structure, using `description`, is still working, but is discouraged here