### PR TITLE
feat(logo): update logo markup - FRONT-4480

### DIFF
--- a/src/implementations/twig/components/site-footer/README.md
+++ b/src/implementations/twig/components/site-footer/README.md
@@ -11,6 +11,7 @@ npm install --save @ecl/twig-component-site-footer
 - **"rows"** (array of objects) (default: [])
   - "section_class_name" (optional) (string) (default: '')
   - "logo"
+    - "title": (string) (default: ''): Logo title attribute.
     - "alt" (string) alt attribute for the logo link
     - "path" (string) logo link path
     - "language" (string) Language code
@@ -155,8 +156,7 @@ npm install --save @ecl/twig-component-site-footer
             }, 
           }, 
           logo: { 
-            title: 'European Commission', 
-            alt: 'European Commission logo', 
+            alt: 'European Commission', 
             language: 'en', 
             path: exampleLink, 
             src_desktop: '/logo-ec.svg', 

--- a/src/implementations/twig/components/site-footer/__snapshots__/site-footer.test.js.snap
+++ b/src/implementations/twig/components/site-footer/__snapshots__/site-footer.test.js.snap
@@ -18,20 +18,18 @@ exports[`Site Footer Core EC renders correctly 1`] = `
             class="ecl-site-footer__section"
           >
             <a
-              aria-label="European Commission"
               class="ecl-link ecl-link--standalone ecl-site-footer__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-footer__picture"
-                title="European Commission"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-ec.svg"
                 />
                 <img
-                  alt="European Commission logo"
+                  alt="European Commission"
                   class="ecl-site-footer__logo-image"
                   src="/logo-ec.svg"
                 />
@@ -360,20 +358,18 @@ exports[`Site Footer Core EC renders correctly with extra attributes 1`] = `
             class="ecl-site-footer__section"
           >
             <a
-              aria-label="European Commission"
               class="ecl-link ecl-link--standalone ecl-site-footer__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-footer__picture"
-                title="European Commission"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-ec.svg"
                 />
                 <img
-                  alt="European Commission logo"
+                  alt="European Commission"
                   class="ecl-site-footer__logo-image"
                   src="/logo-ec.svg"
                 />
@@ -700,20 +696,18 @@ exports[`Site Footer Core EC renders correctly with extra class names 1`] = `
             class="ecl-site-footer__section"
           >
             <a
-              aria-label="European Commission"
               class="ecl-link ecl-link--standalone ecl-site-footer__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-footer__picture"
-                title="European Commission"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-ec.svg"
                 />
                 <img
-                  alt="European Commission logo"
+                  alt="European Commission"
                   class="ecl-site-footer__logo-image"
                   src="/logo-ec.svg"
                 />
@@ -1040,20 +1034,18 @@ exports[`Site Footer Core EU renders correctly 1`] = `
             class="ecl-site-footer__section"
           >
             <a
-              aria-label="European Union"
               class="ecl-link ecl-link--standalone ecl-site-footer__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-footer__picture"
-                title="European Union"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-eu.svg"
                 />
                 <img
-                  alt="European Union logo"
+                  alt="European Union"
                   class="ecl-site-footer__logo-image"
                   src="/logo-mobile-eu.svg"
                 />
@@ -1523,20 +1515,18 @@ exports[`Site Footer Harmonised EC renders correctly 1`] = `
             class="ecl-site-footer__section"
           >
             <a
-              aria-label="European Commission"
               class="ecl-link ecl-link--standalone ecl-site-footer__logo-link"
               href="https://commission.europa.eu/index_en"
             >
               <picture
                 class="ecl-picture ecl-site-footer__picture"
-                title="European Commission"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-ec.svg"
                 />
                 <img
-                  alt="European Commission logo"
+                  alt="European Commission"
                   class="ecl-site-footer__logo-image"
                   src="/logo-ec.svg"
                 />
@@ -1879,20 +1869,18 @@ exports[`Site Footer Harmonised EU renders correctly 1`] = `
             class="ecl-site-footer__section"
           >
             <a
-              aria-label="European Union"
               class="ecl-link ecl-link--standalone ecl-site-footer__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-footer__picture"
-                title="European Union"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-eu.svg"
                 />
                 <img
-                  alt="European Union logo"
+                  alt="European Union"
                   class="ecl-site-footer__logo-image"
                   src="/logo-mobile-eu.svg"
                 />
@@ -2371,20 +2359,18 @@ exports[`Site Footer Standardised EC renders correctly 1`] = `
             class="ecl-site-footer__section"
           >
             <a
-              aria-label="European Commission"
               class="ecl-link ecl-link--standalone ecl-site-footer__logo-link"
               href="https://commission.europa.eu/index_en"
             >
               <picture
                 class="ecl-picture ecl-site-footer__picture"
-                title="European Commission"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-ec.svg"
                 />
                 <img
-                  alt="European Commission logo"
+                  alt="European Commission"
                   class="ecl-site-footer__logo-image"
                   src="/logo-ec.svg"
                 />

--- a/src/implementations/twig/components/site-footer/site-footer.html.twig
+++ b/src/implementations/twig/components/site-footer/site-footer.html.twig
@@ -4,7 +4,8 @@
   Parameters:
   - "rows" (array of objects) (default: [])
     - "section_class_name" (string) (default: '')
-    - "logo" (EU only)
+    - "logo"
+      - "title": (string) (default: ''): Logo title attribute.
       - "alt" (string) alt attribute for the logo link
       - "path" (string) logo link path
       - "language" (string) Language code
@@ -93,15 +94,14 @@
             picture: _picture,
             extra_classes: "ecl-site-footer__picture",
             extra_image_classes: 'ecl-site-footer__logo-image',
-            extra_attributes: [{ name: 'title', value: _sections.logo.title }],
+            extra_attributes: _sections.logo.title is not empty ? [{ name: 'title', value: _sections.logo.title }] : [],
           } only %}
           {% endset %}
           {% include '@ecl/link/link.html.twig' with {
             link: {
               path: _sections.logo.path,
               label: _label,
-              type: 'standalone',
-              aria_label: _sections.logo.title
+              type: 'standalone'
             },
             extra_classes: 'ecl-site-footer__logo-link'
           } only %}

--- a/src/implementations/twig/components/site-header/README.md
+++ b/src/implementations/twig/components/site-header/README.md
@@ -68,9 +68,8 @@ npm install --save @ecl/twig-component-site-header
   banner: 'Class name',
   site_name: 'This site name'
   icon_path: '/icons.svg', 
-  logo: { 
-    title: 'European Commission', 
-    alt: 'European Commission logo', 
+  logo: {
+    alt: 'European Commission', 
     href: '/example', 
     src: '/logo-ec--en.svg', 
   }, 

--- a/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
+++ b/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
@@ -20,20 +20,18 @@ exports[`Site Header EC renders correctly 1`] = `
             data-ecl-site-header-top=""
           >
             <a
-              aria-label="European Commission"
               class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-header__picture"
-                title="European Commission"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-ec--en.svg"
                 />
                 <img
-                  alt="European Commission logo"
+                  alt="European Commission"
                   class="ecl-site-header__logo-image ecl-site-header__logo-image--l"
                   src="/logo-ec--mute.svg"
                 />
@@ -1077,20 +1075,18 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
             data-ecl-site-header-top=""
           >
             <a
-              aria-label="European Commission"
               class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-header__picture"
-                title="European Commission"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-ec--en.svg"
                 />
                 <img
-                  alt="European Commission logo"
+                  alt="European Commission"
                   class="ecl-site-header__logo-image ecl-site-header__logo-image--l"
                   src="/logo-ec--mute.svg"
                 />
@@ -2158,20 +2154,18 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
             data-ecl-site-header-top=""
           >
             <a
-              aria-label="European Commission"
               class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-header__picture"
-                title="European Commission"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-ec--en.svg"
                 />
                 <img
-                  alt="European Commission logo"
+                  alt="European Commission"
                   class="ecl-site-header__logo-image ecl-site-header__logo-image--l"
                   src="/logo-ec--mute.svg"
                 />
@@ -3215,20 +3209,18 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
             data-ecl-site-header-top=""
           >
             <a
-              aria-label="European Commission"
               class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-header__picture"
-                title="European Commission"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/logo-ec--en.svg"
                 />
                 <img
-                  alt="European Commission logo"
+                  alt="European Commission"
                   class="ecl-site-header__logo-image ecl-site-header__logo-image--l"
                   src="/logo-ec--mute.svg"
                 />
@@ -4272,20 +4264,18 @@ exports[`Site Header EU renders correctly 1`] = `
             data-ecl-site-header-top=""
           >
             <a
-              aria-label="European Union"
               class="ecl-link ecl-link--standalone ecl-site-header__logo-link"
               href="/example"
             >
               <picture
                 class="ecl-picture ecl-site-header__picture"
-                title="European Union"
               >
                 <source
                   media="(min-width: 996px)"
                   srcset="/standard-version/positive/logo-eu--en.svg"
                 />
                 <img
-                  alt="European Union flag"
+                  alt="European Union"
                   class="ecl-site-header__logo-image ecl-site-header__logo-image--l"
                   src="/condensed-version/positive/logo-eu--en.svg"
                 />

--- a/src/implementations/twig/components/site-header/site-header.html.twig
+++ b/src/implementations/twig/components/site-header/site-header.html.twig
@@ -234,15 +234,14 @@
                 picture: _picture,
                 extra_classes: "ecl-site-header__picture",
                 extra_image_classes: image_classes,
-                extra_attributes: [{ name: 'title', value: _logo.title }],
+                extra_attributes: _logo.title is not empty ? [{ name: 'title', value: _logo.title }] : [],
               } only %}
             {% endset %}
             {% include '@ecl/link/link.html.twig' with {
               link: {
                 path: _logo.path,
                 label: _label,
-                type: 'standalone',
-                aria_label: _logo.title
+                type: 'standalone'
               },
               extra_classes: 'ecl-site-header__logo-link'
             } only %}

--- a/src/implementations/twig/components/splash-page/README.md
+++ b/src/implementations/twig/components/splash-page/README.md
@@ -44,8 +44,7 @@ npm install --save @ecl/twig-component-splash-page
 ```twig
 {% include '@ecl/splash-page/splash-page.html.twig' with { 
   logo: {
-    title: 'European Commission',
-    alt: 'European Commission logo',
+    alt: 'European Commission',
     path: exampleLink,
     src_desktop: '/logo-ec--en.svg',
     src_mobile: '/logo-ec--mute.svg',

--- a/src/implementations/twig/components/splash-page/__snapshots__/splash-page.test.js.snap
+++ b/src/implementations/twig/components/splash-page/__snapshots__/splash-page.test.js.snap
@@ -12,20 +12,18 @@ exports[`Splash page EC renders correctly 1`] = `
         class="ecl-container"
       >
         <a
-          aria-label="European Commission"
           class="ecl-link ecl-link--standalone ecl-splash-page__logo-link"
           href="/example"
         >
           <picture
             class="ecl-picture ecl-splash-page__picture"
-            title="European Commission"
           >
             <source
               media="(min-width: 768px)"
               srcset="/logo-ec--en.svg"
             />
             <img
-              alt="European Commission logo"
+              alt="European Commission"
               class="ecl-splash-page__logo-image"
               src="/logo-ec--mute.svg"
             />
@@ -804,20 +802,18 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
         class="ecl-container"
       >
         <a
-          aria-label="European Commission"
           class="ecl-link ecl-link--standalone ecl-splash-page__logo-link"
           href="/example"
         >
           <picture
             class="ecl-picture ecl-splash-page__picture"
-            title="European Commission"
           >
             <source
               media="(min-width: 768px)"
               srcset="/logo-ec--en.svg"
             />
             <img
-              alt="European Commission logo"
+              alt="European Commission"
               class="ecl-splash-page__logo-image"
               src="/logo-ec--mute.svg"
             />
@@ -1594,20 +1590,18 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
         class="ecl-container"
       >
         <a
-          aria-label="European Commission"
           class="ecl-link ecl-link--standalone ecl-splash-page__logo-link"
           href="/example"
         >
           <picture
             class="ecl-picture ecl-splash-page__picture"
-            title="European Commission"
           >
             <source
               media="(min-width: 768px)"
               srcset="/logo-ec--en.svg"
             />
             <img
-              alt="European Commission logo"
+              alt="European Commission"
               class="ecl-splash-page__logo-image"
               src="/logo-ec--mute.svg"
             />
@@ -2384,20 +2378,18 @@ exports[`Splash page EU renders correctly 1`] = `
         class="ecl-container"
       >
         <a
-          aria-label="European Union"
           class="ecl-link ecl-link--standalone ecl-splash-page__logo-link"
           href="/example"
         >
           <picture
             class="ecl-picture ecl-splash-page__picture"
-            title="European Union"
           >
             <source
               media="(min-width: 768px)"
               srcset="/standard-version/positive/logo-eu--en.svg"
             />
             <img
-              alt="European Union flag"
+              alt="European Union"
               class="ecl-splash-page__logo-image"
               src="/condensed-version/positive/logo-eu--en.svg"
             />

--- a/src/implementations/twig/components/splash-page/splash-page.html.twig
+++ b/src/implementations/twig/components/splash-page/splash-page.html.twig
@@ -92,15 +92,14 @@
             picture: _picture,
             extra_classes: "ecl-splash-page__picture",
             extra_image_classes: 'ecl-splash-page__logo-image',
-            extra_attributes: [{ name: 'title', value: _logo.title }],
+            extra_attributes: _logo.title is not empty ? [{ name: 'title', value: _logo.title }] : [],
           } only %}
         {% endset %}
         {% include '@ecl/link/link.html.twig' with {
           link: {
             path: _logo.path,
             label: _label,
-            type: 'standalone',
-            aria_label: _logo.title
+            type: 'standalone'
           },
           extra_classes: 'ecl-splash-page__logo-link'
         } only %}

--- a/src/specs/components/site-footer/demo/data-core--ec.js
+++ b/src/specs/components/site-footer/demo/data-core--ec.js
@@ -8,8 +8,7 @@ module.exports = {
       [
         {
           logo: {
-            title: 'European Commission',
-            alt: 'European Commission logo',
+            alt: 'European Commission',
             language: 'en',
             path: exampleLink,
             src_desktop: '/logo-ec.svg',

--- a/src/specs/components/site-footer/demo/data-core--eu.js
+++ b/src/specs/components/site-footer/demo/data-core--eu.js
@@ -7,8 +7,7 @@ module.exports = {
       [
         {
           logo: {
-            title: 'European Union',
-            alt: 'European Union logo',
+            alt: 'European Union',
             language: 'en',
             path: exampleLink,
             src_desktop: '/logo-eu.svg',

--- a/src/specs/components/site-footer/demo/data-harmonised--ec.js
+++ b/src/specs/components/site-footer/demo/data-harmonised--ec.js
@@ -153,8 +153,7 @@ module.exports = {
       [
         {
           logo: {
-            title: 'European Commission',
-            alt: 'European Commission logo',
+            alt: 'European Commission',
             language: 'en',
             path: 'https://commission.europa.eu/index_en',
             src_desktop: '/logo-ec.svg',

--- a/src/specs/components/site-footer/demo/data-harmonised--eu.js
+++ b/src/specs/components/site-footer/demo/data-harmonised--eu.js
@@ -118,8 +118,7 @@ module.exports = {
       [
         {
           logo: {
-            title: 'European Union',
-            alt: 'European Union logo',
+            alt: 'European Union',
             language: 'en',
             path: exampleLink,
             src_desktop: '/logo-eu.svg',

--- a/src/specs/components/site-footer/demo/data-standardised--ec.js
+++ b/src/specs/components/site-footer/demo/data-standardised--ec.js
@@ -153,8 +153,7 @@ module.exports = {
       [
         {
           logo: {
-            title: 'European Commission',
-            alt: 'European Commission logo',
+            alt: 'European Commission',
             language: 'en',
             path: 'https://commission.europa.eu/index_en',
             src_desktop: '/logo-ec.svg',

--- a/src/specs/components/site-header/demo/data--ec.js
+++ b/src/specs/components/site-header/demo/data--ec.js
@@ -3,8 +3,7 @@ const exampleLink = `${publicUrl}/example`;
 
 module.exports = {
   logo: {
-    title: 'European Commission',
-    alt: 'European Commission logo',
+    alt: 'European Commission',
     path: exampleLink,
     language: 'en',
     src_desktop: '/logo-ec--en.svg',

--- a/src/specs/components/site-header/demo/data--eu.js
+++ b/src/specs/components/site-header/demo/data--eu.js
@@ -3,8 +3,7 @@ const exampleLink = `${publicUrl}/example`;
 
 module.exports = {
   logo: {
-    title: 'European Union',
-    alt: 'European Union flag',
+    alt: 'European Union',
     path: exampleLink,
     language: 'en',
     src_desktop: '/standard-version/positive/logo-eu--en.svg',

--- a/src/specs/components/splash-page/demo/data--ec.js
+++ b/src/specs/components/splash-page/demo/data--ec.js
@@ -3,8 +3,7 @@ const exampleLink = `${publicUrl}/example`;
 
 module.exports = {
   logo: {
-    title: 'European Commission',
-    alt: 'European Commission logo',
+    alt: 'European Commission',
     path: exampleLink,
     src_desktop: '/logo-ec--en.svg',
     src_mobile: '/logo-ec--mute.svg',

--- a/src/specs/components/splash-page/demo/data--eu.js
+++ b/src/specs/components/splash-page/demo/data--eu.js
@@ -3,8 +3,7 @@ const exampleLink = `${publicUrl}/example`;
 
 module.exports = {
   logo: {
-    title: 'European Union',
-    alt: 'European Union flag',
+    alt: 'European Union',
     path: exampleLink,
     src_desktop: '/standard-version/positive/logo-eu--en.svg',
     src_mobile: '/condensed-version/positive/logo-eu--en.svg',


### PR DESCRIPTION
in splash page, site header and site footer:
- remove unneeded aria-label
- set title as optional