### PR TITLE
feat(splash-page): change markup for "lang" attribute

### DIFF
--- a/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
+++ b/src/implementations/twig/components/site-header/__snapshots__/site-header.test.js.snap
@@ -160,7 +160,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="bg"
-                            lang="bg"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -169,6 +168,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="bg"
                             >
                               български
                             </span>
@@ -181,7 +181,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="es"
-                            lang="es"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -190,6 +189,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="es"
                             >
                               español
                             </span>
@@ -202,7 +202,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="cs"
-                            lang="cs"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -211,6 +210,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="cs"
                             >
                               čeština
                             </span>
@@ -223,7 +223,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="da"
-                            lang="da"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -232,6 +231,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="da"
                             >
                               dansk
                             </span>
@@ -244,7 +244,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="de"
-                            lang="de"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -253,6 +252,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="de"
                             >
                               Deutsch
                             </span>
@@ -265,7 +265,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="et"
-                            lang="et"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -274,6 +273,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="et"
                             >
                               eesti
                             </span>
@@ -286,7 +286,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="el"
-                            lang="el"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -295,6 +294,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="el"
                             >
                               ελληνικά
                             </span>
@@ -307,7 +307,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link ecl-site-header__language-link--active"
                             href="/example"
                             hreflang="en"
-                            lang="en"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -316,6 +315,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="en"
                             >
                               English
                             </span>
@@ -328,7 +328,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fr"
-                            lang="fr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -337,6 +336,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fr"
                             >
                               français
                             </span>
@@ -349,7 +349,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ga"
-                            lang="ga"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -358,6 +357,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ga"
                             >
                               Gaeilge
                             </span>
@@ -370,7 +370,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hr"
-                            lang="hr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -379,6 +378,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hr"
                             >
                               hrvatski
                             </span>
@@ -391,7 +391,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="it"
-                            lang="it"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -400,6 +399,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="it"
                             >
                               italiano
                             </span>
@@ -412,7 +412,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lv"
-                            lang="lv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -421,6 +420,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lv"
                             >
                               latviešu
                             </span>
@@ -433,7 +433,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lt"
-                            lang="lt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -442,6 +441,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lt"
                             >
                               lietuvių
                             </span>
@@ -454,7 +454,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hu"
-                            lang="hu"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -463,6 +462,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hu"
                             >
                               magyar
                             </span>
@@ -475,7 +475,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="mt"
-                            lang="mt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -484,6 +483,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="mt"
                             >
                               Malti
                             </span>
@@ -496,7 +496,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="nl"
-                            lang="nl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -505,6 +504,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="nl"
                             >
                               Nederlands
                             </span>
@@ -517,7 +517,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pl"
-                            lang="pl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -526,6 +525,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pl"
                             >
                               polski
                             </span>
@@ -538,7 +538,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pt"
-                            lang="pt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -547,6 +546,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pt"
                             >
                               português
                             </span>
@@ -559,7 +559,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ro"
-                            lang="ro"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -568,6 +567,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ro"
                             >
                               română
                             </span>
@@ -580,7 +580,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sk"
-                            lang="sk"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -589,6 +588,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sk"
                             >
                               slovenčina
                             </span>
@@ -601,7 +601,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sl"
-                            lang="sl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -610,6 +609,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sl"
                             >
                               slovenščina
                             </span>
@@ -622,7 +622,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fi"
-                            lang="fi"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -631,6 +630,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fi"
                             >
                               suomi
                             </span>
@@ -643,7 +643,6 @@ exports[`Site Header EC renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sv"
-                            lang="sv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -652,6 +651,7 @@ exports[`Site Header EC renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sv"
                             >
                               svenska
                             </span>
@@ -1237,7 +1237,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="bg"
-                            lang="bg"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1246,6 +1245,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="bg"
                             >
                               български
                             </span>
@@ -1258,7 +1258,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="es"
-                            lang="es"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1267,6 +1266,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="es"
                             >
                               español
                             </span>
@@ -1279,7 +1279,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="cs"
-                            lang="cs"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1288,6 +1287,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="cs"
                             >
                               čeština
                             </span>
@@ -1300,7 +1300,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="da"
-                            lang="da"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1309,6 +1308,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="da"
                             >
                               dansk
                             </span>
@@ -1321,7 +1321,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="de"
-                            lang="de"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1330,6 +1329,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="de"
                             >
                               Deutsch
                             </span>
@@ -1342,7 +1342,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="et"
-                            lang="et"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1351,6 +1350,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="et"
                             >
                               eesti
                             </span>
@@ -1363,7 +1363,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="el"
-                            lang="el"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1372,6 +1371,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="el"
                             >
                               ελληνικά
                             </span>
@@ -1384,7 +1384,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link ecl-site-header__language-link--active"
                             href="/example"
                             hreflang="en"
-                            lang="en"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1393,6 +1392,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="en"
                             >
                               English
                             </span>
@@ -1405,7 +1405,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fr"
-                            lang="fr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1414,6 +1413,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fr"
                             >
                               français
                             </span>
@@ -1426,7 +1426,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ga"
-                            lang="ga"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1435,6 +1434,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ga"
                             >
                               Gaeilge
                             </span>
@@ -1447,7 +1447,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hr"
-                            lang="hr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1456,6 +1455,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hr"
                             >
                               hrvatski
                             </span>
@@ -1468,7 +1468,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="it"
-                            lang="it"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1477,6 +1476,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="it"
                             >
                               italiano
                             </span>
@@ -1489,7 +1489,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lv"
-                            lang="lv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1498,6 +1497,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lv"
                             >
                               latviešu
                             </span>
@@ -1510,7 +1510,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lt"
-                            lang="lt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1519,6 +1518,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lt"
                             >
                               lietuvių
                             </span>
@@ -1531,7 +1531,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hu"
-                            lang="hu"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1540,6 +1539,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hu"
                             >
                               magyar
                             </span>
@@ -1552,7 +1552,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="mt"
-                            lang="mt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1561,6 +1560,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="mt"
                             >
                               Malti
                             </span>
@@ -1573,7 +1573,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="nl"
-                            lang="nl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1582,6 +1581,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="nl"
                             >
                               Nederlands
                             </span>
@@ -1594,7 +1594,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pl"
-                            lang="pl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1603,6 +1602,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pl"
                             >
                               polski
                             </span>
@@ -1615,7 +1615,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pt"
-                            lang="pt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1624,6 +1623,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pt"
                             >
                               português
                             </span>
@@ -1636,7 +1636,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ro"
-                            lang="ro"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1645,6 +1644,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ro"
                             >
                               română
                             </span>
@@ -1657,7 +1657,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sk"
-                            lang="sk"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1666,6 +1665,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sk"
                             >
                               slovenčina
                             </span>
@@ -1678,7 +1678,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sl"
-                            lang="sl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1687,6 +1686,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sl"
                             >
                               slovenščina
                             </span>
@@ -1699,7 +1699,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fi"
-                            lang="fi"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1708,6 +1707,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fi"
                             >
                               suomi
                             </span>
@@ -1720,7 +1720,6 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sv"
-                            lang="sv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -1729,6 +1728,7 @@ exports[`Site Header EC renders correctly when logged in 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sv"
                             >
                               svenska
                             </span>
@@ -2294,7 +2294,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="bg"
-                            lang="bg"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2303,6 +2302,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="bg"
                             >
                               български
                             </span>
@@ -2315,7 +2315,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="es"
-                            lang="es"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2324,6 +2323,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="es"
                             >
                               español
                             </span>
@@ -2336,7 +2336,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="cs"
-                            lang="cs"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2345,6 +2344,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="cs"
                             >
                               čeština
                             </span>
@@ -2357,7 +2357,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="da"
-                            lang="da"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2366,6 +2365,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="da"
                             >
                               dansk
                             </span>
@@ -2378,7 +2378,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="de"
-                            lang="de"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2387,6 +2386,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="de"
                             >
                               Deutsch
                             </span>
@@ -2399,7 +2399,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="et"
-                            lang="et"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2408,6 +2407,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="et"
                             >
                               eesti
                             </span>
@@ -2420,7 +2420,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="el"
-                            lang="el"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2429,6 +2428,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="el"
                             >
                               ελληνικά
                             </span>
@@ -2441,7 +2441,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link ecl-site-header__language-link--active"
                             href="/example"
                             hreflang="en"
-                            lang="en"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2450,6 +2449,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="en"
                             >
                               English
                             </span>
@@ -2462,7 +2462,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fr"
-                            lang="fr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2471,6 +2470,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fr"
                             >
                               français
                             </span>
@@ -2483,7 +2483,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ga"
-                            lang="ga"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2492,6 +2491,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ga"
                             >
                               Gaeilge
                             </span>
@@ -2504,7 +2504,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hr"
-                            lang="hr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2513,6 +2512,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hr"
                             >
                               hrvatski
                             </span>
@@ -2525,7 +2525,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="it"
-                            lang="it"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2534,6 +2533,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="it"
                             >
                               italiano
                             </span>
@@ -2546,7 +2546,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lv"
-                            lang="lv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2555,6 +2554,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lv"
                             >
                               latviešu
                             </span>
@@ -2567,7 +2567,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lt"
-                            lang="lt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2576,6 +2575,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lt"
                             >
                               lietuvių
                             </span>
@@ -2588,7 +2588,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hu"
-                            lang="hu"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2597,6 +2596,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hu"
                             >
                               magyar
                             </span>
@@ -2609,7 +2609,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="mt"
-                            lang="mt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2618,6 +2617,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="mt"
                             >
                               Malti
                             </span>
@@ -2630,7 +2630,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="nl"
-                            lang="nl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2639,6 +2638,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="nl"
                             >
                               Nederlands
                             </span>
@@ -2651,7 +2651,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pl"
-                            lang="pl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2660,6 +2659,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pl"
                             >
                               polski
                             </span>
@@ -2672,7 +2672,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pt"
-                            lang="pt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2681,6 +2680,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pt"
                             >
                               português
                             </span>
@@ -2693,7 +2693,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ro"
-                            lang="ro"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2702,6 +2701,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ro"
                             >
                               română
                             </span>
@@ -2714,7 +2714,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sk"
-                            lang="sk"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2723,6 +2722,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sk"
                             >
                               slovenčina
                             </span>
@@ -2735,7 +2735,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sl"
-                            lang="sl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2744,6 +2743,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sl"
                             >
                               slovenščina
                             </span>
@@ -2756,7 +2756,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fi"
-                            lang="fi"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2765,6 +2764,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fi"
                             >
                               suomi
                             </span>
@@ -2777,7 +2777,6 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sv"
-                            lang="sv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -2786,6 +2785,7 @@ exports[`Site Header EC renders correctly with extra attributes 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sv"
                             >
                               svenska
                             </span>
@@ -3349,7 +3349,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="bg"
-                            lang="bg"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3358,6 +3357,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="bg"
                             >
                               български
                             </span>
@@ -3370,7 +3370,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="es"
-                            lang="es"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3379,6 +3378,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="es"
                             >
                               español
                             </span>
@@ -3391,7 +3391,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="cs"
-                            lang="cs"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3400,6 +3399,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="cs"
                             >
                               čeština
                             </span>
@@ -3412,7 +3412,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="da"
-                            lang="da"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3421,6 +3420,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="da"
                             >
                               dansk
                             </span>
@@ -3433,7 +3433,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="de"
-                            lang="de"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3442,6 +3441,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="de"
                             >
                               Deutsch
                             </span>
@@ -3454,7 +3454,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="et"
-                            lang="et"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3463,6 +3462,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="et"
                             >
                               eesti
                             </span>
@@ -3475,7 +3475,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="el"
-                            lang="el"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3484,6 +3483,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="el"
                             >
                               ελληνικά
                             </span>
@@ -3496,7 +3496,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link ecl-site-header__language-link--active"
                             href="/example"
                             hreflang="en"
-                            lang="en"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3505,6 +3504,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="en"
                             >
                               English
                             </span>
@@ -3517,7 +3517,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fr"
-                            lang="fr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3526,6 +3525,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fr"
                             >
                               français
                             </span>
@@ -3538,7 +3538,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ga"
-                            lang="ga"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3547,6 +3546,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ga"
                             >
                               Gaeilge
                             </span>
@@ -3559,7 +3559,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hr"
-                            lang="hr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3568,6 +3567,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hr"
                             >
                               hrvatski
                             </span>
@@ -3580,7 +3580,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="it"
-                            lang="it"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3589,6 +3588,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="it"
                             >
                               italiano
                             </span>
@@ -3601,7 +3601,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lv"
-                            lang="lv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3610,6 +3609,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lv"
                             >
                               latviešu
                             </span>
@@ -3622,7 +3622,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lt"
-                            lang="lt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3631,6 +3630,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lt"
                             >
                               lietuvių
                             </span>
@@ -3643,7 +3643,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hu"
-                            lang="hu"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3652,6 +3651,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hu"
                             >
                               magyar
                             </span>
@@ -3664,7 +3664,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="mt"
-                            lang="mt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3673,6 +3672,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="mt"
                             >
                               Malti
                             </span>
@@ -3685,7 +3685,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="nl"
-                            lang="nl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3694,6 +3693,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="nl"
                             >
                               Nederlands
                             </span>
@@ -3706,7 +3706,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pl"
-                            lang="pl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3715,6 +3714,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pl"
                             >
                               polski
                             </span>
@@ -3727,7 +3727,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pt"
-                            lang="pt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3736,6 +3735,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pt"
                             >
                               português
                             </span>
@@ -3748,7 +3748,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ro"
-                            lang="ro"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3757,6 +3756,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ro"
                             >
                               română
                             </span>
@@ -3769,7 +3769,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sk"
-                            lang="sk"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3778,6 +3777,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sk"
                             >
                               slovenčina
                             </span>
@@ -3790,7 +3790,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sl"
-                            lang="sl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3799,6 +3798,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sl"
                             >
                               slovenščina
                             </span>
@@ -3811,7 +3811,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fi"
-                            lang="fi"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3820,6 +3819,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fi"
                             >
                               suomi
                             </span>
@@ -3832,7 +3832,6 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sv"
-                            lang="sv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -3841,6 +3840,7 @@ exports[`Site Header EC renders correctly with extra class names 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sv"
                             >
                               svenska
                             </span>
@@ -4404,7 +4404,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="bg"
-                            lang="bg"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4413,6 +4412,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="bg"
                             >
                               български
                             </span>
@@ -4425,7 +4425,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="es"
-                            lang="es"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4434,6 +4433,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="es"
                             >
                               español
                             </span>
@@ -4446,7 +4446,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="cs"
-                            lang="cs"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4455,6 +4454,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="cs"
                             >
                               čeština
                             </span>
@@ -4467,7 +4467,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="da"
-                            lang="da"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4476,6 +4475,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="da"
                             >
                               dansk
                             </span>
@@ -4488,7 +4488,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="de"
-                            lang="de"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4497,6 +4496,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="de"
                             >
                               Deutsch
                             </span>
@@ -4509,7 +4509,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="et"
-                            lang="et"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4518,6 +4517,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="et"
                             >
                               eesti
                             </span>
@@ -4530,7 +4530,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="el"
-                            lang="el"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4539,6 +4538,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="el"
                             >
                               ελληνικά
                             </span>
@@ -4551,7 +4551,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link ecl-site-header__language-link--active"
                             href="/example"
                             hreflang="en"
-                            lang="en"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4560,6 +4559,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="en"
                             >
                               English
                             </span>
@@ -4572,7 +4572,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fr"
-                            lang="fr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4581,6 +4580,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fr"
                             >
                               français
                             </span>
@@ -4593,7 +4593,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ga"
-                            lang="ga"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4602,6 +4601,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ga"
                             >
                               Gaeilge
                             </span>
@@ -4614,7 +4614,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hr"
-                            lang="hr"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4623,6 +4622,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hr"
                             >
                               hrvatski
                             </span>
@@ -4635,7 +4635,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="it"
-                            lang="it"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4644,6 +4643,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="it"
                             >
                               italiano
                             </span>
@@ -4656,7 +4656,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lv"
-                            lang="lv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4665,6 +4664,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lv"
                             >
                               latviešu
                             </span>
@@ -4677,7 +4677,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="lt"
-                            lang="lt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4686,6 +4685,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="lt"
                             >
                               lietuvių
                             </span>
@@ -4698,7 +4698,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="hu"
-                            lang="hu"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4707,6 +4706,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="hu"
                             >
                               magyar
                             </span>
@@ -4719,7 +4719,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="mt"
-                            lang="mt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4728,6 +4727,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="mt"
                             >
                               Malti
                             </span>
@@ -4740,7 +4740,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="nl"
-                            lang="nl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4749,6 +4748,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="nl"
                             >
                               Nederlands
                             </span>
@@ -4761,7 +4761,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pl"
-                            lang="pl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4770,6 +4769,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pl"
                             >
                               polski
                             </span>
@@ -4782,7 +4782,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="pt"
-                            lang="pt"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4791,6 +4790,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="pt"
                             >
                               português
                             </span>
@@ -4803,7 +4803,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="ro"
-                            lang="ro"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4812,6 +4811,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="ro"
                             >
                               română
                             </span>
@@ -4824,7 +4824,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sk"
-                            lang="sk"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4833,6 +4832,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sk"
                             >
                               slovenčina
                             </span>
@@ -4845,7 +4845,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sl"
-                            lang="sl"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4854,6 +4853,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sl"
                             >
                               slovenščina
                             </span>
@@ -4866,7 +4866,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="fi"
-                            lang="fi"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4875,6 +4874,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="fi"
                             >
                               suomi
                             </span>
@@ -4887,7 +4887,6 @@ exports[`Site Header EU renders correctly 1`] = `
                             class="ecl-link ecl-link--standalone ecl-link--no-visited ecl-site-header__language-link"
                             href="/example"
                             hreflang="sv"
-                            lang="sv"
                           >
                             <span
                               class="ecl-site-header__language-link-code"
@@ -4896,6 +4895,7 @@ exports[`Site Header EU renders correctly 1`] = `
                             </span>
                             <span
                               class="ecl-site-header__language-link-label"
+                              lang="sv"
                             >
                               svenska
                             </span>

--- a/src/implementations/twig/components/site-header/site-header-language-switcher.html.twig
+++ b/src/implementations/twig/components/site-header/site-header-language-switcher.html.twig
@@ -111,7 +111,7 @@
           <li class="ecl-site-header__language-item">
             {% set _link_label %}
               <span class="ecl-site-header__language-link-code">{{ _item.lang|default('') }}</span>
-              <span class="ecl-site-header__language-link-label">{{ _item.label|default('') }}</span>
+              <span class="ecl-site-header__language-link-label" lang="{{ _item.lang|default('') }}">{{ _item.label|default('') }}</span>
             {% endset %}
             {% set _link_classes = 'ecl-site-header__language-link' %}
             {% if _item.active %}
@@ -125,7 +125,6 @@
               }),
               extra_classes: _link_classes,
               extra_attributes: [
-                { name: 'lang', value: _item.lang|default('')|e('html_attr') },
                 { name: 'hreflang', value: _item.lang|default('')|e('html_attr') },
               ],
             } only %}

--- a/src/implementations/twig/components/splash-page/__snapshots__/splash-page.test.js.snap
+++ b/src/implementations/twig/components/splash-page/__snapshots__/splash-page.test.js.snap
@@ -60,7 +60,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="bg"
-                lang="bg"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -69,6 +68,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="bg"
                 >
                   български
                 </span>
@@ -81,7 +81,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="es"
-                lang="es"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -90,6 +89,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="es"
                 >
                   español
                 </span>
@@ -102,7 +102,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="cs"
-                lang="cs"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -111,6 +110,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="cs"
                 >
                   čeština
                 </span>
@@ -123,7 +123,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="da"
-                lang="da"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -132,6 +131,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="da"
                 >
                   dansk
                 </span>
@@ -144,7 +144,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="de"
-                lang="de"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -153,6 +152,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="de"
                 >
                   Deutsch
                 </span>
@@ -165,7 +165,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="et"
-                lang="et"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -174,6 +173,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="et"
                 >
                   eesti
                 </span>
@@ -186,7 +186,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="el"
-                lang="el"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -195,6 +194,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="el"
                 >
                   ελληνικά
                 </span>
@@ -207,7 +207,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link ecl-splash-page__language-link--active"
                 href="/example"
                 hreflang="en"
-                lang="en"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -216,6 +215,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="en"
                 >
                   English
                 </span>
@@ -228,7 +228,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="fr"
-                lang="fr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -237,6 +236,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="fr"
                 >
                   français
                 </span>
@@ -249,7 +249,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ga"
-                lang="ga"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -258,6 +257,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ga"
                 >
                   Gaeilge
                 </span>
@@ -270,7 +270,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="hr"
-                lang="hr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -279,6 +278,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="hr"
                 >
                   hrvatski
                 </span>
@@ -291,7 +291,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="it"
-                lang="it"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -300,6 +299,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="it"
                 >
                   italiano
                 </span>
@@ -312,7 +312,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lv"
-                lang="lv"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -321,6 +320,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lv"
                 >
                   latviešu
                 </span>
@@ -333,7 +333,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lt"
-                lang="lt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -342,6 +341,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lt"
                 >
                   lietuvių
                 </span>
@@ -354,7 +354,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="hu"
-                lang="hu"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -363,6 +362,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="hu"
                 >
                   magyar
                 </span>
@@ -375,7 +375,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="mt"
-                lang="mt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -384,6 +383,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="mt"
                 >
                   Malti
                 </span>
@@ -396,7 +396,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="nl"
-                lang="nl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -405,6 +404,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="nl"
                 >
                   Nederlands
                 </span>
@@ -417,7 +417,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="pl"
-                lang="pl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -426,6 +425,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="pl"
                 >
                   polski
                 </span>
@@ -438,7 +438,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="pt"
-                lang="pt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -447,6 +446,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="pt"
                 >
                   português
                 </span>
@@ -459,7 +459,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ro"
-                lang="ro"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -468,6 +467,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ro"
                 >
                   română
                 </span>
@@ -480,7 +480,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sk"
-                lang="sk"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -489,6 +488,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sk"
                 >
                   slovenčina
                 </span>
@@ -501,7 +501,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sl"
-                lang="sl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -510,6 +509,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sl"
                 >
                   slovenščina
                 </span>
@@ -522,7 +522,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="fi"
-                lang="fi"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -531,6 +530,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="fi"
                 >
                   suomi
                 </span>
@@ -543,7 +543,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sv"
-                lang="sv"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -552,6 +551,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sv"
                 >
                   svenska
                 </span>
@@ -577,7 +577,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ar"
-                lang="ar"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -586,6 +585,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ar"
                 >
                   عَرَبِيّ
                 </span>
@@ -598,7 +598,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ca"
-                lang="ca"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -607,6 +606,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ca"
                 >
                   Català
                 </span>
@@ -619,7 +619,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="is"
-                lang="is"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -628,6 +627,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="is"
                 >
                   Íslenska
                 </span>
@@ -640,7 +640,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lb"
-                lang="lb"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -649,6 +648,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lb"
                 >
                   Lëtzebuergesch
                 </span>
@@ -661,7 +661,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ja"
-                lang="ja"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -670,6 +669,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ja"
                 >
                   日本語
                 </span>
@@ -682,7 +682,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="nb"
-                lang="nb"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -691,6 +690,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="nb"
                 >
                   Norsk bokmål
                 </span>
@@ -703,7 +703,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ru"
-                lang="ru"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -712,6 +711,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ru"
                 >
                   русский язык
                 </span>
@@ -724,7 +724,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="tr"
-                lang="tr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -733,6 +732,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="tr"
                 >
                   Türkçe
                 </span>
@@ -745,7 +745,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="uk"
-                lang="uk"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -754,6 +753,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="uk"
                 >
                   українська мова
                 </span>
@@ -766,7 +766,6 @@ exports[`Splash page EC renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="zh"
-                lang="zh"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -775,6 +774,7 @@ exports[`Splash page EC renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="zh"
                 >
                   中文
                 </span>
@@ -850,7 +850,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="bg"
-                lang="bg"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -859,6 +858,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="bg"
                 >
                   български
                 </span>
@@ -871,7 +871,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="es"
-                lang="es"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -880,6 +879,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="es"
                 >
                   español
                 </span>
@@ -892,7 +892,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="cs"
-                lang="cs"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -901,6 +900,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="cs"
                 >
                   čeština
                 </span>
@@ -913,7 +913,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="da"
-                lang="da"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -922,6 +921,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="da"
                 >
                   dansk
                 </span>
@@ -934,7 +934,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="de"
-                lang="de"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -943,6 +942,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="de"
                 >
                   Deutsch
                 </span>
@@ -955,7 +955,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="et"
-                lang="et"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -964,6 +963,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="et"
                 >
                   eesti
                 </span>
@@ -976,7 +976,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="el"
-                lang="el"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -985,6 +984,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="el"
                 >
                   ελληνικά
                 </span>
@@ -997,7 +997,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link ecl-splash-page__language-link--active"
                 href="/example"
                 hreflang="en"
-                lang="en"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1006,6 +1005,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="en"
                 >
                   English
                 </span>
@@ -1018,7 +1018,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="fr"
-                lang="fr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1027,6 +1026,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="fr"
                 >
                   français
                 </span>
@@ -1039,7 +1039,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ga"
-                lang="ga"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1048,6 +1047,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ga"
                 >
                   Gaeilge
                 </span>
@@ -1060,7 +1060,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="hr"
-                lang="hr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1069,6 +1068,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="hr"
                 >
                   hrvatski
                 </span>
@@ -1081,7 +1081,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="it"
-                lang="it"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1090,6 +1089,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="it"
                 >
                   italiano
                 </span>
@@ -1102,7 +1102,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lv"
-                lang="lv"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1111,6 +1110,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lv"
                 >
                   latviešu
                 </span>
@@ -1123,7 +1123,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lt"
-                lang="lt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1132,6 +1131,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lt"
                 >
                   lietuvių
                 </span>
@@ -1144,7 +1144,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="hu"
-                lang="hu"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1153,6 +1152,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="hu"
                 >
                   magyar
                 </span>
@@ -1165,7 +1165,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="mt"
-                lang="mt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1174,6 +1173,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="mt"
                 >
                   Malti
                 </span>
@@ -1186,7 +1186,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="nl"
-                lang="nl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1195,6 +1194,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="nl"
                 >
                   Nederlands
                 </span>
@@ -1207,7 +1207,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="pl"
-                lang="pl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1216,6 +1215,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="pl"
                 >
                   polski
                 </span>
@@ -1228,7 +1228,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="pt"
-                lang="pt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1237,6 +1236,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="pt"
                 >
                   português
                 </span>
@@ -1249,7 +1249,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ro"
-                lang="ro"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1258,6 +1257,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ro"
                 >
                   română
                 </span>
@@ -1270,7 +1270,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sk"
-                lang="sk"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1279,6 +1278,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sk"
                 >
                   slovenčina
                 </span>
@@ -1291,7 +1291,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sl"
-                lang="sl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1300,6 +1299,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sl"
                 >
                   slovenščina
                 </span>
@@ -1312,7 +1312,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="fi"
-                lang="fi"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1321,6 +1320,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="fi"
                 >
                   suomi
                 </span>
@@ -1333,7 +1333,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sv"
-                lang="sv"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1342,6 +1341,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sv"
                 >
                   svenska
                 </span>
@@ -1367,7 +1367,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ar"
-                lang="ar"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1376,6 +1375,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ar"
                 >
                   عَرَبِيّ
                 </span>
@@ -1388,7 +1388,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ca"
-                lang="ca"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1397,6 +1396,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ca"
                 >
                   Català
                 </span>
@@ -1409,7 +1409,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="is"
-                lang="is"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1418,6 +1417,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="is"
                 >
                   Íslenska
                 </span>
@@ -1430,7 +1430,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lb"
-                lang="lb"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1439,6 +1438,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lb"
                 >
                   Lëtzebuergesch
                 </span>
@@ -1451,7 +1451,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ja"
-                lang="ja"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1460,6 +1459,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ja"
                 >
                   日本語
                 </span>
@@ -1472,7 +1472,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="nb"
-                lang="nb"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1481,6 +1480,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="nb"
                 >
                   Norsk bokmål
                 </span>
@@ -1493,7 +1493,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ru"
-                lang="ru"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1502,6 +1501,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ru"
                 >
                   русский язык
                 </span>
@@ -1514,7 +1514,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="tr"
-                lang="tr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1523,6 +1522,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="tr"
                 >
                   Türkçe
                 </span>
@@ -1535,7 +1535,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="uk"
-                lang="uk"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1544,6 +1543,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="uk"
                 >
                   українська мова
                 </span>
@@ -1556,7 +1556,6 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="zh"
-                lang="zh"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1565,6 +1564,7 @@ exports[`Splash page EC renders correctly with extra attributes 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="zh"
                 >
                   中文
                 </span>
@@ -1638,7 +1638,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="bg"
-                lang="bg"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1647,6 +1646,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="bg"
                 >
                   български
                 </span>
@@ -1659,7 +1659,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="es"
-                lang="es"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1668,6 +1667,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="es"
                 >
                   español
                 </span>
@@ -1680,7 +1680,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="cs"
-                lang="cs"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1689,6 +1688,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="cs"
                 >
                   čeština
                 </span>
@@ -1701,7 +1701,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="da"
-                lang="da"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1710,6 +1709,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="da"
                 >
                   dansk
                 </span>
@@ -1722,7 +1722,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="de"
-                lang="de"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1731,6 +1730,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="de"
                 >
                   Deutsch
                 </span>
@@ -1743,7 +1743,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="et"
-                lang="et"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1752,6 +1751,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="et"
                 >
                   eesti
                 </span>
@@ -1764,7 +1764,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="el"
-                lang="el"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1773,6 +1772,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="el"
                 >
                   ελληνικά
                 </span>
@@ -1785,7 +1785,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link ecl-splash-page__language-link--active"
                 href="/example"
                 hreflang="en"
-                lang="en"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1794,6 +1793,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="en"
                 >
                   English
                 </span>
@@ -1806,7 +1806,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="fr"
-                lang="fr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1815,6 +1814,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="fr"
                 >
                   français
                 </span>
@@ -1827,7 +1827,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ga"
-                lang="ga"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1836,6 +1835,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ga"
                 >
                   Gaeilge
                 </span>
@@ -1848,7 +1848,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="hr"
-                lang="hr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1857,6 +1856,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="hr"
                 >
                   hrvatski
                 </span>
@@ -1869,7 +1869,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="it"
-                lang="it"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1878,6 +1877,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="it"
                 >
                   italiano
                 </span>
@@ -1890,7 +1890,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lv"
-                lang="lv"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1899,6 +1898,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lv"
                 >
                   latviešu
                 </span>
@@ -1911,7 +1911,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lt"
-                lang="lt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1920,6 +1919,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lt"
                 >
                   lietuvių
                 </span>
@@ -1932,7 +1932,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="hu"
-                lang="hu"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1941,6 +1940,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="hu"
                 >
                   magyar
                 </span>
@@ -1953,7 +1953,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="mt"
-                lang="mt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1962,6 +1961,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="mt"
                 >
                   Malti
                 </span>
@@ -1974,7 +1974,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="nl"
-                lang="nl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -1983,6 +1982,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="nl"
                 >
                   Nederlands
                 </span>
@@ -1995,7 +1995,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="pl"
-                lang="pl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2004,6 +2003,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="pl"
                 >
                   polski
                 </span>
@@ -2016,7 +2016,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="pt"
-                lang="pt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2025,6 +2024,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="pt"
                 >
                   português
                 </span>
@@ -2037,7 +2037,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ro"
-                lang="ro"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2046,6 +2045,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ro"
                 >
                   română
                 </span>
@@ -2058,7 +2058,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sk"
-                lang="sk"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2067,6 +2066,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sk"
                 >
                   slovenčina
                 </span>
@@ -2079,7 +2079,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sl"
-                lang="sl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2088,6 +2087,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sl"
                 >
                   slovenščina
                 </span>
@@ -2100,7 +2100,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="fi"
-                lang="fi"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2109,6 +2108,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="fi"
                 >
                   suomi
                 </span>
@@ -2121,7 +2121,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sv"
-                lang="sv"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2130,6 +2129,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sv"
                 >
                   svenska
                 </span>
@@ -2155,7 +2155,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ar"
-                lang="ar"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2164,6 +2163,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ar"
                 >
                   عَرَبِيّ
                 </span>
@@ -2176,7 +2176,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ca"
-                lang="ca"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2185,6 +2184,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ca"
                 >
                   Català
                 </span>
@@ -2197,7 +2197,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="is"
-                lang="is"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2206,6 +2205,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="is"
                 >
                   Íslenska
                 </span>
@@ -2218,7 +2218,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lb"
-                lang="lb"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2227,6 +2226,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lb"
                 >
                   Lëtzebuergesch
                 </span>
@@ -2239,7 +2239,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ja"
-                lang="ja"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2248,6 +2247,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ja"
                 >
                   日本語
                 </span>
@@ -2260,7 +2260,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="nb"
-                lang="nb"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2269,6 +2268,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="nb"
                 >
                   Norsk bokmål
                 </span>
@@ -2281,7 +2281,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ru"
-                lang="ru"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2290,6 +2289,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ru"
                 >
                   русский язык
                 </span>
@@ -2302,7 +2302,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="tr"
-                lang="tr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2311,6 +2310,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="tr"
                 >
                   Türkçe
                 </span>
@@ -2323,7 +2323,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="uk"
-                lang="uk"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2332,6 +2331,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="uk"
                 >
                   українська мова
                 </span>
@@ -2344,7 +2344,6 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="zh"
-                lang="zh"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2353,6 +2352,7 @@ exports[`Splash page EC renders correctly with extra class names 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="zh"
                 >
                   中文
                 </span>
@@ -2426,7 +2426,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="bg"
-                lang="bg"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2435,6 +2434,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="bg"
                 >
                   български
                 </span>
@@ -2447,7 +2447,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="es"
-                lang="es"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2456,6 +2455,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="es"
                 >
                   español
                 </span>
@@ -2468,7 +2468,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="cs"
-                lang="cs"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2477,6 +2476,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="cs"
                 >
                   čeština
                 </span>
@@ -2489,7 +2489,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="da"
-                lang="da"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2498,6 +2497,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="da"
                 >
                   dansk
                 </span>
@@ -2510,7 +2510,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="de"
-                lang="de"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2519,6 +2518,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="de"
                 >
                   Deutsch
                 </span>
@@ -2531,7 +2531,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="et"
-                lang="et"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2540,6 +2539,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="et"
                 >
                   eesti
                 </span>
@@ -2552,7 +2552,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="el"
-                lang="el"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2561,6 +2560,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="el"
                 >
                   ελληνικά
                 </span>
@@ -2573,7 +2573,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link ecl-splash-page__language-link--active"
                 href="/example"
                 hreflang="en"
-                lang="en"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2582,6 +2581,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="en"
                 >
                   English
                 </span>
@@ -2594,7 +2594,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="fr"
-                lang="fr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2603,6 +2602,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="fr"
                 >
                   français
                 </span>
@@ -2615,7 +2615,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ga"
-                lang="ga"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2624,6 +2623,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ga"
                 >
                   Gaeilge
                 </span>
@@ -2636,7 +2636,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="hr"
-                lang="hr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2645,6 +2644,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="hr"
                 >
                   hrvatski
                 </span>
@@ -2657,7 +2657,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="it"
-                lang="it"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2666,6 +2665,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="it"
                 >
                   italiano
                 </span>
@@ -2678,7 +2678,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lv"
-                lang="lv"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2687,6 +2686,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lv"
                 >
                   latviešu
                 </span>
@@ -2699,7 +2699,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lt"
-                lang="lt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2708,6 +2707,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lt"
                 >
                   lietuvių
                 </span>
@@ -2720,7 +2720,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="hu"
-                lang="hu"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2729,6 +2728,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="hu"
                 >
                   magyar
                 </span>
@@ -2741,7 +2741,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="mt"
-                lang="mt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2750,6 +2749,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="mt"
                 >
                   Malti
                 </span>
@@ -2762,7 +2762,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="nl"
-                lang="nl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2771,6 +2770,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="nl"
                 >
                   Nederlands
                 </span>
@@ -2783,7 +2783,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="pl"
-                lang="pl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2792,6 +2791,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="pl"
                 >
                   polski
                 </span>
@@ -2804,7 +2804,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="pt"
-                lang="pt"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2813,6 +2812,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="pt"
                 >
                   português
                 </span>
@@ -2825,7 +2825,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ro"
-                lang="ro"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2834,6 +2833,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ro"
                 >
                   română
                 </span>
@@ -2846,7 +2846,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sk"
-                lang="sk"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2855,6 +2854,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sk"
                 >
                   slovenčina
                 </span>
@@ -2867,7 +2867,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sl"
-                lang="sl"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2876,6 +2875,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sl"
                 >
                   slovenščina
                 </span>
@@ -2888,7 +2888,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="fi"
-                lang="fi"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2897,6 +2896,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="fi"
                 >
                   suomi
                 </span>
@@ -2909,7 +2909,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="sv"
-                lang="sv"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2918,6 +2917,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="sv"
                 >
                   svenska
                 </span>
@@ -2943,7 +2943,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ar"
-                lang="ar"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2952,6 +2951,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ar"
                 >
                   عَرَبِيّ
                 </span>
@@ -2964,7 +2964,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ca"
-                lang="ca"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2973,6 +2972,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ca"
                 >
                   Català
                 </span>
@@ -2985,7 +2985,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="is"
-                lang="is"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -2994,6 +2993,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="is"
                 >
                   Íslenska
                 </span>
@@ -3006,7 +3006,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="lb"
-                lang="lb"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -3015,6 +3014,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="lb"
                 >
                   Lëtzebuergesch
                 </span>
@@ -3027,7 +3027,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ja"
-                lang="ja"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -3036,6 +3035,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ja"
                 >
                   日本語
                 </span>
@@ -3048,7 +3048,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="nb"
-                lang="nb"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -3057,6 +3056,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="nb"
                 >
                   Norsk bokmål
                 </span>
@@ -3069,7 +3069,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="ru"
-                lang="ru"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -3078,6 +3077,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="ru"
                 >
                   русский язык
                 </span>
@@ -3090,7 +3090,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="tr"
-                lang="tr"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -3099,6 +3098,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="tr"
                 >
                   Türkçe
                 </span>
@@ -3111,7 +3111,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="uk"
-                lang="uk"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -3120,6 +3119,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="uk"
                 >
                   українська мова
                 </span>
@@ -3132,7 +3132,6 @@ exports[`Splash page EU renders correctly 1`] = `
                 class="ecl-link ecl-link--standalone ecl-splash-page__language-link"
                 href="/example"
                 hreflang="zh"
-                lang="zh"
               >
                 <span
                   class="ecl-splash-page__language-link-code"
@@ -3141,6 +3140,7 @@ exports[`Splash page EU renders correctly 1`] = `
                 </span>
                 <span
                   class="ecl-splash-page__language-link-label"
+                  lang="zh"
                 >
                   中文
                 </span>

--- a/src/implementations/twig/components/splash-page/splash-page.html.twig
+++ b/src/implementations/twig/components/splash-page/splash-page.html.twig
@@ -126,7 +126,7 @@
           <li class="ecl-splash-page__language-item">
             {% set _link_label %}
               <span class="ecl-splash-page__language-link-code">{{ _item.lang|default('') }}</span>
-              <span class="ecl-splash-page__language-link-label">{{ _item.label }}</span>
+              <span class="ecl-splash-page__language-link-label" lang="{{ _item.lang|default('') }}">{{ _item.label }}</span>
             {% endset %}
             {% set _link_classes = 'ecl-splash-page__language-link' %}
             {% if _item.active %}
@@ -139,7 +139,6 @@
               }),
               extra_classes: _link_classes,
               extra_attributes: [
-                { name: 'lang', value: _item.lang|default('')|e('html_attr') },
                 { name: 'hreflang', value: _item.lang|default('')|e('html_attr') },
               ],
             } only %}
@@ -162,7 +161,7 @@
           <li class="ecl-splash-page__language-item">
           {% set _link_label %}
             <span class="ecl-splash-page__language-link-code">{{ _item.lang|default('') }}</span>
-            <span class="ecl-splash-page__language-link-label">{{ _item.label }}</span>
+            <span class="ecl-splash-page__language-link-label" lang="{{ _item.lang|default('') }}">{{ _item.label }}</span>
           {% endset %}
             {% set _link_classes = 'ecl-splash-page__language-link' %}
             {% if _item.active %}
@@ -175,7 +174,6 @@
               }),
               extra_classes: _link_classes,
               extra_attributes: [
-                { name: 'lang', value: _item.lang|default('') },
                 { name: 'hreflang', value: _item.lang|default('') },
               ],
             } only %}


### PR DESCRIPTION
- Set the "lang" on the element that is really using this language, instead of the whole link