### PR TITLE
feat(mega-menu): Adding blur handler on featured links - FRONT-4544

### DIFF
--- a/src/implementations/twig/components/mega-menu/__snapshots__/mega-menu.test.js.snap
+++ b/src/implementations/twig/components/mega-menu/__snapshots__/mega-menu.test.js.snap
@@ -383,6 +383,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -393,6 +394,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -948,6 +950,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -958,6 +961,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -1449,6 +1453,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -1459,6 +1464,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -2014,6 +2020,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -2024,6 +2031,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -2517,6 +2525,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -2527,6 +2536,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -3082,6 +3092,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -3092,6 +3103,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -3583,6 +3595,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -3593,6 +3606,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                   test-featured="testing value"
                                 >
@@ -4149,6 +4163,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -4159,6 +4174,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -4651,6 +4667,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -4661,6 +4678,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -5216,6 +5234,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -5226,6 +5245,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -5718,6 +5738,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -5728,6 +5749,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -6283,6 +6305,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -6293,6 +6316,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -6784,6 +6808,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -6794,6 +6819,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -7349,6 +7375,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -7359,6 +7386,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -7850,6 +7878,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -7860,6 +7889,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2
@@ -8415,6 +8445,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 1
@@ -8425,6 +8456,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
                               >
                                 <a
                                   class="ecl-link ecl-link--standalone"
+                                  data-ecl-mega-menu-featured-link=""
                                   href="/example"
                                 >
                                   Featured link 2

--- a/src/implementations/twig/components/mega-menu/mega-menu-item.html.twig
+++ b/src/implementations/twig/components/mega-menu/mega-menu-item.html.twig
@@ -346,7 +346,8 @@
               <li class="ecl-mega-menu__featured-list__item">
                 {% include '@ecl/link/link.html.twig' with {
                   link: item|merge({ type: 'standalone', icon_path: _icon_path }),
-                  extra_attributes: item.extra_attributes|default([]),
+                  extra_attributes: [{ name: 'data-ecl-mega-menu-featured-link' }]|merge(item.extra_attributes|default([])),
+                  extra_classes: item.extra_classes|default(''),
                 } only %}
               </li>
             {% endfor %}

--- a/src/implementations/vanilla/components/mega-menu/mega-menu.js
+++ b/src/implementations/vanilla/components/mega-menu/mega-menu.js
@@ -80,6 +80,7 @@ export class MegaMenu {
       containerSelector = '[data-ecl-has-container]',
       subItemSelector = '[data-ecl-mega-menu-subitem]',
       featuredAttribute = '[data-ecl-mega-menu-featured]',
+      featuredLinkAttribute = '[data-ecl-mega-menu-featured-link]',
       labelOpenAttribute = 'data-ecl-mega-menu-label-open',
       labelCloseAttribute = 'data-ecl-mega-menu-label-close',
       attachClickListener = true,
@@ -115,6 +116,7 @@ export class MegaMenu {
     this.attachKeyListener = attachKeyListener;
     this.attachResizeListener = attachResizeListener;
     this.featuredAttribute = featuredAttribute;
+    this.featuredLinkAttribute = featuredLinkAttribute;
 
     // Private variables
     this.direction = 'ltr';
@@ -136,6 +138,9 @@ export class MegaMenu {
     this.totalItemsWidth = 0;
     this.breakpointL = 996;
     this.openPanel = { num: 0, item: {} };
+    this.infoLinks = null;
+    this.seeAllLinks = null;
+    this.featuredLinks = null;
 
     // Bind `this` for use in callbacks
     this.handleClickOnOpen = this.handleClickOnOpen.bind(this);
@@ -230,19 +235,34 @@ export class MegaMenu {
       });
     }
 
-    const infoLinks = queryAll('.ecl-mega-menu__info-link   ', this.element);
-    if (infoLinks.length > 0) {
-      infoLinks.forEach((infoLink) => {
-        infoLink.addEventListener('keyup', this.handleKeyboard);
-        infoLink.addEventListener('blur', this.handleFocusOut);
+    this.infoLinks = queryAll('.ecl-mega-menu__info-link a', this.element);
+    if (this.infoLinks.length > 0) {
+      this.infoLinks.forEach((infoLink) => {
+        if (this.attachKeyListener) {
+          infoLink.addEventListener('keyup', this.handleKeyboard);
+        }
+        if (this.attachFocusListener) {
+          infoLink.addEventListener('blur', this.handleFocusOut);
+        }
       });
     }
 
-    const seeAllLinks = queryAll('.ecl-mega-menu__see-all a', this.element);
-    if (seeAllLinks.length > 0) {
-      seeAllLinks.forEach((seeAll) => {
-        seeAll.addEventListener('keyup', this.handleKeyboard);
-        seeAll.addEventListener('blur', this.handleFocusOut);
+    this.seeAllLinks = queryAll('.ecl-mega-menu__see-all a', this.element);
+    if (this.seeAllLinks.length > 0) {
+      this.seeAllLinks.forEach((seeAll) => {
+        if (this.attachKeyListener) {
+          seeAll.addEventListener('keyup', this.handleKeyboard);
+        }
+        if (this.attachFocusListener) {
+          seeAll.addEventListener('blur', this.handleFocusOut);
+        }
+      });
+    }
+
+    this.featuredLinks = queryAll(this.featuredLinkAttribute, this.element);
+    if (this.featuredLinks.length > 0 && this.attachFocusListener) {
+      this.featuredLinks.forEach((featured) => {
+        featured.addEventListener('blur', this.handleFocusOut);
       });
     }
 
@@ -363,6 +383,34 @@ export class MegaMenu {
         if (this.attachFocusListener && subLink) {
           subLink.removeEventListener('focusout', this.handleFocusOut);
         }
+      });
+    }
+
+    if (this.infoLinks) {
+      this.infoLinks.forEach((infoLink) => {
+        if (this.attachFocusListener) {
+          infoLink.removeEventListener('blur', this.handleFocusOut);
+        }
+        if (this.attachKeyListener) {
+          infoLink.removeEventListener('keyup', this.handleKeyboard);
+        }
+      });
+    }
+
+    if (this.seeAllLinks) {
+      this.seeAllLinks.forEach((seeAll) => {
+        if (this.attachFocusListener) {
+          seeAll.removeEventListener('blur', this.handleFocusOut);
+        }
+        if (this.attachKeyListener) {
+          seeAll.removeEventListener('keyup', this.handleKeyboard);
+        }
+      });
+    }
+
+    if (this.featuredLinks && this.attachFocusListener) {
+      this.featuredLinks.forEach((featuredLink) => {
+        featuredLink.removeEventListener('blur', this.handleFocusOut);
       });
     }
 


### PR DESCRIPTION
It seems this was the only use case in our demo where the trap would not activate, the featured links did not have any handler before, so the focus was simply moving out of the mega-menu, the handler has been added and now the focus goes back on the close button when reaching the last link in the featured column as well.