### PR TITLE
fix(banner): allows image to take full height - FRONT-4578

### DIFF
--- a/src/implementations/twig/components/banner/banner.story.js
+++ b/src/implementations/twig/components/banner/banner.story.js
@@ -334,6 +334,10 @@ const prepareData = (data, args) => {
     if (showDescription) clone.description = description;
   }
 
+  if (clone.picture) {
+    clone.picture.img.src = args.image;
+  }
+
   return clone;
 };
 

--- a/src/implementations/vanilla/components/banner/banner.scss
+++ b/src/implementations/vanilla/components/banner/banner.scss
@@ -77,6 +77,7 @@ $banner: null !default;
 
 .ecl-banner__image {
   display: block;
+  height: 100%;
   object-fit: cover;
   object-position: top;
   position: relative;
@@ -320,10 +321,13 @@ $banner: null !default;
 
   .ecl-banner__picture-container,
   .ecl-banner__video-container {
+    height: 100%;
     position: static;
   }
 
   .ecl-banner__picture {
+    display: block;
+    height: 100%;
     position: relative;
   }
 


### PR DESCRIPTION
Fix cases where the image is not tall enough to fill the banner. 
This could happen when the content is larger, and pushes the banner size