### PR TITLE
feat(separator): Adding new component - FRONT-4597

### DIFF
--- a/src/implementations/twig/components/separator/README.md
+++ b/src/implementations/twig/components/separator/README.md
@@ -1,0 +1,21 @@
+# ECL separator component
+
+npm package: `@ecl/twig-component-separator`
+
+### Parameters:
+
+- **"extra_classes"** (optional) (string) (default: '') Extra classes (space separated)
+- **"extra_attributes"** (optional) (array) (default: []) Extra attributes
+  - "name" (string) Attribute name, eg. 'data-test'
+  - "value" (string) Attribute value, eg: 'data-test-1'
+
+```shell
+npm install --save @ecl/twig-component-separator
+```
+
+### Example:
+
+<!-- prettier-ignore -->
+```twig
+{% include '@ecl/separator/separator.html.twig'  %}
+```

--- a/src/implementations/twig/components/separator/__snapshots__/separator.test.js.snap
+++ b/src/implementations/twig/components/separator/__snapshots__/separator.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Separator Default renders correctly 1`] = `
+<jest>
+  <hr
+    class="ecl-separator"
+  />
+</jest>
+`;
+
+exports[`Separator Default renders correctly with extra attributes 1`] = `
+<jest>
+  <hr
+    class="ecl-separator"
+    data-test="data-test-value"
+    data-test-1="data-test-value-1"
+  />
+</jest>
+`;
+
+exports[`Separator Default renders correctly with extra class names 1`] = `
+<jest>
+  <hr
+    class="ecl-separator custom-class custom-class--test"
+  />
+</jest>
+`;

--- a/src/implementations/twig/components/separator/package.json
+++ b/src/implementations/twig/components/separator/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ecl/twig-component-separator",
+  "author": "European Commission",
+  "license": "EUPL-1.2",
+  "version": "4.6.3",
+  "description": "ECL Separator",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@ecl/vanilla-component-separator": "4.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system",
+    "twig"
+  ]
+}

--- a/src/implementations/twig/components/separator/separator.html.twig
+++ b/src/implementations/twig/components/separator/separator.html.twig
@@ -1,0 +1,39 @@
+{% apply spaceless %}
+
+{#
+  Parameters:
+  - "extra_classes" (optional) (string) (default: '') Extra classes (space separated) for the icon
+  - "extra_attributes" (optional) (array) (default: []) Extra attributes for icon
+    - "name" (string) Attribute name, eg. 'data-test'
+    - "value" (optional) (string) Attribute value, eg: 'data-test-1'
+#}
+
+{# Internal properties #}
+
+{% set _css_class = 'ecl-separator' %}
+{% set _extra_attributes = '' %}
+
+{# Internal logic - Process properties #}
+
+{% if extra_classes is defined and extra_classes is not empty %}
+  {% set _css_class = _css_class ~ ' ' ~ extra_classes %}
+{% endif %}
+
+{% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
+  {% for attr in extra_attributes %}
+    {% if attr.value is defined %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+    {% else %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+{# Print the result #}
+
+<hr
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+/>
+
+{% endapply %}

--- a/src/implementations/twig/components/separator/separator.story.js
+++ b/src/implementations/twig/components/separator/separator.story.js
@@ -29,6 +29,7 @@ Default.render = async () => {
     <ol class="ecl-ordered-list">
       <li class="ecl-ordered-list__item">Ordered list</li>
       <li class="ecl-ordered-list__item">Ordered list <ol>
+        <ol class="ecl-ordered-list">
           <li class="ecl-ordered-list__item">Nested ordered list</li>
           <li class="ecl-ordered-list__item">Nested ordered list</li>
         </ol>

--- a/src/implementations/twig/components/separator/separator.story.js
+++ b/src/implementations/twig/components/separator/separator.story.js
@@ -19,7 +19,7 @@ Default.render = async () => {
   const renderedSeparator = `<ul class="ecl-unordered-list">
       <li class="ecl-unordered-list__item">Unordered list</li>
       <li class="ecl-unordered-list__item">Unordered list 
-        <ul>
+        <ul class="ecl-unordered-list">
           <li class="ecl-unordered-list__item">Nested unordered list</li>
           <li class="ecl-unordered-list__item">Nested unordered list</li>
         </ul>

--- a/src/implementations/twig/components/separator/separator.story.js
+++ b/src/implementations/twig/components/separator/separator.story.js
@@ -1,0 +1,49 @@
+import { withNotes } from '@ecl/storybook-addon-notes';
+import withCode from '@ecl/storybook-addon-code';
+
+import separator from './separator.html.twig';
+import notes from './README.md';
+
+export default {
+  title: 'Components/Separator',
+  decorators: [withNotes, withCode],
+  parameters: {
+    controls: { disable: true },
+    parameters: { layout: 'fullscreen' },
+  },
+};
+
+export const Default = (_, { loaded: { component } }) => component;
+
+Default.render = async () => {
+  const renderedSeparator = `<ul class="ecl-unordered-list">
+      <li class="ecl-unordered-list__item">Unordered list</li>
+      <li class="ecl-unordered-list__item">Unordered list 
+        <ul>
+          <li class="ecl-unordered-list__item">Nested unordered list</li>
+          <li class="ecl-unordered-list__item">Nested unordered list</li>
+        </ul>
+      </li>
+    </ul>
+    ${await separator()}
+    <ol class="ecl-ordered-list">
+      <li class="ecl-ordered-list__item">Ordered list</li>
+      <li class="ecl-ordered-list__item">Ordered list <ol>
+          <li class="ecl-ordered-list__item">Nested ordered list</li>
+          <li class="ecl-ordered-list__item">Nested ordered list</li>
+        </ol>
+      </li>
+    </ol>
+    ${await separator()}
+    <dl class="ecl-description-list">
+      <dt class="ecl-description-list__term">Description term</dt>
+      <dd class="ecl-description-list__definition">Description definition</dd>
+      <dt class="ecl-description-list__term">Description term</dt>
+      <dd class="ecl-description-list__definition">Description definition</dd>
+    </dl>${await separator()}`;
+
+  return renderedSeparator;
+};
+
+Default.storyName = 'default';
+Default.parameters = { notes: { markdown: notes } };

--- a/src/implementations/twig/components/separator/separator.test.js
+++ b/src/implementations/twig/components/separator/separator.test.js
@@ -1,0 +1,46 @@
+import { renderTwigFileAsNode, renderTwigFileAsHtml } from '@ecl/test-utils';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);
+
+describe('Separator', () => {
+  const template = '@ecl/separator/separator.html.twig';
+  const render = (params) => renderTwigFileAsNode(template, params);
+
+  describe('Default', () => {
+    test('renders correctly', () => {
+      expect.assertions(1);
+
+      return expect(render()).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra class names', () => {
+      expect.assertions(1);
+
+      const withExtraClasses = {
+        extra_classes: 'custom-class custom-class--test',
+      };
+
+      return expect(render(withExtraClasses)).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra attributes', () => {
+      expect.assertions(1);
+
+      const withExtraAttributes = {
+        extra_attributes: [
+          { name: 'data-test', value: 'data-test-value' },
+          { name: 'data-test-1', value: 'data-test-value-1' },
+        ],
+      };
+
+      return expect(render(withExtraAttributes)).resolves.toMatchSnapshot();
+    });
+
+    test(`passes the accessibility tests`, async () => {
+      expect(
+        await axe(await renderTwigFileAsHtml(template, {}, true)),
+      ).toHaveNoViolations();
+    });
+  });
+});

--- a/src/implementations/twig/utilities/html-tag/index.story.js
+++ b/src/implementations/twig/utilities/html-tag/index.story.js
@@ -49,7 +49,7 @@ export const Default = () => `
           </ul>
         </li>
       </ul>
-      <br />
+      <hr />
       <ol>
         <li>Ordered list</li>
         <li>Ordered list

--- a/src/implementations/vanilla/components/separator/README.md
+++ b/src/implementations/vanilla/components/separator/README.md
@@ -1,0 +1,1 @@
+# ECL Separator

--- a/src/implementations/vanilla/components/separator/package.json
+++ b/src/implementations/vanilla/components/separator/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ecl/vanilla-component-separator",
+  "author": "European Commission",
+  "license": "EUPL-1.2",
+  "version": "4.6.3",
+  "description": "ECL Separator",
+  "style": "separator.scss",
+  "sass": "separator.scss",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ec-europa/europa-component-library.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ec-europa/europa-component-library/issues"
+  },
+  "homepage": "https://github.com/ec-europa/europa-component-library",
+  "keywords": [
+    "ecl",
+    "europa-component-library",
+    "design-system"
+  ]
+}

--- a/src/implementations/vanilla/components/separator/separator-print.scss
+++ b/src/implementations/vanilla/components/separator/separator-print.scss
@@ -1,0 +1,15 @@
+/**
+ * Separator print
+ * @define separator
+ */
+
+@use 'sass:map';
+
+// Exposed variables
+$theme: null !default;
+
+.ecl-separator,
+%ecl-separator {
+  border-top: 1px solid var(--c-n);
+  margin: map.get($theme, 'spacing-print', 'xs') 0;
+}

--- a/src/implementations/vanilla/components/separator/separator-print.scss
+++ b/src/implementations/vanilla/components/separator/separator-print.scss
@@ -7,9 +7,10 @@
 
 // Exposed variables
 $theme: null !default;
+$separator: null !default;
 
 .ecl-separator,
 %ecl-separator {
-  border-top: 1px solid var(--c-n);
+  border-top: 1px solid map.get($separator, 'color');
   margin: map.get($theme, 'spacing-print', 'xs') 0;
 }

--- a/src/implementations/vanilla/components/separator/separator.scss
+++ b/src/implementations/vanilla/components/separator/separator.scss
@@ -5,9 +5,12 @@
 
 @use 'sass:map';
 
+// Exposed variables
+$separator: null !default;
+
 .ecl-separator,
 %ecl-separator {
   border-width: 0;
-  border-top: 1px solid var(--c-n);
+  border-top: 1px solid map.get($separator, 'color');
   margin: var(--s-xs) 0;
 }

--- a/src/implementations/vanilla/components/separator/separator.scss
+++ b/src/implementations/vanilla/components/separator/separator.scss
@@ -1,0 +1,13 @@
+/**
+ * Separator
+ * @define separator
+ */
+
+@use 'sass:map';
+
+.ecl-separator,
+%ecl-separator {
+  border-width: 0;
+  border-top: 1px solid var(--c-n);
+  margin: var(--s-xs) 0;
+}

--- a/src/presets/ec/src/ec-default-print.scss
+++ b/src/presets/ec/src/ec-default-print.scss
@@ -28,6 +28,9 @@
   $theme: theme.$theme,
   $list: var.$list
 );
+@use '@ecl/vanilla-component-separator/separator-print' with (
+  $theme: theme.$theme
+);
 @use '@ecl/vanilla-component-table/table-print' with (
   $theme: theme.$theme,
   $table: var.$table
@@ -146,6 +149,10 @@ html {
 .ecl dd:not([class*='ecl-'], [class*='wt-']),
 .ecl dd:is([class*='ecl-u-']) {
   @extend %ecl-description-list__definition;
+}
+
+.ecl hr:not([class*='ecl-']) {
+  @extend %ecl-separator;
 }
 
 .ecl table:not([class*='ecl-'], [class*='wt-']),

--- a/src/presets/ec/src/ec-default-print.scss
+++ b/src/presets/ec/src/ec-default-print.scss
@@ -29,7 +29,8 @@
   $list: var.$list
 );
 @use '@ecl/vanilla-component-separator/separator-print' with (
-  $theme: theme.$theme
+  $theme: theme.$theme,
+  $separator: var.$separator
 );
 @use '@ecl/vanilla-component-table/table-print' with (
   $theme: theme.$theme,

--- a/src/presets/ec/src/ec-default.scss
+++ b/src/presets/ec/src/ec-default.scss
@@ -26,7 +26,9 @@
   $theme: theme.$theme,
   $list: var.$list
 );
-@use '@ecl/vanilla-component-separator/separator';
+@use '@ecl/vanilla-component-separator/separator' with (
+  $separator: var.$separator
+);
 @use '@ecl/vanilla-component-table/table' with (
   $theme: theme.$theme,
   $table: var.$table

--- a/src/presets/ec/src/ec-default.scss
+++ b/src/presets/ec/src/ec-default.scss
@@ -26,6 +26,7 @@
   $theme: theme.$theme,
   $list: var.$list
 );
+@use '@ecl/vanilla-component-separator/separator';
 @use '@ecl/vanilla-component-table/table' with (
   $theme: theme.$theme,
   $table: var.$table
@@ -80,6 +81,10 @@
 .ecl h6:not([class*='ecl-'], [class*='wt-']),
 .ecl h6:is([class*='ecl-u-']) {
   @extend %ecl-heading-6;
+}
+
+.ecl hr:not([class*='ecl-']) {
+  @extend %ecl-separator;
 }
 
 .ecl p:not([class*='ecl-'], [class*='wt-']),

--- a/src/presets/ec/src/ec-print.scss
+++ b/src/presets/ec/src/ec-print.scss
@@ -125,7 +125,8 @@
 @use '@ecl/vanilla-component-pagination/pagination-print';
 @use '@ecl/vanilla-component-popover/popover-print';
 @use '@ecl/vanilla-component-separator/separator-print' with (
-  $theme: theme.$theme
+  $theme: theme.$theme,
+  $separator: var.$separator
 );
 @use '@ecl/vanilla-component-search-form/search-form-print';
 @use '@ecl/vanilla-component-social-media-follow/social-media-follow-print' with (

--- a/src/presets/ec/src/ec-print.scss
+++ b/src/presets/ec/src/ec-print.scss
@@ -124,6 +124,9 @@
 );
 @use '@ecl/vanilla-component-pagination/pagination-print';
 @use '@ecl/vanilla-component-popover/popover-print';
+@use '@ecl/vanilla-component-separator/separator-print' with (
+  $theme: theme.$theme
+);
 @use '@ecl/vanilla-component-search-form/search-form-print';
 @use '@ecl/vanilla-component-social-media-follow/social-media-follow-print' with (
   $theme: theme.$theme,

--- a/src/presets/ec/src/ec.scss
+++ b/src/presets/ec/src/ec.scss
@@ -80,7 +80,9 @@
   $theme: theme.$theme,
   $notification: var.$notification
 );
-@use '@ecl/vanilla-component-separator/separator';
+@use '@ecl/vanilla-component-separator/separator' with (
+  $separator: var.$separator
+);
 @use '@ecl/vanilla-component-spinner/spinner' with (
   $theme: theme.$theme,
   $spinner: var.$spinner

--- a/src/presets/ec/src/ec.scss
+++ b/src/presets/ec/src/ec.scss
@@ -80,6 +80,7 @@
   $theme: theme.$theme,
   $notification: var.$notification
 );
+@use '@ecl/vanilla-component-separator/separator';
 @use '@ecl/vanilla-component-spinner/spinner' with (
   $theme: theme.$theme,
   $spinner: var.$spinner

--- a/src/presets/eu/src/eu-default-print.scss
+++ b/src/presets/eu/src/eu-default-print.scss
@@ -29,7 +29,8 @@
   $list: var.$list
 );
 @use '@ecl/vanilla-component-separator/separator-print' with (
-  $theme: theme.$theme
+  $theme: theme.$theme,
+  $separator: var.$separator
 );
 @use '@ecl/vanilla-component-table/table-print' with (
   $theme: theme.$theme,

--- a/src/presets/eu/src/eu-default-print.scss
+++ b/src/presets/eu/src/eu-default-print.scss
@@ -28,6 +28,9 @@
   $theme: theme.$theme,
   $list: var.$list
 );
+@use '@ecl/vanilla-component-separator/separator-print' with (
+  $theme: theme.$theme
+);
 @use '@ecl/vanilla-component-table/table-print' with (
   $theme: theme.$theme,
   $table: var.$table
@@ -92,6 +95,10 @@ html {
 .ecl p:not([class*='ecl-'], [class*='wt-']),
 .ecl p:is([class*='ecl-u-']) {
   @extend %ecl-paragraph;
+}
+
+.ecl hr:not([class*='ecl-']) {
+  @extend %ecl-separator;
 }
 
 .ecl ul:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),

--- a/src/presets/eu/src/eu-default.scss
+++ b/src/presets/eu/src/eu-default.scss
@@ -26,7 +26,9 @@
   $theme: theme.$theme,
   $list: var.$list
 );
-@use '@ecl/vanilla-component-separator/separator';
+@use '@ecl/vanilla-component-separator/separator' with (
+  $separator: var.$separator
+);
 @use '@ecl/vanilla-component-table/table' with (
   $theme: theme.$theme,
   $table: var.$table

--- a/src/presets/eu/src/eu-default.scss
+++ b/src/presets/eu/src/eu-default.scss
@@ -26,6 +26,7 @@
   $theme: theme.$theme,
   $list: var.$list
 );
+@use '@ecl/vanilla-component-separator/separator';
 @use '@ecl/vanilla-component-table/table' with (
   $theme: theme.$theme,
   $table: var.$table
@@ -80,6 +81,10 @@
 .ecl h6:not([class*='ecl-'], [class*='wt-']),
 .ecl h6:is([class*='ecl-u-']) {
   @extend %ecl-heading-6;
+}
+
+.ecl hr:not([class*='ecl-']) {
+  @extend %ecl-separator;
 }
 
 .ecl p:not([class*='ecl-'], [class*='wt-']),

--- a/src/presets/eu/src/eu-print.scss
+++ b/src/presets/eu/src/eu-print.scss
@@ -125,6 +125,9 @@
 @use '@ecl/vanilla-component-pagination/pagination-print';
 @use '@ecl/vanilla-component-popover/popover-print';
 @use '@ecl/vanilla-component-search-form/search-form-print';
+@use '@ecl/vanilla-component-separator/separator-print' with (
+  $theme: theme.$theme
+);
 @use '@ecl/vanilla-component-social-media-follow/social-media-follow-print' with (
   $theme: theme.$theme,
   $social-media-follow: var.$social-media-follow

--- a/src/presets/eu/src/eu-print.scss
+++ b/src/presets/eu/src/eu-print.scss
@@ -126,7 +126,8 @@
 @use '@ecl/vanilla-component-popover/popover-print';
 @use '@ecl/vanilla-component-search-form/search-form-print';
 @use '@ecl/vanilla-component-separator/separator-print' with (
-  $theme: theme.$theme
+  $theme: theme.$theme,
+  $separator: var.$separator
 );
 @use '@ecl/vanilla-component-social-media-follow/social-media-follow-print' with (
   $theme: theme.$theme,

--- a/src/presets/eu/src/eu.scss
+++ b/src/presets/eu/src/eu.scss
@@ -80,7 +80,9 @@
   $theme: theme.$theme,
   $notification: var.$notification
 );
-@use '@ecl/vanilla-component-separator/separator';
+@use '@ecl/vanilla-component-separator/separator' with (
+  $separator: var.$separator
+);
 @use '@ecl/vanilla-component-spinner/spinner' with (
   $theme: theme.$theme,
   $spinner: var.$spinner

--- a/src/presets/eu/src/eu.scss
+++ b/src/presets/eu/src/eu.scss
@@ -80,6 +80,7 @@
   $theme: theme.$theme,
   $notification: var.$notification
 );
+@use '@ecl/vanilla-component-separator/separator';
 @use '@ecl/vanilla-component-spinner/spinner' with (
   $theme: theme.$theme,
   $spinner: var.$spinner

--- a/src/themes/ec/_variables.scss
+++ b/src/themes/ec/_variables.scss
@@ -43,6 +43,7 @@
 @forward 'variables/rating-field';
 @forward 'variables/search-form';
 @forward 'variables/select';
+@forward 'variables/separator';
 @forward 'variables/site-footer';
 @forward 'variables/site-header';
 @forward 'variables/social-media-follow';

--- a/src/themes/ec/variables/_separator.scss
+++ b/src/themes/ec/variables/_separator.scss
@@ -1,0 +1,6 @@
+@use 'sass:map';
+@use '../index' as *;
+
+$separator: (
+  color: var(--c-n),
+);

--- a/src/themes/eu/_variables.scss
+++ b/src/themes/eu/_variables.scss
@@ -43,6 +43,7 @@
 @forward 'variables/rating-field';
 @forward 'variables/search-form';
 @forward 'variables/select';
+@forward 'variables/separator';
 @forward 'variables/site-footer';
 @forward 'variables/site-header';
 @forward 'variables/social-media-follow';

--- a/src/themes/eu/variables/_separator.scss
+++ b/src/themes/eu/variables/_separator.scss
@@ -1,0 +1,6 @@
+@use 'sass:map';
+@use '../index' as *;
+
+$separator: (
+  color: var(--c-p-20),
+);

--- a/src/website/public/admin/config.yml
+++ b/src/website/public/admin/config.yml
@@ -253,6 +253,11 @@ collections:
         file: 'src/website/src/pages/ec/components/forms/select/docs/usage.md'
         fields:
           - { label: Body, name: body, widget: markdown }
+      - label: 'Separator'
+        name: 'ec_separator'
+        file: 'src/website/src/pages/ec/components/separator/docs/usage.md'
+        fields:
+          - { label: Body, name: body, widget: markdown }
       - label: 'Site Header'
         name: 'ec_site_header'
         file: 'src/website/src/pages/ec/components/site-wide/site-header/docs/usage.md'
@@ -561,6 +566,11 @@ collections:
       - label: 'Select'
         name: 'eu_select'
         file: 'src/website/src/pages/eu/components/forms/select/docs/usage.md'
+        fields:
+          - { label: Body, name: body, widget: markdown }
+      - label: 'Separator'
+        name: 'eu_separator'
+        file: 'src/website/src/pages/eu/components/separator/docs/usage.md'
         fields:
           - { label: Body, name: body, widget: markdown }
       - label: 'Site Header'

--- a/src/website/src/pages/ec/components/separator/demo/index.js
+++ b/src/website/src/pages/ec/components/separator/demo/index.js
@@ -1,0 +1,4 @@
+import template from '@ecl/twig-component-separator/separator.html.twig';
+
+const separator = template();
+export default separator;

--- a/src/website/src/pages/ec/components/separator/docs/code.mdx
+++ b/src/website/src/pages/ec/components/separator/docs/code.mdx
@@ -1,0 +1,15 @@
+---
+title: Showcase
+order: 2
+---
+
+import { Playground, Html } from '@ecl/website-components';
+import separator from '../demo';
+
+<Playground
+  system="ec"
+  selectedKind="components-separator"
+  selectedStory="default"
+>
+  <Html markup={separator} />
+</Playground>

--- a/src/website/src/pages/ec/components/separator/docs/usage.md
+++ b/src/website/src/pages/ec/components/separator/docs/usage.md
@@ -1,0 +1,5 @@
+---
+title: Usage
+order: 1
+---
+

--- a/src/website/src/pages/ec/components/separator/index.md
+++ b/src/website/src/pages/ec/components/separator/index.md
@@ -1,0 +1,8 @@
+---
+title: Separator
+defaultTab: usage
+status: ready
+playground:
+  system: ec
+  path: /story/components-separator--default
+---

--- a/src/website/src/pages/eu/components/separator/demo/index.js
+++ b/src/website/src/pages/eu/components/separator/demo/index.js
@@ -1,0 +1,4 @@
+import template from '@ecl/twig-component-separator/separator.html.twig';
+
+const separator = template();
+export default separator;

--- a/src/website/src/pages/eu/components/separator/docs/code.mdx
+++ b/src/website/src/pages/eu/components/separator/docs/code.mdx
@@ -1,0 +1,15 @@
+---
+title: Showcase
+order: 2
+---
+
+import { Playground, Html } from '@ecl/website-components';
+import separator from '../demo';
+
+<Playground
+  system="eu"
+  selectedKind="components-separator"
+  selectedStory="default"
+>
+  <Html markup={separator} />
+</Playground>

--- a/src/website/src/pages/eu/components/separator/docs/usage.md
+++ b/src/website/src/pages/eu/components/separator/docs/usage.md
@@ -1,0 +1,4 @@
+---
+title: Usage
+order: 1
+---

--- a/src/website/src/pages/eu/components/separator/index.md
+++ b/src/website/src/pages/eu/components/separator/index.md
@@ -1,0 +1,8 @@
+---
+title: Separator
+defaultTab: usage
+status: ready
+playground:
+  system: eu
+  path: /story/components-separator--default
+---


### PR DESCRIPTION
Well, in the end i talked to EWPP to understand what to do and they are expecting a template, so i have added both a vanilla and a twig public packages.
The demo in storybook is showing the "separator" in a kind of real example with some content, in the website we show only the hr, instead.
An example has been added also to the html default tags story 