### PR TITLE
chore(twig): Harmonising syntax when rendering classes and attributes -- FRONT-4609

### DIFF
--- a/src/implementations/twig/components/accordion/accordion.html.twig
+++ b/src/implementations/twig/components/accordion/accordion.html.twig
@@ -53,7 +53,8 @@
 {# Print the result #}
 
 <div
-  class="{{ _css_class }}" {{ _extra_attributes|raw }}
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
   data-ecl-accordion
 >
   {% if _items is not empty %}

--- a/src/implementations/twig/components/banner/banner.html.twig
+++ b/src/implementations/twig/components/banner/banner.html.twig
@@ -137,7 +137,10 @@
 
 {# Print the result #}
 
-<section class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<section
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {# Media #}
   {% if _picture.img is not empty %}
     {# Image #}

--- a/src/implementations/twig/components/blockquote/blockquote.html.twig
+++ b/src/implementations/twig/components/blockquote/blockquote.html.twig
@@ -43,7 +43,10 @@
 
 {# Print the result #}
 
-<figure class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<figure
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {% if _picture is not empty and _picture.img is not empty %}
     {% include '@ecl/picture/picture.html.twig' with {
       picture: _picture,

--- a/src/implementations/twig/components/breadcrumb/breadcrumb.html.twig
+++ b/src/implementations/twig/components/breadcrumb/breadcrumb.html.twig
@@ -76,7 +76,10 @@
 
 {# Print the result #}
 
-<nav class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<nav
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <ol class="ecl-breadcrumb__container">
   {% if _links is not empty %}
     {% for key, link in _links %}

--- a/src/implementations/twig/components/button/button.html.twig
+++ b/src/implementations/twig/components/button/button.html.twig
@@ -89,7 +89,11 @@
 
 {# Print the result #}
 
-<button class="{{ _css_class }}" type="{{ _type }}" {{ _extra_attributes|raw }}>
+<button
+  class="{{ _css_class }}"
+  type="{{ _type }}"
+  {{ _extra_attributes|raw }}
+>
 {%- if _icons is defined %}
   <span class="ecl-button__container">
   {% if _icon_position == 'before' %}

--- a/src/implementations/twig/components/card/card.html.twig
+++ b/src/implementations/twig/components/card/card.html.twig
@@ -57,7 +57,10 @@
 
 {# Print the result #}
 
-<article class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<article
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
 {% if _picture is not empty and _picture.img is not empty %}
   {% set _picture_extra_attrs = _picture.extra_attributes|default([]) %}
   {% if _title.link is defined %}

--- a/src/implementations/twig/components/category-filter/category-filter-items.html.twig
+++ b/src/implementations/twig/components/category-filter/category-filter-items.html.twig
@@ -61,7 +61,10 @@
     {% endif %}
     <li class="ecl-category-filter__list-item">
       {%- if _has_children -%}
-        <button class="{{ _item_class }}" {{ _extra_attributes|raw }}>
+        <button
+          class="{{ _item_class }}"
+          {{ _extra_attributes|raw }}
+        >
           {%- if _level != 1 -%}
             {% include '@ecl/icon/icon.html.twig' with {
               icon: {

--- a/src/implementations/twig/components/checkbox/checkbox-item.html.twig
+++ b/src/implementations/twig/components/checkbox/checkbox-item.html.twig
@@ -71,7 +71,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <input
     name="{{ _name }}"
     class="ecl-checkbox__input"

--- a/src/implementations/twig/components/date-block/date-block.html.twig
+++ b/src/implementations/twig/components/date-block/date-block.html.twig
@@ -58,7 +58,10 @@
     {% set _extra_attributes = _extra_attributes ~ ' datetime="' ~ _date_time|e('html_attr') ~ '"' %}
   {% endif %}
 
-  <time class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+  <time
+    class="{{ _css_class }}"
+    {{ _extra_attributes|raw }}
+  >
   {% if _date_time is not empty %}
     <span class="ecl-date-block__daytime">{{ _date_time }}</span>
   {% endif %}

--- a/src/implementations/twig/components/description-list/description-list.html.twig
+++ b/src/implementations/twig/components/description-list/description-list.html.twig
@@ -63,7 +63,10 @@
 {# Print the result #}
 
 {% if _items is not empty and _items is iterable %}
-  <dl class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+  <dl
+    class="{{ _css_class }}"
+    {{ _extra_attributes|raw }}
+  >
     {% for _item in _items %}
       {% if _item.term is not empty %}
         {% if _item.term is iterable %}

--- a/src/implementations/twig/components/expandable/expandable.html.twig
+++ b/src/implementations/twig/components/expandable/expandable.html.twig
@@ -58,7 +58,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {% set _label = _label_collapsed %}
   {% set _button_attributes = [
     { name: 'aria-controls', value: _aria_controls },

--- a/src/implementations/twig/components/fact-figures/fact-figures.html.twig
+++ b/src/implementations/twig/components/fact-figures/fact-figures.html.twig
@@ -63,7 +63,10 @@
   {% endfor %}
 {% endif %}
 
-<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
 
 {% if items is defined and items is not empty and items is iterable %}
   <div class="ecl-fact-figures__items">

--- a/src/implementations/twig/components/featured-item/featured-item.html.twig
+++ b/src/implementations/twig/components/featured-item/featured-item.html.twig
@@ -63,7 +63,10 @@
 
 {# Print the result #}
 
-<article class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<article
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <div class="{{ _css_container_class }}">
     <div class="ecl-featured-item__item">
     {% if _title is not empty %}

--- a/src/implementations/twig/components/file/file.html.twig
+++ b/src/implementations/twig/components/file/file.html.twig
@@ -105,7 +105,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <div class="ecl-file__container">
   {% if _variant == 'default' %}
     {% include '@ecl/icon/icon.html.twig' with {

--- a/src/implementations/twig/components/gallery/gallery-item.html.twig
+++ b/src/implementations/twig/components/gallery/gallery-item.html.twig
@@ -84,7 +84,10 @@
 
 {# Print the result #}
 
-<li class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<li
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <a
     href="{{ _media_href ?: _picture.img.src }}"
     data-ecl-gallery-item

--- a/src/implementations/twig/components/gallery/gallery-overlay.html.twig
+++ b/src/implementations/twig/components/gallery/gallery-overlay.html.twig
@@ -45,7 +45,10 @@
 
 {# Print the result #}
 
-<dialog class="{{ _css_class }}"{{ _extra_attributes|raw }} data-ecl-gallery-overlay
+<dialog
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+  data-ecl-gallery-overlay
 {% if _overlay.sr_overlay_label is defined and _overlay.sr_overlay_label is not empty %}
   aria-label="{{ _overlay.sr_overlay_label }}"
 {% endif %}

--- a/src/implementations/twig/components/gallery/gallery.html.twig
+++ b/src/implementations/twig/components/gallery/gallery.html.twig
@@ -119,7 +119,11 @@
 
 {# Print the result #}
 
-<section class="{{ _css_class }}" {{ _extra_attributes|raw }} data-ecl-gallery>
+<section
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+  data-ecl-gallery
+>
   <ul class="ecl-gallery__list">
     {% for _key, _item in _items %}
       {% set _item_class = '' %}

--- a/src/implementations/twig/components/inpage-navigation/inpage-navigation.html.twig
+++ b/src/implementations/twig/components/inpage-navigation/inpage-navigation.html.twig
@@ -51,7 +51,12 @@
 
 {# Print the result #}
 
-<nav class="{{ _css_class }}"{{ _extra_attributes|raw }} data-ecl-inpage-navigation="true" aria-labelledby="{{ _id }}">
+<nav
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+  data-ecl-inpage-navigation="true"
+  aria-labelledby="{{ _id }}"
+>
   <div class="ecl-inpage-navigation__title" id="{{ _id }}">{{ _title }}</div>
   {% set _button_attributes = '
       type="button"

--- a/src/implementations/twig/components/list-illustration/list-illustration-item.html.twig
+++ b/src/implementations/twig/components/list-illustration/list-illustration-item.html.twig
@@ -63,7 +63,10 @@
 
 {# Print the result #}
 
-<li class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<li
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {% if _picture.img is not empty %}
     {% include '@ecl/picture/picture.html.twig' with {
       picture: _picture,

--- a/src/implementations/twig/components/list-illustration/list-illustration.html.twig
+++ b/src/implementations/twig/components/list-illustration/list-illustration.html.twig
@@ -61,11 +61,14 @@
 {# Print the result #}
 
 {% if _items is not empty and _items is iterable %}
-  <ul class="{{ _css_class }}"{{ _extra_attributes|raw }}>
-    {%- for _item in _items %}
-      {% include '@ecl/list-illustration/list-illustration-item.html.twig' with _item only %}
-    {% endfor -%}
-  </ul>
+<ul
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
+  {%- for _item in _items %}
+    {% include '@ecl/list-illustration/list-illustration-item.html.twig' with _item only %}
+  {% endfor -%}
+</ul>
 {% endif %}
 
 {% endapply %}

--- a/src/implementations/twig/components/media-container/media-container.html.twig
+++ b/src/implementations/twig/components/media-container/media-container.html.twig
@@ -122,10 +122,12 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes|raw }} 
-  {% if _video_title is not empty and _embedded_media is not empty %}
-    data-ecl-media-container-video-title="{{ _video_title }}"
-  {% endif %}
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }} 
+{% if _video_title is not empty and _embedded_media is not empty %}
+  data-ecl-media-container-video-title="{{ _video_title }}"
+{% endif %}
 >
   <figure class="{{ _figure_class }}">
   {% if _embedded_media is not empty %}

--- a/src/implementations/twig/components/navigation-list/navigation-list-item.html.twig
+++ b/src/implementations/twig/components/navigation-list/navigation-list-item.html.twig
@@ -61,7 +61,10 @@
 {% endif %}
 
 {# Print the result #}
-<article class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<article
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
 {% if _picture.img is not empty %}
   {% include '@ecl/picture/picture.html.twig' with {
     picture: _picture,

--- a/src/implementations/twig/components/navigation-list/navigation-list.html.twig
+++ b/src/implementations/twig/components/navigation-list/navigation-list.html.twig
@@ -44,7 +44,10 @@
 {# Print the result #}
 
 {% if _items is not empty and _items is iterable %}
-  <div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+  <div
+    class="{{ _css_class }}"
+    {{ _extra_attributes|raw }}
+  >
     {%- for _item in _items %}
       {% include '@ecl/navigation-list/navigation-list-item.html.twig' with _item|merge({ border: _border }) only %}
     {% endfor -%}

--- a/src/implementations/twig/components/news-ticker/news-ticker.html.twig
+++ b/src/implementations/twig/components/news-ticker/news-ticker.html.twig
@@ -73,7 +73,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {% if _items is not empty and _items is iterable %}
   <div class="ecl-news-ticker__container">
     <div class="ecl-news-ticker__content">

--- a/src/implementations/twig/components/notification/notification.html.twig
+++ b/src/implementations/twig/components/notification/notification.html.twig
@@ -49,7 +49,12 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" data-ecl-notification role="alert"{{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  data-ecl-notification
+  role="alert"
+  {{ _extra_attributes|raw }}
+>
 {% if _variant == 'warning' and _icon is not empty and _icon.name is defined and _icon.name == 'warning' %}
   <span class="ecl-notification__icon-background"></span>
 {% endif %}

--- a/src/implementations/twig/components/ordered-list/ordered-list.html.twig
+++ b/src/implementations/twig/components/ordered-list/ordered-list.html.twig
@@ -52,7 +52,10 @@
 
   {# Print the result #}
   {% if _items is not empty %}
-    <ol class="{{ _css_class }}" {{ _extra_attributes|raw }}>
+    <ol
+      class="{{ _css_class }}"
+      {{ _extra_attributes|raw }}
+    >
       {% for _item in _items %}
         {% set _item_class = 'ecl-ordered-list__item' %}
 

--- a/src/implementations/twig/components/page-header/page-header.html.twig
+++ b/src/implementations/twig/components/page-header/page-header.html.twig
@@ -67,7 +67,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {% if _picture_background.img is not empty %}
     <div class="ecl-page-header__background-container" aria-hidden="true">
       {% include '@ecl/picture/picture.html.twig' with {

--- a/src/implementations/twig/components/pagination/pagination.html.twig
+++ b/src/implementations/twig/components/pagination/pagination.html.twig
@@ -41,7 +41,11 @@
 
 {# Print the result #}
 
-<nav class="{{ _css_class }}"{{ _extra_attributes|raw }} aria-label="{{ _label }}">
+<nav
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+  aria-label="{{ _label }}"
+>
   <ul class="ecl-pagination__list">
     {% for _item in _items %}
       <li class="ecl-pagination__item{{ _item.type ? ' ecl-pagination__item--' ~ _item.type }}">

--- a/src/implementations/twig/components/picture/picture.html.twig
+++ b/src/implementations/twig/components/picture/picture.html.twig
@@ -48,7 +48,10 @@
 
 {# Print the result #}
 
-<picture class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<picture
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {% if _picture.sources is not empty and _picture.sources is iterable %}
     {% for _source in _picture.sources %}
       {% if _source.media == 's' %}

--- a/src/implementations/twig/components/popover/popover.html.twig
+++ b/src/implementations/twig/components/popover/popover.html.twig
@@ -46,7 +46,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {% set _toggle_attributes = [
     { name: 'aria-controls', value: _id },
     { name: 'data-ecl-popover-toggle' },

--- a/src/implementations/twig/components/radio/radio-button.html.twig
+++ b/src/implementations/twig/components/radio/radio-button.html.twig
@@ -71,7 +71,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <input
   {% if _id %}
     id="{{ _id }}"

--- a/src/implementations/twig/components/search-form/search-form.html.twig
+++ b/src/implementations/twig/components/search-form/search-form.html.twig
@@ -44,7 +44,11 @@
 
 {# Print the result #}
 
-<form class="{{ _css_class }}" role="search"{{ _extra_attributes|raw }}>
+<form
+  class="{{ _css_class }}"
+  role="search"
+  {{ _extra_attributes|raw }}
+>
   {% if _text_input is not empty %}
     {% include '@ecl/form-group/form-group.html.twig' with {
       label: _label,

--- a/src/implementations/twig/components/site-footer/site-footer.html.twig
+++ b/src/implementations/twig/components/site-footer/site-footer.html.twig
@@ -55,7 +55,10 @@
 {% endif %}
 
 {# Print the result #}
-<footer class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<footer
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {# Main container #}
   <div class="ecl-container ecl-site-footer__container">
   {% for _row in _rows %}

--- a/src/implementations/twig/components/site-header/site-header.html.twig
+++ b/src/implementations/twig/components/site-header/site-header.html.twig
@@ -208,7 +208,10 @@
 
 {# Print the result #}
 
-<header class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<header
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <div class="ecl-site-header__inner">
     <div class="ecl-site-header__background">
       <div class="ecl-site-header__header">

--- a/src/implementations/twig/components/social-media-follow/social-media-follow.html.twig
+++ b/src/implementations/twig/components/social-media-follow/social-media-follow.html.twig
@@ -50,7 +50,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <p class="ecl-social-media-follow__description">{{ _description }}</p>
   {% if _links is not empty %}
     <ul class="ecl-social-media-follow__list">

--- a/src/implementations/twig/components/social-media-share/social-media-share.html.twig
+++ b/src/implementations/twig/components/social-media-share/social-media-share.html.twig
@@ -46,7 +46,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <p class="ecl-social-media-share__description">{{ _description }}</p>
   {% if _links is not empty %}
     <ul class="ecl-social-media-share__list">

--- a/src/implementations/twig/components/spinner/spinner.html.twig
+++ b/src/implementations/twig/components/spinner/spinner.html.twig
@@ -59,7 +59,11 @@
 {% if _overlay %}
 <div class="{{ _overlay_classes }}"></div>
 {% endif %}
-<div class="{{ _css_classes }}" {{ _extra_attributes|raw }} role="alert">
+<div
+  class="{{ _css_classes }}"
+  {{ _extra_attributes|raw }}
+  role="alert"
+>
   <svg class="ecl-spinner__loader" viewBox="25 25 50 50">
     <circle
       class="ecl-spinner__circle"

--- a/src/implementations/twig/components/splash-page/splash-page.html.twig
+++ b/src/implementations/twig/components/splash-page/splash-page.html.twig
@@ -66,7 +66,10 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {# Logo #}
   {% if _logo is not empty and _logo.src_desktop is not empty %}
     <div class="ecl-splash-page__logo-container">

--- a/src/implementations/twig/components/table/table.html.twig
+++ b/src/implementations/twig/components/table/table.html.twig
@@ -99,7 +99,11 @@
 {# Print the result #}
 
 <div class="ecl-table-responsive">
-  <table class="{{ _css_class }}" id="{{ _id }}" {{ _extra_attributes|raw }}>
+  <table
+    class="{{ _css_class }}"
+    id="{{ _id }}"
+    {{ _extra_attributes|raw }}
+  >
     {% if _caption is not empty %}
     <caption class="ecl-table__caption">{{ _caption }}</caption>
     {% endif %}

--- a/src/implementations/twig/components/tabs/tabs.html.twig
+++ b/src/implementations/twig/components/tabs/tabs.html.twig
@@ -63,7 +63,10 @@
 {# Print the result #}
 
 {% if _items is not empty and _items is iterable %}
-<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<div
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   <div class="ecl-tabs__container">
     <div class="ecl-tabs__list" role="tablist">
       {% for _item in _items %}

--- a/src/implementations/twig/components/tag/tag-set.html.twig
+++ b/src/implementations/twig/components/tag/tag-set.html.twig
@@ -36,7 +36,10 @@
 {# Print the result #}
 
 {% if _items is not empty and _items is iterable %}
-  <ul class="{{ _css_class }}" {{ _extra_attributes|raw }}>
+  <ul 
+    class="{{ _css_class }}"
+    {{ _extra_attributes|raw }}
+  >
     {%- for _item in _items %}
       <li class="ecl-tag-set__item">
         {% include '@ecl/tag/tag.html.twig' with _item|merge({

--- a/src/implementations/twig/components/tag/tag.html.twig
+++ b/src/implementations/twig/components/tag/tag.html.twig
@@ -69,7 +69,11 @@
 {# Print the result #}
 
 {% if _tag.type == 'removable' %}
-  <button type="button" class="{{ _css_class }}" {{ _extra_attributes|raw }}>
+  <button
+    type="button"
+    class="{{ _css_class }}"
+    {{ _extra_attributes|raw }}
+  >
     {{- _tag.label -}}
     <span class="ecl-tag__icon">
       {% include '@ecl/icon/icon.html.twig' with {
@@ -83,7 +87,11 @@
     </span>
   </button>
 {% else %}
-  <a href="{{ _tag.path }}" class="{{ _css_class }}" {{ _extra_attributes|raw }}>
+  <a
+    href="{{ _tag.path }}"
+    class="{{ _css_class }}"
+    {{ _extra_attributes|raw }}
+  >
     {{- _tag.label -}}
     {%- if _tag.external -%}
       {%- include '@ecl/icon/icon.html.twig' with {

--- a/src/implementations/twig/components/timeline/timeline.html.twig
+++ b/src/implementations/twig/components/timeline/timeline.html.twig
@@ -62,7 +62,10 @@ Parameters:
 {% endif %}
 
 {# Print the result #}
-<ol class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+<ol
+  class="{{ _css_class }}"
+  {{ _extra_attributes|raw }}
+>
   {% if _items is not empty %}
     {% for _item in _items %}
       {# Decide on per item if it should display. #}

--- a/src/implementations/twig/components/unordered-list/unordered-list.html.twig
+++ b/src/implementations/twig/components/unordered-list/unordered-list.html.twig
@@ -53,7 +53,10 @@
 
   {# Print the result #}
   {% if _items is not empty %}
-    <ul class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+    <ul
+      class="{{ _css_class }}"
+      {{ _extra_attributes|raw }}
+    >
       {% for _item in _items %}
         {% set _item_class = 'ecl-unordered-list__item' %}
 


### PR DESCRIPTION
As it can be seen, these has 0 consequences on our tests, but this solution has been tested on platform side to ensure that a whitespace is present and it was confirmed it works ;)