### PR TITLE
feat(templates): Removing trailing slashes from void elements - FRONT-4612

### DIFF
--- a/src/implementations/twig/components/checkbox/checkbox-item.html.twig
+++ b/src/implementations/twig/components/checkbox/checkbox-item.html.twig
@@ -89,7 +89,7 @@
   {% if _required %}
     required
   {% endif %}
-  />
+  >
   <label
     {% if _id %}
       for="{{ _id }}"

--- a/src/implementations/twig/components/content-item/content-item.html.twig
+++ b/src/implementations/twig/components/content-item/content-item.html.twig
@@ -117,7 +117,7 @@
           <source srcset="{{ _source.src }}" media="{{ _source.media|default('') }}" type="{{ _source.type|default('') }}">
         {% endfor %}
       {% endif %}
-      <img class="ecl-content-item__image" src="{{ _picture.img.src }}" alt="{{ _picture.img.alt|default('') }}" />
+      <img class="ecl-content-item__image" src="{{ _picture.img.src }}" alt="{{ _picture.img.alt|default('') }}">
     </picture>
   {% endif %}
   {% if _date is not empty %}

--- a/src/implementations/twig/components/file-upload/file-upload.html.twig
+++ b/src/implementations/twig/components/file-upload/file-upload.html.twig
@@ -92,7 +92,7 @@
   {% if _extra_attributes is not empty %}
     {{- _extra_attributes -}}
   {% endif %}
-  />
+  >
 
   <label
     class="ecl-file-upload__button-container"

--- a/src/implementations/twig/components/picture/picture.html.twig
+++ b/src/implementations/twig/components/picture/picture.html.twig
@@ -89,7 +89,7 @@
     {% if _lazy %}
       loading="lazy"
     {% endif %}
-  />
+  >
   {% endif %}
 </picture> 
 

--- a/src/implementations/twig/components/radio/radio-button.html.twig
+++ b/src/implementations/twig/components/radio/radio-button.html.twig
@@ -91,7 +91,7 @@
   {% if _required %}
     required
   {% endif %}
-  />
+  >
 
   <label
     class="{{ _label_css_class }}"

--- a/src/implementations/twig/components/range/range.html.twig
+++ b/src/implementations/twig/components/range/range.html.twig
@@ -100,7 +100,7 @@
   required
 {% endif %}
   {{ _extra_attributes|raw }}
-/>
+>
 
 <div class="ecl-range__bubble" data-ecl-range-bubble>
   <span class="ecl-range__value-bubble" data-ecl-range-value-current></span>

--- a/src/implementations/twig/components/rating-field/rating-field.html.twig
+++ b/src/implementations/twig/components/rating-field/rating-field.html.twig
@@ -68,7 +68,7 @@
       {% if _disabled %}
         disabled
       {% endif %}
-    />
+    >
     <label 
       class="ecl-rating-field__label" 
       for="{{ _item_id }}">

--- a/src/implementations/twig/components/separator/separator.html.twig
+++ b/src/implementations/twig/components/separator/separator.html.twig
@@ -34,6 +34,6 @@
 <hr
   class="{{ _css_class }}"
   {{ _extra_attributes|raw }}
-/>
+>
 
 {% endapply %}

--- a/src/implementations/twig/components/text-input/text-input.html.twig
+++ b/src/implementations/twig/components/text-input/text-input.html.twig
@@ -75,6 +75,6 @@
     required
   {% endif %}
     {{ _extra_attributes|raw }}
-  />
+  >
 
 {% endapply %}

--- a/src/implementations/twig/components/video/video.html.twig
+++ b/src/implementations/twig/components/video/video.html.twig
@@ -83,7 +83,7 @@
   {% if _source.src is defined and _source.src is not empty %}
     src="{{ _source.src }}"
   {% endif %}
-  />
+  >
   {% endfor %}
 {% endif %}
 
@@ -102,7 +102,7 @@
   {% if _track.src_lang is defined and _track.src_lang is not empty %}
     srclang="{{ _track.src_lang }}"
   {% endif %}
-  />
+  >
 
   {% endfor %}
 {% endif %}

--- a/src/implementations/twig/utilities/background/index.story.js
+++ b/src/implementations/twig/utilities/background/index.story.js
@@ -58,7 +58,7 @@ export const Custom = (args) => {
   }
   return `<p class='ecl-u-type-paragraph ${background}'>
       Sample text regular
-      <br />
+      <br>
       <strong>Sample text bold</strong>
     </p>
   `;

--- a/src/implementations/twig/utilities/html-tag/index.story.js
+++ b/src/implementations/twig/utilities/html-tag/index.story.js
@@ -16,13 +16,13 @@ export const Default = () => `
   <p class="ecl-u-type-paragraph">To see the following HTML tags styled with ECL, just activate the optional "ecl-${getSystem()}-default" or "ecl-${getSystem()}-default-print" css file in the "CSS resources" tab.</p>
   <details>
     <summary><strong>Link and button</strong></summary>
-    <br />
+    <br>
     <div class="ecl">
-      <a href="#">Link</a><br /><br />
+      <a href="#">Link</a><br><br>
       <button>Button</button>
     </div>
   </details>
-  <br />
+  <br>
   <details>
     <summary><strong>Typography</strong></summary>
     <div class="ecl">
@@ -35,10 +35,10 @@ export const Default = () => `
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce quis volutpat diam. Aliquam ac eleifend elit. Vivamus urna orci, vehicula nec sagittis et, facilisis a dolor. Mauris sed justo a sapien venenatis lobortis. Sed eu ornare nunc. Curabitur vitae est suscipit, mattis magna aliquam, scelerisque lorem. Aenean sem ex, dignissim eget justo vitae, fringilla dictum ligula.</p>
     </div>
   </details>
-  <br />
+  <br>
   <details>
     <summary><strong>Lists</strong></summary>
-    <br />
+    <br>
     <div class="ecl">
       <ul>
         <li>Unordered list</li>
@@ -67,10 +67,10 @@ export const Default = () => `
       </dl>
     </div>
   </details>
-  <br />
+  <br>
   <details>
     <summary><strong>Blockquote</strong></summary>
-    <br />
+    <br>
     <div class="ecl">
       <blockquote>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed efficitur vulputate venenatis.</p>
@@ -78,10 +78,10 @@ export const Default = () => `
       </blockquote>
     </div>
   </details>
-  <br />
+  <br>
   <details>
     <summary><strong>Table</strong></summary>
-    <br />
+    <br>
     <div class="ecl">
       <table>
         <thead>


### PR DESCRIPTION
Strangely enough, in our tests the trailing slash is still "rendered", not really sure what is adding it, in the rendered html in storybook i do not see them, so apparently it's not twing, but what instead?