### PR TITLE
fix(multiselect): Setting margin-top when there is a label and no helper text - FRONT-4640

### DIFF
--- a/src/implementations/vanilla/components/select/select.scss
+++ b/src/implementations/vanilla/components/select/select.scss
@@ -234,6 +234,10 @@ $select: null !default;
   position: relative;
   max-width: 100%;
 
+  .ecl-form-label + .ecl-select__container--hidden + & {
+    margin-top: var(--s-xs);
+  }
+
   .ecl-select__multiple-dropdown {
     background-color: map.get($select, 'multiple-dropdown-background-color');
     border: map.get($select, 'multiple-dropdown-border');


### PR DESCRIPTION
The multiselect seems the only one missing a spacing without the helper text, the other visually diffrerent one is the radio, but that is due to the padding we set for the single input, not sure whether we want to do something about it.