### PR TITLE
fix(datepicker): Parsing user input, use moment for custom formats, handle resize - FRONT-4643

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -27,14 +27,14 @@
   },
   {
     "path": "dist/packages/ec/scripts/ecl-ec.js",
-    "limit": "235 KB",
+    "limit": "240 KB",
     "webpack": false,
     "gzip": false,
     "brotli": false
   },
   {
     "path": "dist/packages/eu/scripts/ecl-eu.js",
-    "limit": "235 KB",
+    "limit": "240 KB",
     "webpack": false,
     "gzip": false,
     "brotli": false


### PR DESCRIPTION
A bit of context:

-  We were showing dates in this format: DD-MM-YYYY but only if the user picked a day from the calendar, if a user tried to enter a valid date in the requested format instead the resulting date would have been screwed because pikaday was still parsing it using its default format.
- So a parsing function has been added, if it's our default format we parse it directly to a string using DD-MM-YYYY, if it's a custom format we pass to moment.js the user input and see if returns a valid date in the chosen format.
- Additionally a resize listener has been added, we customise the styles of the drowpdown in mobile we are now also resetting those styles if the user resizes the window.

To test this simply type a date in the datepicker, it should pick up the right date.
To test the custom formats you would need to play with the story, set the autoInit() to false and manually initialising the component with a custom format passed as an option.