### PR TITLE
fix(language-list): Fixing styles - FRONT-4647

### DIFF
--- a/src/implementations/vanilla/components/site-header/_site-header-language-switcher.scss
+++ b/src/implementations/vanilla/components/site-header/_site-header-language-switcher.scss
@@ -78,6 +78,7 @@ $language-list: null !default;
   align-items: center;
   display: flex;
   justify-content: space-between;
+  padding-inline-start: var(--s-s);
 }
 
 .ecl-site-header__language-title {

--- a/src/implementations/vanilla/components/splash-page/splash-page.scss
+++ b/src/implementations/vanilla/components/splash-page/splash-page.scss
@@ -45,6 +45,7 @@ $language-list: null !default;
 .ecl-splash-page__language-title {
   font: map.get($language-list, 'header-font-mobile');
   margin: 0;
+  padding-inline-start: var(--s-s);
 }
 
 .ecl-splash-page__language-content {

--- a/src/themes/ec/variables/_language-list.scss
+++ b/src/themes/ec/variables/_language-list.scss
@@ -3,18 +3,18 @@
 
 $language-list: (
   color: var(--c-d),
-  container-padding: var(--s-3xl),
+  container-padding: var(--s-3xl) var(--s-3xl) var(--s-3xl) 28px,
   header-font-mobile: var(--f-l),
   header-font-desktop: var(--f-xl),
   content-margin-mobile: var(--s-s),
   content-margin-desktop: var(--s-s),
   category-title-font: var(--f-m),
   category-title-font-weight: map.get($font-weight, 'regular'),
-  category-title-padding: var(--s-l) 0 var(--s-xs),
+  category-title-padding: var(--s-l) 0 var(--s-xs) var(--s-s),
   category-separator: 1px solid var(--c-n),
   category-stack-margin: var(--s-s),
-  list-margin: 0 0 0 calc(-1 * var(--s-s)),
-  list-margin-rtl: calc(-1 * var(--s-s)) 0 0 0,
+  list-margin: 0,
+  list-margin-rtl: 0,
   item-padding: var(--s-xs) var(--s-s),
   code-color: var(--c-d),
   code-font-weight: map.get($font-weight, 'regular'),
@@ -25,7 +25,7 @@ $language-list: (
   item-active-shadow: none,
   item-width: 184px,
   column-spacing-before: var(--s-m),
-  column-spacing-after: calc(var(--s-m) + var(--s-s)),
+  column-spacing-after: var(--s-2xs),
 );
 $language-list-print: (
   container-padding: map.get($spacing-print, '3xl'),

--- a/src/themes/eu/variables/_language-list.scss
+++ b/src/themes/eu/variables/_language-list.scss
@@ -22,7 +22,7 @@ $language-list: (
   code-width: 30px,
   item-active-background: var(--c-p-10),
   item-active-color: var(--c-d-140),
-  item-active-shadow: inset 4px 0 0 0 var(--c-p),
+  item-active-shadow: none,
   item-width: 188px,
   column-spacing-before: var(--s-m),
   column-spacing-after: var(--s-m),

--- a/src/themes/eu/variables/_language-list.scss
+++ b/src/themes/eu/variables/_language-list.scss
@@ -3,18 +3,18 @@
 
 $language-list: (
   color: var(--c-d-140),
-  container-padding: var(--s-2xl) var(--s-l) var(--s-l),
+  container-padding: var(--s-2xl) var(--s-l) var(--s-l) var(--s-s),
   header-font-mobile: var(--f-p-l),
   header-font-desktop: var(--f-p-xl),
   content-margin-mobile: var(--s-m),
   content-margin-desktop: var(--s-m),
   category-title-font: var(--f-p-m),
   category-title-font-weight: map.get($font-weight, 'bold'),
-  category-title-padding: var(--s-l) 0 var(--s-xs),
+  category-title-padding: var(--s-l) 0 var(--s-xs) var(--s-s),
   category-separator: 1px solid var(--c-p-20),
   category-stack-margin: var(--s-s),
-  list-margin: 0 0 0 calc(-1 * var(--s-s)),
-  list-margin-rtl: calc(-1 * var(--s-s)) 0 0 0,
+  list-margin: 0,
+  list-margin-rtl: 0,
   item-padding: var(--s-s),
   code-color: var(--c-d-140),
   code-font-weight: map.get($font-weight, 'bold'),
@@ -25,7 +25,7 @@ $language-list: (
   item-active-shadow: inset 4px 0 0 0 var(--c-p),
   item-width: 188px,
   column-spacing-before: var(--s-m),
-  column-spacing-after: var(--s-xl),
+  column-spacing-after: var(--s-m),
 );
 $language-list-print: (
   container-padding: map.get($spacing-print, '3xl') map.get($spacing-print, 'l')


### PR DESCRIPTION
This triggered many more changes than expected, the truth is that the implementation was strictly following the design, even in terms of negative margins to reproduce questionable requirements.
Since we introduced overflow handling in the language list, this broke the styles, because effectively the list were pushed outside of the boundaries of their container.
Now the styles have changed, the lists do not have negative margins anymore and the container padding has been adapted in order to reproduce what we have in figma (i've only found the splash page specs and i used those), inclusing some changes in the spacing of the second column in desktop.
