### PR TITLE
fix(docs): Fix wrong API name class for Menu and MegaMenu - FRONT-4685

### DIFF
--- a/src/website/src/pages/ec/components/navigation/mega-menu/docs/api.mdx
+++ b/src/website/src/pages/ec/components/navigation/mega-menu/docs/api.mdx
@@ -28,7 +28,7 @@ Given you have 1 element with an attribute `data-ecl-mega-menu` on the page:
 
 ```js
 var elt = document.querySelector('[data-ecl-mega-menu]');
-var menu = new ECL.megaMenu(elt);
+var menu = new ECL.MegaMenu(elt);
 menu.init();
 ```
 

--- a/src/website/src/pages/ec/components/navigation/menu/docs/api.mdx
+++ b/src/website/src/pages/ec/components/navigation/menu/docs/api.mdx
@@ -35,7 +35,7 @@ Given you have 1 element with an attribute `data-ecl-menu` on the page:
 
 ```js
 var elt = document.querySelector('[data-ecl-menu]');
-var menu = new ECL.menu(elt);
+var menu = new ECL.Menu(elt);
 menu.init();
 ```
 

--- a/src/website/src/pages/eu/components/navigation/mega-menu/docs/api.mdx
+++ b/src/website/src/pages/eu/components/navigation/mega-menu/docs/api.mdx
@@ -28,7 +28,7 @@ Given you have 1 element with an attribute `data-ecl-mega-menu` on the page:
 
 ```js
 var elt = document.querySelector('[data-ecl-mega-menu]');
-var menu = new ECL.megaMenu(elt);
+var menu = new ECL.MegaMenu(elt);
 menu.init();
 ```
 

--- a/src/website/src/pages/eu/components/navigation/menu/docs/api.mdx
+++ b/src/website/src/pages/eu/components/navigation/menu/docs/api.mdx
@@ -28,7 +28,7 @@ Given you have 1 element with an attribute `data-ecl-menu` on the page:
 
 ```js
 var elt = document.querySelector('[data-ecl-menu]');
-var menu = new ECL.menu(elt);
+var menu = new ECL.Menu(elt);
 menu.init();
 ```
 


### PR DESCRIPTION
The current documentation has a typo in the current pages:  
https://ec.europa.eu/component-library/ec/components/navigation/mega-menu/api/
https://ec.europa.eu/component-library/eu/components/navigation/mega-menu/api/
https://ec.europa.eu/component-library/ec/components/navigation/menu/api/
https://ec.europa.eu/component-library/eu/components/navigation/menu/api/

That will render an error in the browser console due to the wrong class name failing in the manual way to initialize the menu.