### PR TITLE
fix(eu): Fixing commonJs export - FRONT-4776

### DIFF
--- a/src/presets/eu/ecl-builder.config.js
+++ b/src/presets/eu/ecl-builder.config.js
@@ -23,6 +23,7 @@ module.exports = {
       entry: path.resolve(__dirname, 'src/eu.js'),
       dest: path.resolve(outputFolder, 'scripts/ecl-eu.js'),
       options: {
+        format: 'iife',
         banner,
         moduleName: 'ECL',
         sourceMap: isProd ? false : 'inline',


### PR DESCRIPTION
To test this you can replace the script loaded in preview-head.html in the /src/playground/{ec or eu}.storybook folder, if there is no error in the console and the components are working it means that we fixed the issue.