### PR TITLE
fix(mega-menu): mega menu html validation - FRONT-4859

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -914,6 +914,8 @@ importers:
 
   src/layout/grid: {}
 
+  src/layout/headings: {}
+
   src/page-example/page-fact-sheet:
     dependencies:
       '@ecl/banner':

--- a/src/components/mega-menu/__snapshots__/mega-menu.test.js.snap
+++ b/src/components/mega-menu/__snapshots__/mega-menu.test.js.snap
@@ -14,7 +14,9 @@ exports[`Mega Menu Default renders correctly 1`] = `
   >
     <div
       class="ecl-mega-menu__overlay"
-    />
+    >
+       
+    </div>
     <div
       class="ecl-container ecl-mega-menu__container"
     >
@@ -361,7 +363,9 @@ exports[`Mega Menu Default renders correctly 1`] = `
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -965,7 +969,9 @@ exports[`Mega Menu Default renders correctly 1`] = `
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -1211,7 +1217,9 @@ exports[`Mega Menu Default renders correctly with external items in the first le
   >
     <div
       class="ecl-mega-menu__overlay"
-    />
+    >
+       
+    </div>
     <div
       class="ecl-container ecl-mega-menu__container"
     >
@@ -1558,7 +1566,9 @@ exports[`Mega Menu Default renders correctly with external items in the first le
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -2162,7 +2172,9 @@ exports[`Mega Menu Default renders correctly with external items in the first le
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -2410,7 +2422,9 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
   >
     <div
       class="ecl-mega-menu__overlay"
-    />
+    >
+       
+    </div>
     <div
       class="ecl-container ecl-mega-menu__container"
     >
@@ -2757,7 +2771,9 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -3361,7 +3377,9 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -3607,7 +3625,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
   >
     <div
       class="ecl-mega-menu__overlay"
-    />
+    >
+       
+    </div>
     <div
       class="ecl-container ecl-mega-menu__container"
     >
@@ -3954,7 +3974,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -4559,7 +4581,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -4805,7 +4829,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
   >
     <div
       class="ecl-mega-menu__overlay"
-    />
+    >
+       
+    </div>
     <div
       class="ecl-container ecl-mega-menu__container"
     >
@@ -5153,7 +5179,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -5757,7 +5785,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -6003,7 +6033,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the info 
   >
     <div
       class="ecl-mega-menu__overlay"
-    />
+    >
+       
+    </div>
     <div
       class="ecl-container ecl-mega-menu__container"
     >
@@ -6351,7 +6383,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the info 
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -6955,7 +6989,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the info 
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -7201,7 +7237,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
   >
     <div
       class="ecl-mega-menu__overlay"
-    />
+    >
+       
+    </div>
     <div
       class="ecl-container ecl-mega-menu__container"
     >
@@ -7549,7 +7587,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -8153,7 +8193,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -8399,7 +8441,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
   >
     <div
       class="ecl-mega-menu__overlay"
-    />
+    >
+       
+    </div>
     <div
       class="ecl-container ecl-mega-menu__container"
     >
@@ -8746,7 +8790,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -9351,7 +9397,9 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -9597,7 +9645,9 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
   >
     <div
       class="ecl-mega-menu__overlay"
-    />
+    >
+       
+    </div>
     <div
       class="ecl-container ecl-mega-menu__container"
     >
@@ -9944,7 +9994,9 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""
@@ -10548,7 +10600,9 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
                           <li
                             class="ecl-mega-menu__spacer"
                             data-ecl-mega-menu-subitem=""
-                          />
+                          >
+                             
+                          </li>
                           <li
                             class="ecl-mega-menu__subitem ecl-mega-menu__see-all"
                             data-ecl-mega-menu-subitem=""

--- a/src/components/mega-menu/__snapshots__/mega-menu.test.js.snap
+++ b/src/components/mega-menu/__snapshots__/mega-menu.test.js.snap
@@ -109,7 +109,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
             </a>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -582,7 +582,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -722,7 +722,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -1112,7 +1112,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-container"
             data-ecl-has-container=""
             data-ecl-mega-menu-item=""
@@ -1312,7 +1312,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
             </a>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -1785,7 +1785,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -1925,7 +1925,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -2315,7 +2315,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-container"
             data-ecl-has-container=""
             data-ecl-mega-menu-item=""
@@ -2517,7 +2517,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
             </a>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -2990,7 +2990,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -3130,7 +3130,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -3520,7 +3520,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-container"
             data-ecl-has-container=""
             data-ecl-mega-menu-item=""
@@ -3720,7 +3720,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
             </a>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -4194,7 +4194,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -4334,7 +4334,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -4724,7 +4724,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-container"
             data-ecl-has-container=""
             data-ecl-mega-menu-item=""
@@ -4924,7 +4924,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
             </a>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -5398,7 +5398,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -5538,7 +5538,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -5928,7 +5928,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-container"
             data-ecl-has-container=""
             data-ecl-mega-menu-item=""
@@ -6128,7 +6128,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the info 
             </a>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -6602,7 +6602,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the info 
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -6742,7 +6742,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the info 
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -7132,7 +7132,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the info 
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-container"
             data-ecl-has-container=""
             data-ecl-mega-menu-item=""
@@ -7332,7 +7332,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
             </a>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -7806,7 +7806,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -7946,7 +7946,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -8336,7 +8336,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-container"
             data-ecl-has-container=""
             data-ecl-mega-menu-item=""
@@ -8536,7 +8536,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
             </a>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -9010,7 +9010,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -9150,7 +9150,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -9540,7 +9540,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-container"
             data-ecl-has-container=""
             data-ecl-mega-menu-item=""
@@ -9740,7 +9740,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
             </a>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -10213,7 +10213,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -10353,7 +10353,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-children"
             data-ecl-has-children=""
             data-ecl-mega-menu-item=""
@@ -10743,7 +10743,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
             </div>
           </li>
           <li
-            aria-haspopup=""
+            aria-haspopup="true"
             class="ecl-mega-menu__item ecl-mega-menu__item--has-container"
             data-ecl-has-container=""
             data-ecl-mega-menu-item=""

--- a/src/components/mega-menu/mega-menu-item.html.twig
+++ b/src/components/mega-menu/mega-menu-item.html.twig
@@ -294,7 +294,7 @@
         </li>
       {% endfor %}
       {%- if _see_all and _see_all_label is not empty -%}
-        <li class="ecl-mega-menu__spacer" data-ecl-mega-menu-subitem></li>
+        <li class="ecl-mega-menu__spacer" data-ecl-mega-menu-subitem>&nbsp;</li>
         <li class="ecl-mega-menu__subitem ecl-mega-menu__see-all" data-ecl-mega-menu-subitem>
           {% include '@ecl/link/link.html.twig' with {
             link: {

--- a/src/components/mega-menu/mega-menu-item.html.twig
+++ b/src/components/mega-menu/mega-menu-item.html.twig
@@ -68,11 +68,11 @@
 {% if _item.container is defined and _item.container is not empty %}
   {% set _can_be_external = false %}
   {% set _menu_list_item_class = _menu_list_item_class ~ ' ecl-mega-menu__item--has-container' %}
-  {% set _menu_list_item_attributes = _menu_list_item_attributes ~ ' data-ecl-has-container aria-haspopup' %}
+  {% set _menu_list_item_attributes = _menu_list_item_attributes ~ ' data-ecl-has-container aria-haspopup="true"' %}
 {% endif %}
 
 {% if _item.children is defined and _item.children is not empty and _item.children is iterable %}
-  {% set _menu_list_item_attributes = _menu_list_item_attributes ~ ' data-ecl-has-children aria-haspopup' %}
+  {% set _menu_list_item_attributes = _menu_list_item_attributes ~ ' data-ecl-has-children aria-haspopup="true"' %}
   {% set _menu_list_item_class = _menu_list_item_class ~ ' ecl-mega-menu__item--has-children' %}
 {% endif %}
 

--- a/src/components/mega-menu/mega-menu-item.html.twig
+++ b/src/components/mega-menu/mega-menu-item.html.twig
@@ -249,7 +249,7 @@
         {% endif %}
         <li
           class="{{ _subitem_class }}"
-          {{ _subitem_attrs|raw }}
+          {{ ' ' ~ _subitem_attrs|raw }}
         >
         {%- if child.children is defined and child.children is not empty -%}
           {# Children, 2nd level #}

--- a/src/components/mega-menu/mega-menu.html.twig
+++ b/src/components/mega-menu/mega-menu.html.twig
@@ -102,7 +102,7 @@
   {%- endif -%}
   {{- _extra_attributes|raw -}}
 >
-  <div class="ecl-mega-menu__overlay"></div>
+  <div class="ecl-mega-menu__overlay">&nbsp;</div>
   <div class="ecl-container ecl-mega-menu__container">
     {% set _toggle_icon = {} %}
     {% if _toggle.icon is defined %}


### PR DESCRIPTION
Testing the snapshot we get from jest there is one remaining error:
Error: Attribute an-extra-attribute-for-the-featured-link not allowed on element [a](https://html.spec.whatwg.org/multipage/#the-a-element) at this point
and a few warning for the unneded trailing slash in void elements.
Both are twing specific behaviours, this is not happening in twig, php.

A space has been added in the subitems between classes and attributes, this is the other way around, in twing it is ok but in twig it generates invalid markup, this is visible in the validator's report on the commission's website: https://validator.w3.org/nu/?doc=https%3A%2F%2Fcommission.europa.eu%2Findex_en