### PR TITLE
fix(safari): Icon size in navigation list - FRONT-4877

### DIFF
--- a/src/components/navigation-list/navigation-list.scss
+++ b/src/components/navigation-list/navigation-list.scss
@@ -130,6 +130,7 @@ $navigation-list: null !default;
     width: 60px;
 
     .ecl-navigation-list__image {
+      aspect-ratio: auto;
       border: none;
       object-fit: contain;
       max-width: 100%;


### PR DESCRIPTION
This was done only in v4 in January.