### PR TITLE
fix(featured-item): Fixing text color when using the default css and markup inside the description - FRONT-4887

### DIFF
--- a/src/components/featured-item/featured-item.scss
+++ b/src/components/featured-item/featured-item.scss
@@ -157,11 +157,11 @@ $featured-item: null !default;
   .ecl-featured-item__description {
     color: map.get($featured-item, 'highlight', 'description', 'color');
 
-    .ecl & *,
-    .ecl & a:hover,
-    .ecl & a:focus-visible,
-    .ecl & a:visited,
-    .ecl & a:active {
+    .ecl *,
+    .ecl a:hover,
+    .ecl a:focus-visible,
+    .ecl a:visited,
+    .ecl a:active {
       color: map.get($featured-item, 'highlight', 'description', 'color');
     }
   }


### PR DESCRIPTION
To test this you can use this markup inside the description as in the example we got from ewpp: `<div class="ecl"><p><mark class="custom-highlight-marker-ecl">Lorem ipsum dolor sit amet, consectetur</mark> adipiscing elit. In et commodo mi. Duis laoreet, justo eget pretium facilisis, odio tellus pharetra metus, quis egestas augue elit id dolor. Praesent rhoncus sollicitudin bibendum. Fusce ut ligula ac mauris imperdiet tristique eu ut eros. Suspendisse scelerisque at enim nec rutrum. Ut malesuada aliquet odio, eu aliquet mi vestibulum ac. Nam ac ultrices ipsum.</p><p>Nulla facilisi. In ut dui tristique, sagittis <a href="https://example.com" class="ecl-link ecl-link--icon ecl-link--icon-after"><span class="ecl-link__label">diam a, imperdiet sapien. Duis aliquam est in tortor</span><svg class="ecl-icon ecl-icon--xs ecl-link__icon" focusable="false" aria-hidden="true" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="/themes/contrib/oe_theme/dist/ec/images/icons/sprites/icons.svg#external"></use></svg></a> eleifend scelerisque convallis sit amet nunc. Vivamus vel posuere leo, sit amet pharetra leo. Ut at nunc eros. In et erat vitae mi laoreet sagittis vitae non ex. Sed tincidunt, nulla nec ultrices tincidunt, tellus nisl congue odio, finibus aliquet augue tortor quis ex. Vivamus ut nisi risus. Etiam mol<strong><u>estie lectus ut mattis sagittis.</u></strong> Vivamus odio dolor, varius<em> vel auctor quis, egestas vel elit.</em> Fusce vel turpis erat. Curabitur ante leo, imperdiet non volutpat quis, porttitor vitae massa.</p></div>`