### PR TITLE
feat(typography): Adding values for tablet font styles - FRONT-4895

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -15,7 +15,7 @@
   },
   {
     "path": "dist/packages/eu/styles/ecl-eu.css",
-    "limit": "290 KB",
+    "limit": "295 KB",
     "webpack": false,
     "gzip": false,
     "brotli": false

--- a/src/themes/ec/_custom-properties.scss
+++ b/src/themes/ec/_custom-properties.scss
@@ -111,6 +111,41 @@
   --ecl-font-9xl: #{map.get($font, '9xl')};
   --ecl-font-10xl: #{map.get($font, '10xl')};
 
+  // font-size
+  --ecl-font-size-2xs: #{map.get($font-size, '2xs')};
+  --ecl-font-size-xs: #{map.get($font-size, 'xs')};
+  --ecl-font-size-s: #{map.get($font-size, 's')};
+  --ecl-font-size-m: #{map.get($font-size, 'm')};
+  --ecl-font-size-l: #{map.get($font-size, 'l')};
+  --ecl-font-size-xl: #{map.get($font-size, 'xl')};
+  --ecl-font-size-2xl: #{map.get($font-size, '2xl')};
+  --ecl-font-size-3xl: #{map.get($font-size, '3xl')};
+  --ecl-font-size-4xl: #{map.get($font-size, '4xl')};
+  --ecl-font-size-5xl: #{map.get($font-size, '5xl')};
+  --ecl-font-size-6xl: #{map.get($font-size, '6xl')};
+  --ecl-font-size-7xl: #{map.get($font-size, '7xl')};
+  --ecl-font-size-8xl: #{map.get($font-size, '8xl')};
+  --ecl-font-size-9xl: #{map.get($font-size, '9xl')};
+  --ecl-font-size-10xl: #{map.get($font-size, '10xl')};
+
+  // line-height:
+  --ecl-line-height-3xs: #{map.get($line-height, '3xs')};
+  --ecl-line-height-2xs: #{map.get($line-height, '2xs')};
+  --ecl-line-height-xs: #{map.get($line-height, 'xs')};
+  --ecl-line-height-s: #{map.get($line-height, 's')};
+  --ecl-line-height-m: #{map.get($line-height, 'm')};
+  --ecl-line-height-l: #{map.get($line-height, 'l')};
+  --ecl-line-height-xl: #{map.get($line-height, 'xl')};
+  --ecl-line-height-2xl: #{map.get($line-height, '2xl')};
+  --ecl-line-height-3xl: #{map.get($line-height, '3xl')};
+  --ecl-line-height-4xl: #{map.get($line-height, '4xl')};
+  --ecl-line-height-5xl: #{map.get($line-height, '5xl')};
+  --ecl-line-height-6xl: #{map.get($line-height, '6xl')};
+  --ecl-line-height-7xl: #{map.get($line-height, '7xl')};
+  --ecl-line-height-8xl: #{map.get($line-height, '8xl')};
+  --ecl-line-height-9xl: #{map.get($line-height, '9xl')};
+  --ecl-line-height-10xl: #{map.get($line-height, '10xl')};
+
   // spacing
   --ecl-spacing-5xs: #{map.get($spacing, '5xs')};
   --ecl-spacing-4xs: #{map.get($spacing, '4xs')};
@@ -248,6 +283,41 @@
   --f-8xl: var(--ecl-font-8xl);
   --f-9xl: var(--ecl-font-9xl);
   --f-10xl: var(--ecl-font-10xl);
+
+  // font-size
+  --fs-2xs: var(--ecl-font-size-2xs);
+  --fs-xs: var(--ecl-font-size-xs);
+  --fs-s: var(--ecl-font-size-s);
+  --fs-m: var(--ecl-font-size-m);
+  --fs-l: var(--ecl-font-size-l);
+  --fs-xl: var(--ecl-font-size-xl);
+  --fs-2xl: var(--ecl-font-size-2xl);
+  --fs-3xl: var(--ecl-font-size-3xl);
+  --fs-4xl: var(--ecl-font-size-4xl);
+  --fs-5xl: var(--ecl-font-size-5xl);
+  --fs-6xl: var(--ecl-font-size-6xl);
+  --fs-7xl: var(--ecl-font-size-7xl);
+  --fs-8xl: var(--ecl-font-size-8xl);
+  --fs-9xl: var(--ecl-font-size-9xl);
+  --fs-10xl: var(--ecl-font-size-10xl);
+
+  // line-height:
+  --lh-3xs: var(--ecl-line-height-3xs);
+  --lh-2xs: var(--ecl-line-height-2xs);
+  --lh-xs: var(--ecl-line-height-xs);
+  --lh-s: var(--ecl-line-height-s);
+  --lh-m: var(--ecl-line-height-m);
+  --lh-l: var(--ecl-line-height-l);
+  --lh-xl: var(--ecl-line-height-xl);
+  --lh-2xl: var(--ecl-line-height-2xl);
+  --lh-3xl: var(--ecl-line-height-3xl);
+  --lh-4xl: var(--ecl-line-height-4xl);
+  --lh-5xl: var(--ecl-line-height-5xl);
+  --lh-6xl: var(--ecl-line-height-6xl);
+  --lh-7xl: var(--ecl-line-height-7xl);
+  --lh-8xl: var(--ecl-line-height-8xl);
+  --lh-9xl: var(--ecl-line-height-9xl);
+  --lh-10xl: var(--ecl-line-height-10xl);
 
   // spacing
   --s-5xs: var(--ecl-spacing-5xs);

--- a/src/themes/ec/maps/typography.scss
+++ b/src/themes/ec/maps/typography.scss
@@ -55,6 +55,7 @@ $line-height: (
   '3xs': 0.875rem,
 ) !default;
 $font: (
+  // deprecated
   '10xl': #{map.get($font-size, '10xl') + '/' + map.get($line-height, '10xl')}
     #{map.get($font-family, 'default')},
   '9xl': #{map.get($font-size, '9xl') + '/' + map.get($line-height, '9xl')}
@@ -84,7 +85,7 @@ $font: (
   'xs': #{map.get($font-size, 'xs') + '/' + map.get($line-height, 'xs')}
     #{map.get($font-family, 'default')},
   '2xs': #{map.get($font-size, '2xs') + '/' + map.get($line-height, '3xs')}
-    #{map.get($font-family, 'default')},
+    #{map.get($font-family, 'default')}
 ) !default;
 $letter-spacing-compact: (
   '10xl': -1px,

--- a/src/themes/ec/variables/_typography.scss
+++ b/src/themes/ec/variables/_typography.scss
@@ -20,6 +20,7 @@ $typography: (
       'line-height': var(--lh-10xl),
     ),
     'font-weight': map.get($font-weight, 'regular'),
+    'letter-spacing-compact': -1px,
   ),
   heading1: (
     'mobile': (
@@ -67,8 +68,6 @@ $typography: (
       'line-height': var(--lh-xl),
     ),
     'font-weight': map.get($font-weight, 'light'),
-    'letter-spacing-mobile': map.get($letter-spacing-compact, '2xl'),
-    'letter-spacing-desktop': map.get($letter-spacing-compact, '3xl'),
   ),
   heading4: (
     'mobile': (

--- a/src/themes/ec/variables/_typography.scss
+++ b/src/themes/ec/variables/_typography.scss
@@ -2,49 +2,222 @@
 @use '../index' as *;
 
 $typography: (
+  font-family: map.get($font-family, 'default'),
   heading-margin: var(--s-5xl) 0 var(--s-m),
   heading-color: var(--cm-on-surface-brand),
   text-color: var(--cm-on-surface-brand),
   display: (
-    'mobile': var(--f-9xl),
-    'desktop': var(--f-10xl),
+    'mobile': (
+      'size': var(--fs-6xl),
+      'line-height': var(--lh-3xl),
+    ),
+    'tablet': (
+      'size': var(--fs-9xl),
+      'line-height': var(--lh-9xl),
+    ),
+    'desktop': (
+      'size': var(--fs-10xl),
+      'line-height': var(--lh-10xl),
+    ),
     'font-weight': map.get($font-weight, 'regular'),
   ),
   heading1: (
-    'mobile': var(--f-7xl),
-    'desktop': var(--f-8xl),
+    'mobile': (
+      'size': var(--fs-6xl),
+      'line-height': var(--lh-3xl),
+    ),
+    'tablet': (
+      'size': var(--fs-7xl),
+      'line-height': var(--lh-6xl),
+    ),
+    'desktop': (
+      'size': var(--fs-8xl),
+      'line-height': var(--lh-8xl),
+    ),
     'font-weight': map.get($font-weight, 'light'),
-    'letter-spacing-mobile': map.get($letter-spacing-compact, '7xl'),
-    'letter-spacing-desktop': map.get($letter-spacing-compact, '8xl'),
+    'letter-spacing-compact': -1.5px,
   ),
   heading2: (
-    'mobile': var(--f-5xl),
-    'desktop': var(--f-6xl),
+    'mobile': (
+      'size': var(--fs-4xl),
+      'line-height': var(--lh-xl),
+    ),
+    'tablet': (
+      'size': var(--fs-5xl),
+      'line-height': var(--lh-3xl),
+    ),
+    'desktop': (
+      'size': var(--fs-6xl),
+      'line-height': var(--lh-4xl),
+    ),
     'font-weight': map.get($font-weight, 'light'),
-    'letter-spacing-mobile': map.get($letter-spacing-compact, '5xl'),
-    'letter-spacing-desktop': map.get($letter-spacing-compact, '6xl'),
+    'letter-spacing-compact': -0.5px,
   ),
   heading3: (
-    'mobile': var(--f-2xl),
-    'desktop': var(--f-3xl),
+    'mobile': (
+      'size': var(--fs-2xl),
+      'line-height': var(--lh-l),
+    ),
+    'tablet': (
+      'size': var(--fs-3xl),
+      'line-height': var(--lh-xl),
+    ),
+    'desktop': (
+      'size': var(--fs-3xl),
+      'line-height': var(--lh-xl),
+    ),
     'font-weight': map.get($font-weight, 'light'),
     'letter-spacing-mobile': map.get($letter-spacing-compact, '2xl'),
     'letter-spacing-desktop': map.get($letter-spacing-compact, '3xl'),
   ),
   heading4: (
-    'mobile': var(--f-2xl),
-    'desktop': var(--f-2xl),
+    'mobile': (
+      'size': var(--fs-m),
+      'line-height': var(--lh-m),
+    ),
+    'tablet': (
+      'size': var(--fs-2xl),
+      'line-height': var(--lh-xl),
+    ),
+    'desktop': (
+      'size': var(--fs-2xl),
+      'line-height': var(--lh-xl),
+    ),
     'font-weight': map.get($font-weight, 'light'),
   ),
   heading5: (
-    'mobile': var(--f-xl),
-    'desktop': var(--f-xl),
+    'mobile': (
+      'size': var(--fs-m),
+      'line-height': var(--lh-s),
+    ),
+    'tablet': (
+      'size': var(--fs-xl),
+      'line-height': var(--lh-l),
+    ),
+    'desktop': (
+      'size': var(--fs-xl),
+      'line-height': var(--lh-l),
+    ),
     'font-weight': map.get($font-weight, 'light'),
   ),
   heading6: (
-    'mobile': var(--f-l),
-    'desktop': var(--f-l),
+    'mobile': (
+      'size': var(--fs-m),
+      'line-height': var(--lh-s),
+    ),
+    'tablet': (
+      'size': var(--fs-l),
+      'line-height': var(--lh-m),
+    ),
+    'desktop': (
+      'size': var(--fs-l),
+      'line-height': var(--lh-m),
+    ),
     'font-weight': map.get($font-weight, 'light'),
+  ),
+  body: (
+    'xs': (
+      'mobile': (
+        'size': var(--fs-xs),
+        'line-height': var(--lh-xs),
+      ),
+      'tablet': (
+        'size': var(--fs-xs),
+        'line-height': var(--lh-xs),
+      ),
+      'desktop': (
+        'size': var(--fs-xs),
+        'line-height': var(--lh-xs),
+      ),
+    ),
+    's': (
+      'mobile': (
+        'size': var(--fs-s),
+        'line-height': var(--lh-s),
+      ),
+      'tablet': (
+        'size': var(--fs-s),
+        'line-height': var(--lh-s),
+      ),
+      'desktop': (
+        'size': var(--fs-s),
+        'line-height': var(--lh-s),
+      ),
+    ),
+    'm': (
+      'mobile': (
+        'size': var(--fs-s),
+        'line-height': var(--lh-s),
+      ),
+      'tablet': (
+        'size': var(--fs-m),
+        'line-height': var(--lh-m),
+      ),
+      'desktop': (
+        'size': var(--fs-m),
+        'line-height': var(--lh-m),
+      ),
+    ),
+    'l': (
+      'mobile': (
+        'size': var(--fs-l),
+        'line-height': var(--lh-m),
+      ),
+      'tablet': (
+        'size': var(--fs-l),
+        'line-height': var(--lh-m),
+      ),
+      'desktop': (
+        'size': var(--fs-l),
+        'line-height': var(--lh-m),
+      ),
+    ),
+    'xl': (
+      'mobile': (
+        'size': var(--fs-xl),
+        'line-height': var(--lh-l),
+      ),
+      'tablet': (
+        'size': var(--fs-xl),
+        'line-height': var(--lh-l),
+      ),
+      'desktop': (
+        'size': var(--fs-xl),
+        'line-height': var(--lh-l),
+      ),
+    ),
+    '2xl': (
+      'mobile': (
+        'size': var(--fs-xl),
+        'line-height': var(--lh-l),
+      ),
+      'tablet': (
+        'size': var(--fs-2xl),
+        'line-height': var(--lh-xl),
+      ),
+      'desktop': (
+        'size': var(--fs-2xl),
+        'line-height': var(--lh-xl),
+      ),
+    ),
+  ),
+  microcopy: (
+    '2xs': (
+      'size': var(--fs-2xs),
+      'line-height': var(--lh-3xs),
+    ),
+    'xs': (
+      'size': var(--fs-xs),
+      'line-height': var(--lh-xs),
+    ),
+    's': (
+      'size': var(--fs-s),
+      'line-height': var(--lh-s),
+    ),
+    'm': (
+      'size': var(--fs-m),
+      'line-height': var(--lh-m),
+    ),
   ),
   paragraph: (
     '2xl': var(--f-2xl),

--- a/src/themes/eu/_custom-properties.scss
+++ b/src/themes/eu/_custom-properties.scss
@@ -86,6 +86,24 @@
   --ecl-shadow-negative-inner-2: #{map.get($shadow-negative-inner, '2')};
   --ecl-max-width: #{$max-width};
 
+  // Font sizes
+  --ecl-font-size-m: #{map.get($font-size, 'm')};
+  --ecl-font-size-l: #{map.get($font-size, 'l')};
+  --ecl-font-size-xl: #{map.get($font-size, 'xl')};
+  --ecl-font-size-2xl: #{map.get($font-size, '2xl')};
+  --ecl-font-size-3xl: #{map.get($font-size, '3xl')};
+  --ecl-font-size-4xl: #{map.get($font-size, '4xl')};
+  --ecl-font-size-5xl: #{map.get($font-size, '5xl')};
+
+  // Line heights
+  --ecl-line-height-m: #{map.get($line-height, 'm')};
+  --ecl-line-height-l: #{map.get($line-height, 'l')};
+  --ecl-line-height-xl: #{map.get($line-height, 'xl')};
+  --ecl-line-height-2xl: #{map.get($line-height, '2xl')};
+  --ecl-line-height-3xl: #{map.get($line-height, '3xl')};
+  --ecl-line-height-4xl: #{map.get($line-height, '4xl')};
+  --ecl-line-height-5xl: #{map.get($line-height, '5xl')};
+
   // Aliases (internal use)
   --c-p: var(--ecl-color-primary);
   --c-p-180: var(--ecl-color-primary-180);
@@ -146,6 +164,20 @@
   --f-5xl: var(--ecl-font-5xl);
   --f-ui-s: var(--ecl-font-ui-s);
   --f-ui-m: var(--ecl-font-ui-m);
+  --fs-m: var(--ecl-font-size-m);
+  --fs-l: var(--ecl-font-size-l);
+  --fs-xl: var(--ecl-font-size-xl);
+  --fs-2xl: var(--ecl-font-size-2xl);
+  --fs-3xl: var(--ecl-font-size-3xl);
+  --fs-4xl: var(--ecl-font-size-4xl);
+  --fs-5xl: var(--ecl-font-size-5xl);
+  --lh-m: var(--ecl-line-height-m);
+  --lh-l: var(--ecl-line-height-l);
+  --lh-xl: var(--ecl-line-height-xl);
+  --lh-2xl: var(--ecl-line-height-2xl);
+  --lh-3xl: var(--ecl-line-height-3xl);
+  --lh-4xl: var(--ecl-line-height-4xl);
+  --lh-5xl: var(--ecl-line-height-5xl);
   --s-2xs: var(--ecl-spacing-2xs);
   --s-xs: var(--ecl-spacing-xs);
   --s-s: var(--ecl-spacing-s);

--- a/src/themes/eu/variables/_typography.scss
+++ b/src/themes/eu/variables/_typography.scss
@@ -2,43 +2,104 @@
 @use '../index' as *;
 
 $typography: (
+  font-family: map.get($font-family, 'default'),
   heading-margin: var(--s-2xl) 0 var(--s-m),
   heading-color: var(--c-d),
   text-color: var(--c-d-80),
   heading1: (
-    'mobile': var(--f-4xl),
-    'desktop': var(--f-5xl),
+    'mobile': (
+      'size': var(--fs-4xl),
+      'line-height': var(--lh-4xl),
+    ),
+    'tablet': (
+      'size': var(--fs-4xl),
+      'line-height': var(--lh-4xl),
+    ),
+    'desktop': (
+      'size': var(--fs-5xl),
+      'line-height': var(--lh-5xl),
+    ),
     'font-weight': map.get($font-weight, 'regular'),
     'letter-spacing-mobile': normal,
     'letter-spacing-desktop': normal,
   ),
   heading2: (
-    'mobile': var(--f-3xl),
-    'desktop': var(--f-4xl),
+    'mobile': (
+      'size': var(--fs-3xl),
+      'line-height': var(--lh-3xl),
+    ),
+    'tablet': (
+      'size': var(--fs-3xl),
+      'line-height': var(--lh-3xl),
+    ),
+    'desktop': (
+      'size': var(--fs-4xl),
+      'line-height': var(--lh-4xl),
+    ),
     'font-weight': map.get($font-weight, 'regular'),
     'letter-spacing-mobile': normal,
     'letter-spacing-desktop': normal,
   ),
   heading3: (
-    'mobile': var(--f-2xl),
-    'desktop': var(--f-3xl),
+    'mobile': (
+      'size': var(--fs-2xl),
+      'line-height': var(--lh-2xl),
+    ),
+    'tablet': (
+      'size': var(--fs-2xl),
+      'line-height': var(--lh-2xl),
+    ),
+    'desktop': (
+      'size': var(--fs-3xl),
+      'line-height': var(--lh-3xl),
+    ),
     'font-weight': map.get($font-weight, 'regular'),
     'letter-spacing-mobile': normal,
     'letter-spacing-desktop': normal,
   ),
   heading4: (
-    'mobile': var(--f-xl),
-    'desktop': var(--f-2xl),
+    'mobile': (
+      'size': var(--fs-xl),
+      'line-height': var(--lh-xl),
+    ),
+    'tablet': (
+      'size': var(--fs-xl),
+      'line-height': var(--lh-xl),
+    ),
+    'desktop': (
+      'size': var(--fs-2xl),
+      'line-height': var(--lh-2xl),
+    ),
     'font-weight': map.get($font-weight, 'regular'),
   ),
   heading5: (
-    'mobile': var(--f-l),
-    'desktop': var(--f-l),
+    'mobile': (
+      'size': var(--fs-l),
+      'line-height': var(--lh-l),
+    ),
+    'tablet': (
+      'size': var(--fs-l),
+      'line-height': var(--lh-l),
+    ),
+    'desktop': (
+      'size': var(--fs-l),
+      'line-height': var(--lh-l),
+    ),
     'font-weight': map.get($font-weight, 'regular'),
   ),
   heading6: (
-    'mobile': var(--f-m),
-    'desktop': var(--f-m),
+    'mobile': (
+      'size': var(--fs-m),
+      'line-height': var(--lh-m),
+    ),
+    'tablet': (
+      'size': var(--fs-m),
+      'line-height': var(--lh-m),
+    ),
+    'desktop': (
+      'size': var(--fs-m),
+      'line-height': var(--lh-m),
+    ),
     'font-weight': map.get($font-weight, 'regular'),
   ),
   paragraph: (

--- a/src/utilities/typography/typography.scss
+++ b/src/utilities/typography/typography.scss
@@ -15,12 +15,34 @@ $typography: null !default;
 @if map.has-key($typography, 'display') {
   .ecl-u-type-display {
     color: map.get($typography, 'heading-color');
-    font: map.get($typography, 'display', 'mobile') !important;
+    font-family: map.get($typography, 'font-family') !important;
+    font-size: map.get($typography, 'display', 'mobile', 'size') !important;
     font-weight: map.get($typography, 'display', 'font-weight') !important;
+    line-height: map.get(
+      $typography,
+      'display',
+      'mobile',
+      'line-height'
+    ) !important;
 
     @include breakpoints.up('m') {
-      font: map.get($typography, 'display', 'desktop') !important;
-      font-weight: map.get($typography, 'display', 'font-weight') !important;
+      font-size: map.get($typography, 'display', 'tablet', 'size') !important;
+      line-height: map.get(
+        $typography,
+        'display',
+        'tablet',
+        'line-height'
+      ) !important;
+    }
+
+    @include breakpoints.up('l') {
+      font-size: map.get($typography, 'display', 'desktop', 'size') !important;
+      line-height: map.get(
+        $typography,
+        'display',
+        'desktop',
+        'line-height'
+      ) !important;
     }
   }
 }
@@ -28,21 +50,33 @@ $typography: null !default;
 .ecl-u-type-heading-1,
 %ecl-heading-1 {
   color: map.get($typography, 'heading-color');
-  font: map.get($typography, 'heading1', 'mobile') !important;
+  font-family: map.get($typography, 'font-family') !important;
+  font-size: map.get($typography, 'heading1', 'mobile', 'size') !important;
   font-weight: map.get($typography, 'heading1', 'font-weight') !important;
-  letter-spacing: map.get(
+  line-height: map.get(
     $typography,
     'heading1',
-    'letter-spacing-mobile'
+    'mobile',
+    'line-height'
   ) !important;
 
   @include breakpoints.up('m') {
-    font: map.get($typography, 'heading1', 'desktop') !important;
-    font-weight: map.get($typography, 'heading1', 'font-weight') !important;
-    letter-spacing: map.get(
+    font-size: map.get($typography, 'heading1', 'tablet', 'size') !important;
+    line-height: map.get(
       $typography,
       'heading1',
-      'letter-spacing-desktop'
+      'tablet',
+      'line-height'
+    ) !important;
+  }
+
+  @include breakpoints.up('l') {
+    font-size: map.get($typography, 'heading1', 'desktop', 'size') !important;
+    line-height: map.get(
+      $typography,
+      'heading1',
+      'desktop',
+      'line-height'
     ) !important;
   }
 }
@@ -50,21 +84,33 @@ $typography: null !default;
 .ecl-u-type-heading-2,
 %ecl-heading-2 {
   color: map.get($typography, 'heading-color');
-  font: map.get($typography, 'heading2', 'mobile') !important;
+  font-family: map.get($typography, 'font-family') !important;
+  font-size: map.get($typography, 'heading2', 'mobile', 'size') !important;
   font-weight: map.get($typography, 'heading2', 'font-weight') !important;
-  letter-spacing: map.get(
+  line-height: map.get(
     $typography,
     'heading2',
-    'letter-spacing-mobile'
+    'mobile',
+    'line-height'
   ) !important;
 
   @include breakpoints.up('m') {
-    font: map.get($typography, 'heading2', 'desktop') !important;
-    font-weight: map.get($typography, 'heading2', 'font-weight') !important;
-    letter-spacing: map.get(
+    font-size: map.get($typography, 'heading2', 'tablet', 'size') !important;
+    line-height: map.get(
       $typography,
       'heading2',
-      'letter-spacing-desktop'
+      'tablet',
+      'line-height'
+    ) !important;
+  }
+
+  @include breakpoints.up('l') {
+    font-size: map.get($typography, 'heading2', 'desktop', 'size') !important;
+    line-height: map.get(
+      $typography,
+      'heading2',
+      'desktop',
+      'line-height'
     ) !important;
   }
 }
@@ -72,21 +118,33 @@ $typography: null !default;
 .ecl-u-type-heading-3,
 %ecl-heading-3 {
   color: map.get($typography, 'heading-color');
-  font: map.get($typography, 'heading3', 'mobile') !important;
+  font-family: map.get($typography, 'font-family') !important;
+  font-size: map.get($typography, 'heading3', 'mobile', 'size') !important;
   font-weight: map.get($typography, 'heading3', 'font-weight') !important;
-  letter-spacing: map.get(
+  line-height: map.get(
     $typography,
     'heading3',
-    'letter-spacing-mobile'
+    'mobile',
+    'line-height'
   ) !important;
 
   @include breakpoints.up('m') {
-    font: map.get($typography, 'heading3', 'desktop') !important;
-    font-weight: map.get($typography, 'heading3', 'font-weight') !important;
-    letter-spacing: map.get(
+    font-size: map.get($typography, 'heading3', 'tablet', 'size') !important;
+    line-height: map.get(
       $typography,
       'heading3',
-      'letter-spacing-desktop'
+      'tablet',
+      'line-height'
+    ) !important;
+  }
+
+  @include breakpoints.up('l') {
+    font-size: map.get($typography, 'heading3', 'desktop', 'size') !important;
+    line-height: map.get(
+      $typography,
+      'heading3',
+      'desktop',
+      'line-height'
     ) !important;
   }
 }
@@ -94,36 +152,96 @@ $typography: null !default;
 .ecl-u-type-heading-4,
 %ecl-heading-4 {
   color: map.get($typography, 'heading-color');
-  font: map.get($typography, 'heading4', 'mobile') !important;
+  font-family: map.get($typography, 'font-family') !important;
+  font-size: map.get($typography, 'heading4', 'mobile', 'size') !important;
   font-weight: map.get($typography, 'heading4', 'font-weight') !important;
+  line-height: map.get(
+    $typography,
+    'heading4',
+    'mobile',
+    'line-height'
+  ) !important;
 
   @include breakpoints.up('m') {
-    font: map.get($typography, 'heading4', 'desktop') !important;
-    font-weight: map.get($typography, 'heading4', 'font-weight') !important;
+    font-size: map.get($typography, 'heading4', 'tablet', 'size') !important;
+    line-height: map.get(
+      $typography,
+      'heading4',
+      'tablet',
+      'line-height'
+    ) !important;
+  }
+
+  @include breakpoints.up('l') {
+    font-size: map.get($typography, 'heading4', 'desktop', 'size') !important;
+    line-height: map.get(
+      $typography,
+      'heading4',
+      'desktop',
+      'line-height'
+    ) !important;
   }
 }
 
 .ecl-u-type-heading-5,
 %ecl-heading-5 {
   color: map.get($typography, 'heading-color');
-  font: map.get($typography, 'heading5', 'mobile') !important;
+  font-family: map.get($typography, 'font-family') !important;
+  font-size: map.get($typography, 'heading5', 'mobile', 'size') !important;
   font-weight: map.get($typography, 'heading5', 'font-weight') !important;
 
-  @include breakpoints.up('m') {
-    font: map.get($typography, 'heading5', 'desktop') !important;
-    font-weight: map.get($typography, 'heading5', 'font-weight') !important;
+  @include breakpoints.up('l') {
+    font-size: map.get($typography, 'heading5', 'tablet', 'size') !important;
+    line-height: map.get(
+      $typography,
+      'heading5',
+      'tablet',
+      'line-height'
+    ) !important;
+  }
+
+  @include breakpoints.up('l') {
+    font-size: map.get($typography, 'heading5', 'desktop', 'size') !important;
+    line-height: map.get(
+      $typography,
+      'heading5',
+      'desktop',
+      'line-height'
+    ) !important;
   }
 }
 
 .ecl-u-type-heading-6,
 %ecl-heading-6 {
   color: map.get($typography, 'heading-color');
-  font: map.get($typography, 'heading6', 'mobile') !important;
+  font-family: map.get($typography, 'font-family') !important;
+  font-size: map.get($typography, 'heading6', 'mobile', 'size') !important;
   font-weight: map.get($typography, 'heading6', 'font-weight') !important;
+  line-height: map.get(
+    $typography,
+    'heading6',
+    'mobile',
+    'line-height'
+  ) !important;
 
   @include breakpoints.up('m') {
-    font: map.get($typography, 'heading6', 'desktop') !important;
-    font-weight: map.get($typography, 'heading6', 'font-weight') !important;
+    font-size: map.get($typography, 'heading6', 'tablet', 'size') !important;
+    line-height: map.get(
+      $typography,
+      'heading6',
+      'tablet',
+      'line-height'
+    ) !important;
+  }
+
+  @include breakpoints.up('l') {
+    font-size: map.get($typography, 'heading6', 'desktop', 'size') !important;
+    line-height: map.get(
+      $typography,
+      'heading6',
+      'desktop',
+      'line-height'
+    ) !important;
   }
 }
 


### PR DESCRIPTION
I'm not entirely sure about what breakpoints matches the "tablet" and "desktop" display, in the typograhpy utilities i have used "m" for tablet and "l" for desktop.

It's not particularly clear the situation regarding the letter spacing, astrid m said to me that she is going to generate a list of the different letter spacing needed, for now i set the values directly in the maps.

To be able to generate utilities for EU some variables (font-size and line-height) have been added also there. 