### PR TITLE
fix(mega-menu): Taking into account the minHeight, recalculating also on collapse - FRONT-4922

### DIFF
--- a/src/components/mega-menu/mega-menu.js
+++ b/src/components/mega-menu/mega-menu.js
@@ -798,11 +798,20 @@ export class MegaMenu {
         const containerBottom = containerBounding.bottom;
         // By requirements, limit the height to the 70% of the available space.
         const availableHeight = (window.innerHeight - containerBottom) * 0.7;
+        const minHeight =
+          parseFloat(
+            window.getComputedStyle(queryOne('.ecl-mega-menu__wrapper'))
+              .minHeight,
+          ) || 0;
 
         if (maxHeight > availableHeight) {
           height = availableHeight;
         } else {
           height = maxHeight;
+        }
+
+        if (height < minHeight) {
+          height = minHeight;
         }
 
         const wrapper = queryOne('.ecl-mega-menu__wrapper', menuItem);
@@ -1533,6 +1542,12 @@ export class MegaMenu {
         if (infoPanel) {
           infoPanel.style.top = '';
         }
+
+        this.positionMenuOverlay();
+        this.checkDropdownHeight(
+          menuItem.closest('.ecl-mega-menu__item'),
+          false,
+        );
         break;
 
       default:


### PR DESCRIPTION
This fixes two issues noticed after a report by ewpp on an example with only one item per panel.

- we set a min Height for the dropdown that was not taken into account, resulting in a white space below the panel's content
- When closing a previously opened third panel the height of the panels was not correctly recalculated so that it would not take into account the real heights of the panel being shown (see screenshots in the ticket)