### PR TITLE
feat(print): class name and timeline tweaks - FRONT-4942

### DIFF
--- a/src/components/site-header/site-header-print.scss
+++ b/src/components/site-header/site-header-print.scss
@@ -29,21 +29,12 @@ $site-header: null !default;
   display: none;
 }
 
-.ecl-site-header__banner-top {
-  color: var(--cm-on-surface-brand, var(--c-d));
-  font: map.get($theme, 'font-print', 'm');
-
-  .ecl-link {
-    color: var(--cm-on-surface-brand, var(--c-d));
-  }
-
-  .ecl-link::after {
-    display: none;
-  }
-}
-
 .ecl-site-header__banner {
   display: none !important;
+}
+
+.ecl-site-header__banner-top {
+  display: none;
 }
 
 .ecl-site-header__logo-link::after {

--- a/src/themes/ec/variables/_timeline.scss
+++ b/src/themes/ec/variables/_timeline.scss
@@ -38,6 +38,6 @@ $timeline-print: (
   label-margin: 0,
   content-font: map.get($font-print, 'm'),
   timeline-margin-left: calc(
-      #{map.get($spacing-print, 'xs')} + 12rem + #{map.get($spacing-print, 'm')}
+      #{map.get($spacing-print, 'xs')} + 4.5cm + #{map.get($spacing-print, 'm')}
     ),
 );


### PR DESCRIPTION
an extra spacing at the begining of the featured item seems to be caused by a missing css file on implementation side (ecl-ec-default-print.css)