### PR TITLE
feat(labels): harmonize labels for "see more"

### DIFF
--- a/src/components/description-list/__snapshots__/description-list.test.js.snap
+++ b/src/components/description-list/__snapshots__/description-list.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Description list Default renders correctly 1`] = `
 <jest>
@@ -6,7 +6,7 @@ exports[`Description list Default renders correctly 1`] = `
     class="ecl-description-list"
     data-ecl-auto-init="DescriptionList"
     data-ecl-description-list=""
-    data-ecl-description-list-more-label="See all items"
+    data-ecl-description-list-more-label="Show more items"
     data-ecl-description-list-visible-items="2"
   >
     <dt
@@ -388,7 +388,7 @@ exports[`Description list Default renders correctly in the horizontal variant 1`
     class="ecl-description-list ecl-description-list--horizontal"
     data-ecl-auto-init="DescriptionList"
     data-ecl-description-list=""
-    data-ecl-description-list-more-label="See all items"
+    data-ecl-description-list-more-label="Show more items"
     data-ecl-description-list-visible-items="2"
   >
     <dt
@@ -770,7 +770,7 @@ exports[`Description list Default renders correctly with extra attributes 1`] = 
     class="ecl-description-list"
     data-ecl-auto-init="DescriptionList"
     data-ecl-description-list=""
-    data-ecl-description-list-more-label="See all items"
+    data-ecl-description-list-more-label="Show more items"
     data-ecl-description-list-visible-items="2"
   >
     <dt
@@ -1152,7 +1152,7 @@ exports[`Description list Default renders correctly with extra class names 1`] =
     class="ecl-description-list custom-class custom-class--test"
     data-ecl-auto-init="DescriptionList"
     data-ecl-description-list=""
-    data-ecl-description-list-more-label="See all items"
+    data-ecl-description-list-more-label="Show more items"
     data-ecl-description-list-visible-items="2"
   >
     <dt

--- a/src/components/description-list/demo/data--default.js
+++ b/src/components/description-list/demo/data--default.js
@@ -2,7 +2,7 @@ const publicUrl = process.env.PUBLIC_URL || '';
 const exampleLink = `${publicUrl}/example`;
 
 module.exports = {
-  more_label: 'See all items',
+  more_label: 'Show more items',
   visible_items: 2,
   items: [
     {

--- a/src/components/description-list/demo/data--horizontal.js
+++ b/src/components/description-list/demo/data--horizontal.js
@@ -3,7 +3,7 @@ const exampleLink = `${publicUrl}/example`;
 
 module.exports = {
   variant: 'horizontal',
-  more_label: 'See all items',
+  more_label: 'Show more items',
   visible_items: 2,
   items: [
     {

--- a/src/components/file/__snapshots__/file.test.js.snap
+++ b/src/components/file/__snapshots__/file.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`File Thumbnail renders correctly 1`] = `
 <jest>
@@ -325,7 +325,7 @@ exports[`File Thumbnail renders correctly with taxonomies 1`] = `
             class="ecl-description-list"
             data-ecl-auto-init="DescriptionList"
             data-ecl-description-list=""
-            data-ecl-description-list-more-label="See all items"
+            data-ecl-description-list-more-label="Show more items"
             data-ecl-description-list-visible-items="2"
           >
             <dt

--- a/src/components/file/demo/data--taxonomy.js
+++ b/src/components/file/demo/data--taxonomy.js
@@ -78,7 +78,7 @@ module.exports = {
   lists: [
     {
       visible_items: 2,
-      more_label: 'See all items',
+      more_label: 'Show more items',
       items: [
         {
           term: 'Taxonomy list',

--- a/src/components/gallery/__snapshots__/gallery.test.js.snap
+++ b/src/components/gallery/__snapshots__/gallery.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Gallery Default renders correctly 1`] = `
 <jest>
@@ -903,11 +903,11 @@ exports[`Gallery Default renders correctly 1`] = `
           aria-describedby="gallery-id-info"
           class="ecl-button ecl-button--ghost ecl-gallery__view-all"
           data-ecl-gallery-all=""
-          data-ecl-gallery-collapsed-label="See all"
-          data-ecl-gallery-expanded-label="Collapse"
+          data-ecl-gallery-collapsed-label="Show more items"
+          data-ecl-gallery-expanded-label="Show less"
           type="submit"
         >
-          See all
+          Show more items
         </button>
       </div>
       <hr
@@ -1996,11 +1996,11 @@ exports[`Gallery Default renders correctly with extra attributes 1`] = `
           aria-describedby="gallery-id-info"
           class="ecl-button ecl-button--ghost ecl-gallery__view-all"
           data-ecl-gallery-all=""
-          data-ecl-gallery-collapsed-label="See all"
-          data-ecl-gallery-expanded-label="Collapse"
+          data-ecl-gallery-collapsed-label="Show more items"
+          data-ecl-gallery-expanded-label="Show less"
           type="submit"
         >
-          See all
+          Show more items
         </button>
       </div>
       <hr
@@ -3087,11 +3087,11 @@ exports[`Gallery Default renders correctly with extra class names 1`] = `
           aria-describedby="gallery-id-info"
           class="ecl-button ecl-button--ghost ecl-gallery__view-all"
           data-ecl-gallery-all=""
-          data-ecl-gallery-collapsed-label="See all"
-          data-ecl-gallery-expanded-label="Collapse"
+          data-ecl-gallery-collapsed-label="Show more items"
+          data-ecl-gallery-expanded-label="Show less"
           type="submit"
         >
-          See all
+          Show more items
         </button>
       </div>
       <hr
@@ -4178,11 +4178,11 @@ exports[`Gallery Default renders correctly with old data 1`] = `
           aria-describedby="gallery-id-info"
           class="ecl-button ecl-button--ghost ecl-gallery__view-all"
           data-ecl-gallery-all=""
-          data-ecl-gallery-collapsed-label="See all"
-          data-ecl-gallery-expanded-label="Collapse"
+          data-ecl-gallery-collapsed-label="Show more items"
+          data-ecl-gallery-expanded-label="Show less"
           type="submit"
         >
-          See all
+          Show more items
         </button>
       </div>
       <hr
@@ -5269,11 +5269,11 @@ exports[`Gallery Grid renders correctly 1`] = `
           aria-describedby="gallery-id-info"
           class="ecl-button ecl-button--ghost ecl-gallery__view-all"
           data-ecl-gallery-all=""
-          data-ecl-gallery-collapsed-label="See all"
-          data-ecl-gallery-expanded-label="Collapse"
+          data-ecl-gallery-collapsed-label="Show more items"
+          data-ecl-gallery-expanded-label="Show less"
           type="submit"
         >
-          See all
+          Show more items
         </button>
       </div>
       <hr

--- a/src/components/gallery/demo/data.js
+++ b/src/components/gallery/demo/data.js
@@ -306,8 +306,8 @@ module.exports = {
     sr_overlay_label: 'Gallery overlay',
   },
   disable_overlay: false,
-  view_all_label: 'See all',
-  view_all_expanded_label: 'Collapse',
+  view_all_label: 'Show more items',
+  view_all_expanded_label: 'Show less',
   footer: {
     link: {
       path: exampleLink,

--- a/src/components/mega-menu/__snapshots__/mega-menu.test.js.snap
+++ b/src/components/mega-menu/__snapshots__/mega-menu.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Mega Menu Default renders correctly 1`] = `
 <jest>
@@ -439,7 +439,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
                               <span
                                 class="ecl-link__label"
                               >
-                                See all
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -931,7 +931,7 @@ exports[`Mega Menu Default renders correctly 1`] = `
                               <span
                                 class="ecl-link__label"
                               >
-                                See all items
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -1636,7 +1636,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
                               <span
                                 class="ecl-link__label"
                               >
-                                See all
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -2128,7 +2128,7 @@ exports[`Mega Menu Default renders correctly with external items in the first le
                               <span
                                 class="ecl-link__label"
                               >
-                                See all items
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -2835,7 +2835,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
                               <span
                                 class="ecl-link__label"
                               >
-                                See all
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -3327,7 +3327,7 @@ exports[`Mega Menu Default renders correctly with extra attributes 1`] = `
                               <span
                                 class="ecl-link__label"
                               >
-                                See all items
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -4032,7 +4032,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
                               <span
                                 class="ecl-link__label"
                               >
-                                See all
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -4524,7 +4524,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the featu
                               <span
                                 class="ecl-link__label"
                               >
-                                See all items
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -5230,7 +5230,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
                               <span
                                 class="ecl-link__label"
                               >
-                                See all
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -5722,7 +5722,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the fist 
                               <span
                                 class="ecl-link__label"
                               >
-                                See all items
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -6427,7 +6427,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the info 
                               <span
                                 class="ecl-link__label"
                               >
-                                See all
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -6920,7 +6920,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the info 
                               <span
                                 class="ecl-link__label"
                               >
-                                See all items
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -7626,7 +7626,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
                               <span
                                 class="ecl-link__label"
                               >
-                                See all
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -8118,7 +8118,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the secon
                               <span
                                 class="ecl-link__label"
                               >
-                                See all items
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -8823,7 +8823,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
                               <span
                                 class="ecl-link__label"
                               >
-                                See all
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -9315,7 +9315,7 @@ exports[`Mega Menu Default renders correctly with extra attributes for the see a
                               <span
                                 class="ecl-link__label"
                               >
-                                See all items
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -10020,7 +10020,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
                               <span
                                 class="ecl-link__label"
                               >
-                                See all
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"
@@ -10512,7 +10512,7 @@ exports[`Mega Menu Default renders correctly with extra class names 1`] = `
                               <span
                                 class="ecl-link__label"
                               >
-                                See all items
+                                See all pages
                               </span>
                               <span
                                 class="wt-icon--arrow-left ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-link__icon ecl-icon--arrow-left"

--- a/src/components/mega-menu/demo/data.js
+++ b/src/components/mega-menu/demo/data.js
@@ -105,7 +105,7 @@ module.exports = {
           label: 'Item 2.3 that has a very long label',
           path: exampleLink,
           see_all: true,
-          see_all_label: 'See all',
+          see_all_label: 'See all pages',
           sublink_id: 'item-2.3-that-has-a-very-long-label-id',
           children: [
             { label: 'Item 2.3 subitem 1', path: exampleLink },
@@ -198,7 +198,7 @@ module.exports = {
           label: 'Research and innovation',
           path: exampleLink,
           see_all: true,
-          see_all_label: 'See all items',
+          see_all_label: 'See all pages',
           sublink_id: 'research-and-innovation-id',
           featured: {
             title: 'Featured items',

--- a/src/components/tabs/__snapshots__/tabs.test.js.snap
+++ b/src/components/tabs/__snapshots__/tabs.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Tabs Default renders correctly 1`] = `
 <jest>
@@ -159,7 +159,7 @@ exports[`Tabs Default renders correctly 1`] = `
             class="ecl-button__label"
             data-ecl-label="true"
           >
-            More (%d)
+            Show %d more items
           </span>
           <span
             class="wt-icon--corner-arrow ecl-icon ecl-icon--fluid ecl-icon--rotate-180 ecl-button__icon ecl-icon--corner-arrow"
@@ -375,7 +375,7 @@ exports[`Tabs Default renders correctly with extra attributes 1`] = `
             class="ecl-button__label"
             data-ecl-label="true"
           >
-            More (%d)
+            Show %d more items
           </span>
           <span
             class="wt-icon--corner-arrow ecl-icon ecl-icon--fluid ecl-icon--rotate-180 ecl-button__icon ecl-icon--corner-arrow"
@@ -485,7 +485,7 @@ exports[`Tabs Default renders correctly with extra class name on items 1`] = `
             class="ecl-button__label"
             data-ecl-label="true"
           >
-            More (%d)
+            Show %d more items
           </span>
           <span
             class="wt-icon--corner-arrow ecl-icon ecl-icon--fluid ecl-icon--rotate-180 ecl-button__icon ecl-icon--corner-arrow"
@@ -699,7 +699,7 @@ exports[`Tabs Default renders correctly with extra class names 1`] = `
             class="ecl-button__label"
             data-ecl-label="true"
           >
-            More (%d)
+            Show %d more items
           </span>
           <span
             class="wt-icon--corner-arrow ecl-icon ecl-icon--fluid ecl-icon--rotate-180 ecl-button__icon ecl-icon--corner-arrow"

--- a/src/components/tabs/tabs.html.twig
+++ b/src/components/tabs/tabs.html.twig
@@ -29,7 +29,7 @@
 
 {# Internal properties #}
 
-{% set _more_label = more_label|default('More (%d)') %}
+{% set _more_label = more_label|default('Show %d more items') %}
 {% set _previous_label = previous_label|default('Previous') %}
 {% set _next_label = next_label|default('Next') %}
 {% set _items = items|default([]) %}

--- a/src/components/timeline/__snapshots__/timeline.test.js.snap
+++ b/src/components/timeline/__snapshots__/timeline.test.js.snap
@@ -422,7 +422,7 @@ exports[`Timeline renders correctly in a set 1`] = `
         <button
           class="ecl-button ecl-button--secondary ecl-timeline__toggle"
           data-ecl-label-collapsed="Show %d more items"
-          data-ecl-label-expanded="Hide %d items"
+          data-ecl-label-expanded="Show less"
           data-ecl-timeline-button=""
           type="button"
         >
@@ -779,7 +779,7 @@ exports[`Timeline renders correctly with extra attributes 1`] = `
       <button
         class="ecl-button ecl-button--secondary ecl-timeline__toggle"
         data-ecl-label-collapsed="Show %d more items"
-        data-ecl-label-expanded="Hide %d items"
+        data-ecl-label-expanded="Show less"
         data-ecl-timeline-button=""
         type="button"
       >
@@ -1177,7 +1177,7 @@ exports[`Timeline renders correctly with extra class names 1`] = `
       <button
         class="ecl-button ecl-button--secondary ecl-timeline__toggle"
         data-ecl-label-collapsed="Show %d more items"
-        data-ecl-label-expanded="Hide %d items"
+        data-ecl-label-expanded="Show less"
         data-ecl-timeline-button=""
         type="button"
       >
@@ -1575,7 +1575,7 @@ exports[`Timeline renders correctly with hidden items 1`] = `
       <button
         class="ecl-button ecl-button--secondary ecl-timeline__toggle"
         data-ecl-label-collapsed="Show %d more items"
-        data-ecl-label-expanded="Hide %d items"
+        data-ecl-label-expanded="Show less"
         data-ecl-timeline-button=""
         type="button"
       >
@@ -1973,7 +1973,7 @@ exports[`Timeline renders correctly with hidden items but no items after button 
       <button
         class="ecl-button ecl-button--secondary ecl-timeline__toggle"
         data-ecl-label-collapsed="Show %d more items"
-        data-ecl-label-expanded="Hide %d items"
+        data-ecl-label-expanded="Show less"
         data-ecl-timeline-button=""
         type="button"
       >
@@ -2371,7 +2371,7 @@ exports[`Timeline renders correctly with positive hide.to 1`] = `
       <button
         class="ecl-button ecl-button--secondary ecl-timeline__toggle"
         data-ecl-label-collapsed="Show %d more items"
-        data-ecl-label-expanded="Hide %d items"
+        data-ecl-label-expanded="Show less"
         data-ecl-timeline-button=""
         type="button"
       >
@@ -2769,7 +2769,7 @@ exports[`Timeline renders correctly without hidden items 1`] = `
       <button
         class="ecl-button ecl-button--secondary ecl-timeline__toggle"
         data-ecl-label-collapsed="Show %d more items"
-        data-ecl-label-expanded="Hide %d items"
+        data-ecl-label-expanded="Show less"
         data-ecl-timeline-button=""
         type="button"
       >
@@ -3539,7 +3539,7 @@ exports[`Timeline renders correctly without hide.from or hide.to 1`] = `
       <button
         class="ecl-button ecl-button--secondary ecl-timeline__toggle"
         data-ecl-label-collapsed="Show %d more items"
-        data-ecl-label-expanded="Hide %d items"
+        data-ecl-label-expanded="Show less"
         data-ecl-timeline-button=""
         type="button"
       >
@@ -3937,7 +3937,7 @@ exports[`Timeline renders correctly without hide.to 1`] = `
       <button
         class="ecl-button ecl-button--secondary ecl-timeline__toggle"
         data-ecl-label-collapsed="Show %d more items"
-        data-ecl-label-expanded="Hide %d items"
+        data-ecl-label-expanded="Show less"
         data-ecl-timeline-button=""
         type="button"
       >

--- a/src/components/timeline/demo/data--set.js
+++ b/src/components/timeline/demo/data--set.js
@@ -5,7 +5,7 @@ module.exports = {
   items: [
     {
       toggle_collapsed: 'Show %d more items',
-      toggle_expanded: 'Hide %d items',
+      toggle_expanded: 'Show less',
       hide: {
         from: 5,
         to: 0,

--- a/src/components/timeline/demo/data.js
+++ b/src/components/timeline/demo/data.js
@@ -3,7 +3,7 @@ const exampleLink = `${publicUrl}/example`;
 
 module.exports = {
   toggle_collapsed: 'Show %d more items',
-  toggle_expanded: 'Hide %d items',
+  toggle_expanded: 'Show less',
   hide: {
     from: 5,
     to: -2,

--- a/src/components/timeline/timeline.story.js
+++ b/src/components/timeline/timeline.story.js
@@ -129,7 +129,7 @@ const prepareData = (data, args) => {
     hiddenCount = clone.items.length + to - from;
   }
   clone.toggle_collapsed = `Show ${hiddenCount} more items`;
-  clone.toggle_expanded = `Hide ${hiddenCount} items`;
+  clone.toggle_expanded = 'Show less';
 
   clone.hide.from = args.items_before;
   clone.hide.to = -1 * args.items_after;


### PR DESCRIPTION
Update demo labels of some component, to use the same wording: 
- "Show x more items", when the number of item is known (timeline), and ""Show more items" if not.
- Collapse would always be "Show less"

Affected components:
- description list
- gallery
- tabs
- timeline