### PR TITLE
fix(site-header): fix menu button overlap - FRONT-5044

### DIFF
--- a/src/components/site-header/site-header-ec.scss
+++ b/src/components/site-header/site-header-ec.scss
@@ -62,11 +62,6 @@ $language-list: null !default;
   }
 }
 
-.ecl-site-header__header {
-  position: relative;
-  z-index: 54;
-}
-
 .ecl-site-header__container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This can't be tested directly on ECL, but removing the z-index here seems to solve the issue.
I didn't notice any unwanted side effects on the example pages