### PR TITLE
fix(default-css): fixing styles for nested lists of different types - FRONT-5103

### DIFF
--- a/src/presets/ec/src/ec-default-print.scss
+++ b/src/presets/ec/src/ec-default-print.scss
@@ -136,10 +136,13 @@ html {
 }
 
 .ecl ul ul:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
-.ecl ul ul:is([class*='ecl-u-']),
+.ecl ul ul:is([class*='ecl-u-']) {
+  @extend %ecl-unordered-list--nested;
+}
+
 .ecl ul ol:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
 .ecl ul ol:is([class*='ecl-u-']) {
-  @extend %ecl-unordered-list--nested;
+  @extend %ecl-ordered-list--nested;
 }
 
 .ecl ul li:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
@@ -158,10 +161,13 @@ html {
 }
 
 .ecl ol ol:not([class*='ecl-'], [class*='wt-']),
-.ecl ol ol:is([class*='ecl-u-']),
+.ecl ol ol:is([class*='ecl-u-']) {
+  @extend %ecl-ordered-list--nested;
+}
+
 .ecl ol ul:not([class*='ecl-'], [class*='wt-']),
 .ecl ol ul:is([class*='ecl-u-']) {
-  @extend %ecl-ordered-list--nested;
+  @extend %ecl-unordered-list--nested;
 }
 
 .ecl ol li:not([class*='ecl-'], [class*='wt-']),

--- a/src/presets/ec/src/ec-default.scss
+++ b/src/presets/ec/src/ec-default.scss
@@ -110,10 +110,15 @@
 }
 
 .ecl ul ul:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
-.ecl ul ul:is([class*='ecl-u-']),
+.ecl ul ul:is([class*='ecl-u-']) {
+  @extend %ecl-unordered-list--nested;
+}
+
 .ecl ul ol:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
 .ecl ul ol:is([class*='ecl-u-']) {
-  @extend %ecl-unordered-list--nested;
+  padding-inline-start: var(--s-l);
+
+  @extend %ecl-ordered-list--nested;
 }
 
 .ecl ul li:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
@@ -132,10 +137,15 @@
 }
 
 .ecl ol ol:not([class*='ecl-'], [class*='wt-']),
-.ecl ol ol:is([class*='ecl-u-']),
+.ecl ol ol:is([class*='ecl-u-']) {
+  @extend %ecl-ordered-list--nested;
+}
+
 .ecl ol ul:not([class*='ecl-'], [class*='wt-']),
 .ecl ol ul:is([class*='ecl-u-']) {
-  @extend %ecl-ordered-list--nested;
+  margin-inline-start: 0;
+
+  @extend %ecl-unordered-list__item;
 }
 
 .ecl ol li:not([class*='ecl-'], [class*='wt-']),
@@ -158,12 +168,12 @@
   @extend %ecl-description-list__definition;
 }
 
-.ecl table:not([class*='ecl-'], [class*='wt-']),
+.ecl table:not([class*='ecl-'], [class*='wt-'], .ecl-datepicker table),
 .ecl table:is([class*='ecl-u-']) {
   @extend %ecl-table;
 }
 
-.ecl thead:not([class*='ecl-'], [class*='wt-']),
+.ecl thead:not([class*='ecl-'], [class*='wt-'], .ecl-datepicker thead),
 .ecl thead:is([class*='ecl-u-']) {
   @extend %ecl-table__head;
 
@@ -172,17 +182,17 @@
   }
 }
 
-.ecl th:not([class*='ecl-'], [class*='wt-']),
+.ecl th:not([class*='ecl-'], [class*='wt-'], .ecl-datepicker th),
 .ecl th:is([class*='ecl-u-']) {
   @extend %ecl-table__header;
 }
 
-.ecl tr:not([class*='ecl-'], [class*='wt-']),
+.ecl tr:not([class*='ecl-'], [class*='wt-'], .ecl-datepicker tr),
 .ecl tr:is([class*='ecl-u-']) {
   @extend %ecl-table__row;
 }
 
-.ecl td:not([class*='ecl-'], [class*='wt-']),
+.ecl td:not([class*='ecl-'], [class*='wt-'], .ecl-datepicker td),
 .ecl td:is([class*='ecl-u-']) {
   @extend %ecl-table__cell;
 }

--- a/src/presets/eu/src/eu-default-print.scss
+++ b/src/presets/eu/src/eu-default-print.scss
@@ -136,10 +136,13 @@ html {
 }
 
 .ecl ul ul:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
-.ecl ul ul:is([class*='ecl-u-']),
+.ecl ul ul:is([class*='ecl-u-']) {
+  @extend %ecl-unordered-list--nested;
+}
+
 .ecl ul ol:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
 .ecl ul ol:is([class*='ecl-u-']) {
-  @extend %ecl-unordered-list--nested;
+  @extend %ecl-ordered-list--nested;
 }
 
 .ecl ul li:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
@@ -158,10 +161,13 @@ html {
 }
 
 .ecl ol ol:not([class*='ecl-'], [class*='wt-']),
-.ecl ol ol:is([class*='ecl-u-']),
+.ecl ol ol:is([class*='ecl-u-']) {
+  @extend %ecl-ordered-list--nested;
+}
+
 .ecl ol ul:not([class*='ecl-'], [class*='wt-']),
 .ecl ol ul:is([class*='ecl-u-']) {
-  @extend %ecl-ordered-list--nested;
+  @extend %ecl-unordered-list--nested;
 }
 
 .ecl ol li:not([class*='ecl-'], [class*='wt-']),

--- a/src/presets/eu/src/eu-default.scss
+++ b/src/presets/eu/src/eu-default.scss
@@ -110,10 +110,15 @@
 }
 
 .ecl ul ul:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
-.ecl ul ul:is([class*='ecl-u-']),
+.ecl ul ul:is([class*='ecl-u-']) {
+  @extend %ecl-unordered-list--nested;
+}
+
 .ecl ul ol:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
 .ecl ul ol:is([class*='ecl-u-']) {
-  @extend %ecl-unordered-list--nested;
+  padding-inline-start: var(--s-l);
+
+  @extend %ecl-ordered-list--nested;
 }
 
 .ecl ul li:not([class*='ecl-'], [class*='wt-'], [class*='highcharts-']),
@@ -132,10 +137,13 @@
 }
 
 .ecl ol ol:not([class*='ecl-'], [class*='wt-']),
-.ecl ol ol:is([class*='ecl-u-']),
+.ecl ol ol:is([class*='ecl-u-']) {
+  @extend %ecl-ordered-list--nested;
+}
+
 .ecl ol ul:not([class*='ecl-'], [class*='wt-']),
 .ecl ol ul:is([class*='ecl-u-']) {
-  @extend %ecl-ordered-list--nested;
+  @extend %ecl-unordered-list--nested;
 }
 
 .ecl ol li:not([class*='ecl-'], [class*='wt-']),

--- a/src/utilities/html-tag/index.story.js
+++ b/src/utilities/html-tag/index.story.js
@@ -53,6 +53,16 @@ export const Default = () => `
         </li>
       </ul>
       <hr />
+      <ul>
+        <li>Unordered list</li>
+        <li>Unordered list
+          <ol>
+            <li><a href="${exampleLink}">Nested ordered list in an unordered list</a></li>
+            <li>Nested ordered list in an unordered list</li>
+          </ol>
+        </li>
+      </ul>
+      <hr />
       <ol>
         <li>Ordered list</li>
         <li>Ordered list
@@ -60,6 +70,16 @@ export const Default = () => `
             <li><a href="${exampleLink}"class="ecl-link">Nested ordered list</a></li>
             <li>Nested ordered list</li>
           </ol>
+        </li>
+      </ol>
+      <hr />
+      <ol>
+        <li>Ordered list</li>
+        <li>Ordered list
+          <ul>
+            <li><a href="${exampleLink}"class="ecl-link">Nested unordered list in an ordered list</a></li>
+            <li>Nested unordered list in an ordered list</li>
+          </ul>
         </li>
       </ol>
       <dl>


### PR DESCRIPTION
I added examples of nested ols in uls and viceversa in the html tag page in the utilities