### PR TITLE
feat(menu): close the menu when clicking on a link

### DIFF
--- a/src/implementations/vanilla/components/mega-menu/mega-menu.js
+++ b/src/implementations/vanilla/components/mega-menu/mega-menu.js
@@ -226,6 +226,9 @@ export class MegaMenu {
         if (this.attachKeyListener) {
           link.addEventListener('keyup', this.handleKeyboard);
         }
+        if (this.attachClickListener) {
+          link.addEventListener('click', this.handleClickOnClose);
+        }
       });
     }
 

--- a/src/implementations/vanilla/components/menu/menu.js
+++ b/src/implementations/vanilla/components/menu/menu.js
@@ -260,6 +260,9 @@ export class Menu {
         if (this.attachKeyListener) {
           link.addEventListener('keyup', this.handleKeyboard);
         }
+        if (this.attachClickListener) {
+          link.addEventListener('click', this.handleClickOnClose);
+        }
       });
     }
 


### PR DESCRIPTION
Make the menu close when clicking on a link, so that fragment URLs work as well.

I have a menu with just relative fragment URLs like this one:

```html
<a
  href="#faq"
  class="ecl-link ecl-link--standalone ecl-menu__link"
  data-ecl-menu-link=""
  id="ecl-menu-item-faq-link"
  >FAQ
</a>
```

On mobile, when clicking on the link the viewport correctly scrolls to the expected section, but the menu doesn't close. Most of the times links in the menu load a new page, so closing the menu is not an issue, but it is when the link stays on the same page.

I'm not using the mega menu, but I guess the same feature could apply to it as well. Note that I didn't test it