### PR TITLE
feat(datepicker): update documentation - FRONT-5240

### DIFF
--- a/docs/Migrating-v5.md
+++ b/docs/Migrating-v5.md
@@ -188,7 +188,9 @@ ECL v5 uses [duet datepicker](https://duetds.github.io/date-picker/) which repla
 
 `<script type="module" src="https://cdn.jsdelivr.net/npm/@duetds/date-picker@1.4.0/dist/duet/duet.esm.js"></script>`
 
-if you have no restrictions on the use of external scripts, otherwise you'll need:
+**Important:** Using an external CDN may not be allowed for your website (this is most probably the case if it is hosted under europa.eu).
+In that case, you would have to use one of the following options and use:
+
 A) the npm package `npm install @duetds/date-picker`, and the whole `dist` folder you'll find inside of it
 or
 B) the tarball from https://registry.npmjs.org/@duetds/date-picker/-/date-picker-1.4.0.tgz that is also containing the same `dist` folder

--- a/src/website/src/pages/ec/getting-started/index.mdx
+++ b/src/website/src/pages/ec/getting-started/index.mdx
@@ -272,7 +272,12 @@ This library is **not bundled with ECL**, so you need to include it yourself if 
 
 #### Option 1 — Load from CDN (simplest, no Node required)
 
-If you don’t have restrictions on loading external scripts, you can include the datepicker directly from the CDN:
+**Important**
+
+Before using a resource from an external CDN, you have to make sure that this is allowed for your website. For instance, this is not the case for most of the websites hosted under europa.eu.
+So, even if this solution is the easiest to put in place, it may not be suited in your situation.
+
+If you don't have restrictions on loading external scripts, you can include the datepicker directly by using:
 
 ```html
 <script
@@ -358,7 +363,7 @@ cp -r package/dist/* /path/to/assets/duet/
 - The `/assets/duet/` folder must contain the files from `dist/`, not the `dist` folder itself.
 - Only include the `<script>` on pages that actually use datepickers.
 - Option 2 is recommended for modern build setups and avoids manual copying.
-- Option 1 is the simplest if external scripts are allowed.
+- Option 1 is the simplest, but only if external scripts are allowed.
 - Option 4 is useful for static sites or CMSs where Node.js/npm is not available.
 
 ---

--- a/src/website/src/pages/eu/getting-started/index.mdx
+++ b/src/website/src/pages/eu/getting-started/index.mdx
@@ -268,7 +268,12 @@ This library is **not bundled with ECL**, so you need to include it yourself if 
 
 #### Option 1 — Load from CDN (simplest, no Node required)
 
-If you don’t have restrictions on loading external scripts, you can include the datepicker directly from the CDN:
+**Important**
+
+Before using a resource from an external CDN, you have to make sure that this is allowed for your website. For instance, this is not the case for most of the websites hosted under europa.eu.
+So, even if this solution is the easiest to put in place, it may not be suited in your situation.
+
+If you don't have restrictions on loading external scripts, you can include the datepicker directly by using:
 
 ```html
 <script
@@ -354,7 +359,7 @@ cp -r package/dist/* /path/to/assets/duet/
 - The `/assets/duet/` folder must contain the files from `dist/`, not the `dist` folder itself.
 - Only include the `<script>` on pages that actually use datepickers.
 - Option 2 is recommended for modern build setups and avoids manual copying.
-- Option 1 is the simplest if external scripts are allowed.
+- Option 1 is the simplest, but only if external scripts are allowed.
 - Option 4 is useful for static sites or CMSs where Node.js/npm is not available.
 
 ---


### PR DESCRIPTION
Make it clear that using an external CDN is not allowed in some cases