### PR TITLE
fix language selector items to avoid line breaks in lang codes

### DIFF
--- a/src/components/site-header/_site-header-dropdown.scss
+++ b/src/components/site-header/_site-header-dropdown.scss
@@ -169,6 +169,10 @@ $language-list: null !default;
   padding: 0;
 }
 
+.ecl-site-header__language-item {
+  overflow-wrap: normal;
+}
+
 .ecl-site-header__language-link,
 .ecl-site-header__custom-action-link {
   align-items: baseline;


### PR DESCRIPTION
<img width="2445" height="1383" alt="image" src="https://github.com/user-attachments/assets/f1145e84-286e-4b4b-a08c-40df9be1b9e6" />
