### PR TITLE
feat(multiselect): Adding option to submit the form - FRONT-5287

### DIFF
--- a/src/components/form-group/form-group.story.js
+++ b/src/components/form-group/form-group.story.js
@@ -56,6 +56,7 @@ const getArgs = (data) => {
   if (data.input.input_type === 'select' && data.input.multiple) {
     args.show_select_all = true;
     args.show_search = true;
+    args.submit = false;
   }
 
   Object.assign(args.input, data.input);
@@ -93,6 +94,18 @@ const getArgTypes = (data, type) => ({
             category: 'Optional',
           },
         },
+        submit: {
+          type: { name: 'boolean' },
+          mapping: {
+            0: false,
+            1: true,
+          },
+          table: {
+            type: { summary: 'boolean' },
+            defaultValue: { summary: 'false' },
+            category: 'Optional',
+          },
+        },
       }
     : {}),
 });
@@ -114,6 +127,7 @@ const prepareData = (data, args) => {
   if (clone.input.input_type === 'select' && clone.input.multiple) {
     clone.input.multiple_select_all = !!args.show_select_all;
     clone.input.multiple_search = !!args.show_search;
+    clone.input.multiple_submit = !!args.submit;
   }
   if (clone.input.input_type === 'checkbox') {
     if (clone.input.standalone && args.hide_label) {

--- a/src/components/select/select.html.twig
+++ b/src/components/select/select.html.twig
@@ -26,6 +26,7 @@
   - "multiple_search_text" (string)(default: '') Label for the search box inside the multiple select
   - "multiple_search_no_results_text" (string)(default: '') Label label when there is no result by searching for an option
   - "multiple_select_all" (boolean) (default: true) Show the select all checkbox in the multiple select
+  - "multiple_submit" (boolean) (default: false) Make the primary button of the multiple select a submit button
   - "extra_group_classes" (optional) (string) (default: '') Extra classes (space separated) for the select group
   - "extra_classes" (string) (default: '') Extra classes (space separated) for the select
   - "extra_attributes" (optional) (array) (default: []) Extra attributes for select
@@ -48,6 +49,7 @@
 {% set _label = label|default('') %}
 {% set _toggle_label = toggle_label|default('Toggle dropdown') %}
 {% set _multiple = multiple|default(false) %}
+{% set _multiple_submit = multiple_submit|default(false) %}
 {% set _multiple_placeholder = multiple_placeholder|default('') %}
 {% set _multiple_all_text = multiple_all_text|default('') %}
 {% set _multiple_search = multiple_search ?? true %}
@@ -75,6 +77,10 @@
 
   {% if _multiple_select_all and _multiple_all_text is not empty %}
     {% set extra_attributes = extra_attributes|merge([{ name: 'data-ecl-select-all', value: _multiple_all_text }]) %}
+  {% endif %}
+
+  {% if _multiple_submit %}
+    {% set extra_attributes = extra_attributes|merge([{ name: 'data-ecl-select-submit'}]) %}
   {% endif %}
 
   {% if _multiple_search and _multiple_search_text is not empty %}

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -24,6 +24,7 @@ const iconSize = system === 'eu' ? 's' : 'xs';
  * @param {String} options.selectAllTextAttribute The data attribute for the select all text
  * @param {String} options.noResultsTextAttribute The data attribute for the no results options text
  * @param {String} options.closeLabelAttribute The data attribute for the close button
+ * @param {String} options.submitAttribute The data attribute for the submit button
  * @param {String} options.clearAllLabelAttribute The data attribute for the clear all button
  * @param {String} options.selectMultiplesSelectionCountSelector The selector for the counter of selected options
  * @param {String} options.closeButtonLabel The label of the close button
@@ -84,6 +85,7 @@ export class Select {
       noResultsTextAttribute = 'data-ecl-select-no-results',
       closeLabelAttribute = 'data-ecl-select-close',
       clearAllLabelAttribute = 'data-ecl-select-clear-all',
+      submitAttribute = 'data-ecl-select-submit',
       selectMultiplesSelectionCountSelector = 'ecl-select-multiple-selections-counter',
       closeButtonLabel = '',
       clearAllButtonLabel = '',
@@ -115,6 +117,7 @@ export class Select {
     this.closeButtonLabel = closeButtonLabel;
     this.closeLabelAttribute = closeLabelAttribute;
     this.clearAllLabelAttribute = clearAllLabelAttribute;
+    this.submitAttribute = submitAttribute;
 
     // Private variables
     this.input = null;
@@ -224,7 +227,6 @@ export class Select {
     input.classList.add('ecl-checkbox__input');
     input.setAttribute('type', 'checkbox');
     input.setAttribute('id', `${ctx}-${id}`);
-    input.setAttribute('name', `${ctx}-${id}`);
     checkbox.appendChild(input);
     label.classList.add('ecl-checkbox__label');
     label.setAttribute('for', `${ctx}-${id}`);
@@ -313,6 +315,7 @@ export class Select {
 
     if (this.multiple) {
       const containerClasses = Array.from(this.select.parentElement.classList);
+      this.willSubmit = this.element.hasAttribute(this.submitAttribute);
       this.textDefault =
         this.defaultText ||
         this.element.getAttribute(this.defaultTextAttribute);
@@ -455,6 +458,9 @@ export class Select {
 
         if (this.closeButtonLabel) {
           this.closeButton = document.createElement('button');
+          if (this.willSubmit) {
+            this.closeButton.setAttribute('type', 'submit');
+          }
           this.closeButton.textContent = this.closeButtonLabel;
           this.closeButton.classList.add('ecl-button', 'ecl-button--primary');
           this.closeButton.addEventListener('click', this.handleEsc);
@@ -1456,7 +1462,9 @@ export class Select {
    */
   handleEsc(e) {
     if (this.multiple) {
-      e.preventDefault();
+      if (!(this.willSubmit && e.target === this.closeButton)) {
+        e.preventDefault();
+      }
       this.searchContainer.style.display = 'none';
       this.input.setAttribute('aria-expanded', false);
       this.input.blur();


### PR DESCRIPTION
This can be tested by adding this in the form group story file:
export const SelectMultipleSubmit = (_, { loaded: { component } }) => component;

```
SelectMultipleSubmit.render = async () => {
  dataMultiple.input.multiple_submit = true;
  const renderedSelectMultiple = `<form>${await formGroup(dataMultiple)}</form>`;
  return renderedSelectMultiple;
};
SelectMultipleSubmit.storyName = 'Select multiple submit';

SelectMultipleSubmit.play = async ({ canvasElement }) => {
  const form = canvasElement.querySelector('form');

  form.addEventListener('submit', (e) => {
    e.preventDefault();

    console.log('FormData', [...new FormData(form).entries()]);
  });
};
```
Additionally the name in the checkboxes used in the multiple select has been reoved since that way also the checkboxes where submitting values.