### PR TITLE
Minor doc correction on breadcrumbs

### DIFF
--- a/src/implementations/twig/components/breadcrumb/breadcrumb.html.twig
+++ b/src/implementations/twig/components/breadcrumb/breadcrumb.html.twig
@@ -11,7 +11,7 @@
     ],
     - "navigation_text" (string) (default: ''): Text of navigation in breadcrumb
     - "ellipsis_label" (string) (default: ''): Label of the ellipsis, e.g. "Click to expand"
-    - "ellipsis_text" (string) (default: '...'): Text of the ellipsis
+    - "ellipsis_text" (string) (default: '…'): Text of the ellipsis
     - "icon_path" (string) (default: ''): URL to icons file
     - "extra_classes" (string) (default: '')
     - "extra_attributes" (array) (default: []): format: [


### PR DESCRIPTION
Correct documentation of default value for ellipsis text to be ellipsis character (not 3-dots)