### PR TITLE
fix(quiz): empty markup and css fix - FRONT-5326

### DIFF
--- a/src/components/quiz/quiz.html.twig
+++ b/src/components/quiz/quiz.html.twig
@@ -78,14 +78,20 @@
 {% if _with_background %}
   <div class="ecl-container">
 {% endif %}
+{% if _title is not empty or _description is not empty %}
   <div class="ecl-quiz__header">
+    {% if _title is not empty %}
     <div class="ecl-quiz__title">
       {{-  _title -}}
     </div>
+    {% endif %}
+    {% if _description is not empty %}
     <div class="ecl-quiz__description">
       {{- _description -}}
     </div>
+    {% endif %}
   </div>
+{% endif %}
 {% if _items is not empty and _items is iterable %}
   <div
     class="ecl-quiz__viewport"

--- a/src/components/quiz/quiz.js
+++ b/src/components/quiz/quiz.js
@@ -63,6 +63,7 @@ export class Quiz {
       backClass = '.ecl-quiz-card__back',
       prevClass = '.ecl-quiz__prev',
       nextClass = '.ecl-quiz__next',
+      pagerClass = '.ecl-quiz__pager',
       dotsClass = '.ecl-quiz__dots',
       dotClass = '.ecl-quiz__dot',
       activeDotClass = 'ecl-quiz__dot--active',
@@ -92,6 +93,7 @@ export class Quiz {
     this.answerClass = answerClass;
     this.prevClass = prevClass;
     this.nextClass = nextClass;
+    this.pagerClass = pagerClass;
     this.dotsClass = dotsClass;
     this.dotClass = dotClass;
     this.frontClass = frontClass;
@@ -108,6 +110,8 @@ export class Quiz {
     this.resizeTimer = null;
     this.slider = null;
     this.dotsNode = null;
+    this.pagerNode = null;
+    this.toggleButtonsDisabled = null;
     this.ariaObserver = null;
 
     // Bind `this` for use in callbacks
@@ -289,6 +293,7 @@ export class Quiz {
     const accessibility = this.slider.plugins().accessibility;
     this.prevButtonNode = queryOne(this.prevClass, this.element);
     this.nextButtonNode = queryOne(this.nextClass, this.element);
+    this.pagerNode = queryOne(this.pagerClass, this.element);
 
     if (this.prevButtonNode) {
       this.prevButtonNode.addEventListener(
@@ -306,7 +311,7 @@ export class Quiz {
     }
 
     if (this.prevButtonNode && this.nextButtonNode) {
-      const toggleButtonsDisabled = (emblaApi) => {
+      this.toggleButtonsDisabled = (emblaApi) => {
         const setButtonState = (button, enabled) => {
           button.toggleAttribute('disabled', !enabled);
         };
@@ -314,9 +319,9 @@ export class Quiz {
         setButtonState(this.nextButtonNode, emblaApi.canGoToNext());
       };
 
-      toggleButtonsDisabled(this.slider);
-      this.slider.on('select', toggleButtonsDisabled);
-      this.slider.on('reInit', toggleButtonsDisabled);
+      this.toggleButtonsDisabled(this.slider);
+      this.slider.on('select', this.toggleButtonsDisabled);
+      this.slider.on('reInit', this.toggleButtonsDisabled);
 
       accessibility.setupPrevAndNextButtons(
         this.prevButtonNode,
@@ -348,12 +353,10 @@ export class Quiz {
         const canScroll =
           this.slider.canGoToNext() || this.slider.canGoToPrev();
 
-        this.prevButtonNode.style.display = '';
-        this.nextButtonNode.style.display = '';
+        if (this.pagerNode) this.pagerNode.style.display = '';
 
         if (!canScroll) {
-          this.prevButtonNode.style.display = 'none';
-          this.nextButtonNode.style.display = 'none';
+          if (this.pagerNode) this.pagerNode.style.display = 'none';
 
           this.dotsNode.innerHTML = '';
           dotNodes = [];
@@ -604,6 +607,9 @@ export class Quiz {
       if (this.slider) {
         this.createAndSetupDotButtons(this.slider, this.dotsNode);
         this.updateDots();
+        if (this.toggleButtonsDisabled) {
+          this.toggleButtonsDisabled(this.slider);
+        }
       }
 
       this.checkHeight();

--- a/src/components/quiz/quiz.scss
+++ b/src/components/quiz/quiz.scss
@@ -45,10 +45,18 @@ $quiz: null !default;
   @include mixins.responsive-font(map.get($quiz, 'quiz', 'description-font'));
 }
 
+.ecl-quiz__header + .ecl-quiz__viewport {
+  margin-block-start: map.get($quiz, 'quiz', 'list-spacing-mobile');
+}
+
+.ecl-quiz__header > *:first-child {
+  margin-block-start: 0;
+}
+
 .ecl-quiz__list {
   display: flex;
   gap: map.get($quiz, 'quiz', 'list-gap-mobile');
-  margin-block: map.get($quiz, 'quiz', 'list-spacing-mobile');
+  margin-block: 0;
   padding: 0;
   touch-action: pan-y pinch-zoom;
 }
@@ -58,6 +66,10 @@ $quiz: null !default;
   text-align: center;
 
   @include mixins.responsive-font(map.get($quiz, 'quiz', 'counter-font'));
+}
+
+.ecl-quiz__viewport + .ecl-quiz__pager {
+  margin-block-start: map.get($quiz, 'quiz', 'list-spacing-mobile');
 }
 
 .ecl-quiz .ecl-quiz__pager {
@@ -176,13 +188,20 @@ $quiz: null !default;
     display: none;
   }
 
+  .ecl-quiz__header + .ecl-quiz__viewport {
+    margin-block-start: map.get($quiz, 'quiz', 'list-spacing-tablet');
+  }
+
   .ecl-quiz__list {
     gap: map.get($quiz, 'quiz', 'list-gap-tablet');
-    margin-block: map.get($quiz, 'quiz', 'list-spacing-tablet');
   }
 
   .ecl-quiz__description {
     margin-block-start: var(--s-m);
+  }
+
+  .ecl-quiz__viewport + .ecl-quiz__pager {
+    margin-block-start: map.get($quiz, 'quiz', 'list-spacing-tablet');
   }
 
   .ecl-quiz .ecl-quiz__pager {
@@ -213,9 +232,12 @@ $quiz: null !default;
 }
 
 @container (width >= #{map.get($theme, 'breakpoint', 'xl')}) {
+  .ecl-quiz__header + .ecl-quiz__viewport {
+    margin-block-start: map.get($quiz, 'quiz', 'list-spacing-desktop');
+  }
+
   .ecl-quiz__list {
     gap: map.get($quiz, 'quiz', 'list-gap-desktop');
-    margin-block: map.get($quiz, 'quiz', 'list-spacing-desktop');
   }
 
   .ecl-quiz__description {
@@ -224,6 +246,10 @@ $quiz: null !default;
 
   .ecl-quiz-card {
     width: calc((100% - 2 * map.get($quiz, 'quiz', 'list-gap-desktop')) / 3);
+  }
+
+  .ecl-quiz__viewport + .ecl-quiz__pager {
+    margin-block-start: map.get($quiz, 'quiz', 'list-spacing-desktop');
   }
 }
 


### PR DESCRIPTION
add a check for the quiz header, to prevent empty markup.
The css and js had to be updated, to remove empty spaces when the data is not present

Also fix an unneeded margin when the slider control are not displayed