### PR TITLE
chore(html-source-plugin): Storing source markup in a script tag not to pollute the DOM

### DIFF
--- a/src/playground/addons/storybook-addon-code/register.jsx
+++ b/src/playground/addons/storybook-addon-code/register.jsx
@@ -12,9 +12,13 @@ addons.register(ADDON_ID, () => {
       const iframe = document.querySelector('#storybook-preview-iframe');
       const rootDiv = iframe.contentDocument.querySelector('#storybook-root');
       const storyMarkup = rootDiv ? rootDiv.innerHTML : '';
-      const originalMarkup = rootDiv.querySelector(
-        '.original-markup-source',
-      )?.textContent;
+      let originalMarkup = '';
+
+      if (rootDiv) {
+        originalMarkup = rootDiv.querySelector(
+          '.original-markup-source',
+        )?.textContent;
+      }
 
       return (
         <HTMLMarkup

--- a/src/playground/addons/storybook-addon-code/register.jsx
+++ b/src/playground/addons/storybook-addon-code/register.jsx
@@ -12,9 +12,9 @@ addons.register(ADDON_ID, () => {
       const iframe = document.querySelector('#storybook-preview-iframe');
       const rootDiv = iframe.contentDocument.querySelector('#storybook-root');
       const storyMarkup = rootDiv ? rootDiv.innerHTML : '';
-      const originalMarkup = rootDiv
-        ? rootDiv.getAttribute('data-original-markup')
-        : '';
+      const originalMarkup = rootDiv.querySelector(
+        '.original-markup-source',
+      )?.textContent;
 
       return (
         <HTMLMarkup

--- a/src/playground/ec/.storybook/preview.js
+++ b/src/playground/ec/.storybook/preview.js
@@ -224,8 +224,18 @@ export const loaders = [
       if (typeof component === 'string') {
         setTimeout(() => {
           const rootDiv = document.querySelector('#storybook-root');
+
           if (rootDiv) {
-            rootDiv.setAttribute('data-original-markup', component);
+            // Remove previous script if present
+            rootDiv.querySelector('.original-markup-source')?.remove();
+
+            const script = document.createElement('script');
+
+            script.type = 'text/plain';
+            script.className = 'original-markup-source';
+            script.textContent = component;
+
+            rootDiv.appendChild(script);
           }
         }, 0);
       }

--- a/src/playground/eu/.storybook/preview.js
+++ b/src/playground/eu/.storybook/preview.js
@@ -217,8 +217,18 @@ export const loaders = [
       if (typeof component === 'string') {
         setTimeout(() => {
           const rootDiv = document.querySelector('#storybook-root');
+
           if (rootDiv) {
-            rootDiv.setAttribute('data-original-markup', component);
+            // Remove previous script if present
+            rootDiv.querySelector('.original-markup-source')?.remove();
+
+            const script = document.createElement('script');
+
+            script.type = 'text/plain';
+            script.className = 'original-markup-source';
+            script.textContent = component;
+
+            rootDiv.appendChild(script);
           }
         }, 0);
       }


### PR DESCRIPTION
I was very annoyed by this code appearing always on top in the inspector, i think it's cleaner this way... :)