### PR TITLE
feat(quiz): improve keyboard navigation - FRONT-5316

### DIFF
--- a/src/components/quiz/__snapshots__/quiz.test.js.snap
+++ b/src/components/quiz/__snapshots__/quiz.test.js.snap
@@ -146,6 +146,7 @@ exports[`Quiz Poll renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -331,6 +332,7 @@ exports[`Quiz Poll renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -500,6 +502,7 @@ exports[`Quiz Poll renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -663,6 +666,7 @@ exports[`Quiz Poll renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -826,6 +830,7 @@ exports[`Quiz Poll renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1022,6 +1027,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1096,6 +1102,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1170,6 +1177,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1244,6 +1252,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1318,6 +1327,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1476,6 +1486,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1550,6 +1561,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1624,6 +1636,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1698,6 +1711,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1772,6 +1786,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -1932,6 +1947,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -2006,6 +2022,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -2080,6 +2097,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -2154,6 +2172,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"
@@ -2228,6 +2247,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
             <div
               class="ecl-quiz-card__back"
               hidden=""
+              inert=""
             >
               <div
                 class="ecl-quiz-card__header"

--- a/src/components/quiz/__snapshots__/quiz.test.js.snap
+++ b/src/components/quiz/__snapshots__/quiz.test.js.snap
@@ -144,7 +144,6 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -330,7 +329,6 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -500,7 +498,6 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -664,7 +661,6 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -828,7 +824,6 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1025,7 +1020,6 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1100,7 +1094,6 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1175,7 +1168,6 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1250,7 +1242,6 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1325,7 +1316,6 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1484,7 +1474,6 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1559,7 +1548,6 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1634,7 +1622,6 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1709,7 +1696,6 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1784,7 +1770,6 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1945,7 +1930,6 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -2020,7 +2004,6 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -2095,7 +2078,6 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -2170,7 +2152,6 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -2245,7 +2226,6 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
-              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >

--- a/src/components/quiz/__snapshots__/quiz.test.js.snap
+++ b/src/components/quiz/__snapshots__/quiz.test.js.snap
@@ -144,6 +144,7 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -329,6 +330,7 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -498,6 +500,7 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -661,6 +664,7 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -824,6 +828,7 @@ exports[`Quiz Poll renders correctly 1`] = `
               </fieldset>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1020,6 +1025,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1094,6 +1100,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1168,6 +1175,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1242,6 +1250,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1316,6 +1325,7 @@ exports[`Quiz Reveal renders correctly 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1474,6 +1484,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1548,6 +1559,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1622,6 +1634,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1696,6 +1709,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1770,6 +1784,7 @@ exports[`Quiz Reveal renders correctly with extra attributes 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -1930,6 +1945,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -2004,6 +2020,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -2078,6 +2095,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -2152,6 +2170,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >
@@ -2226,6 +2245,7 @@ exports[`Quiz Reveal renders correctly with extra class names 1`] = `
               </div>
             </div>
             <div
+              aria-hidden="true"
               class="ecl-quiz-card__back"
               hidden=""
             >

--- a/src/components/quiz/quiz-card.html.twig
+++ b/src/components/quiz/quiz-card.html.twig
@@ -133,6 +133,7 @@
     <div
       class="ecl-quiz-card__back"
       hidden
+      inert
     >
       <div class="ecl-quiz-card__header">
         <div class="ecl-quiz-card__icon">

--- a/src/components/quiz/quiz-card.html.twig
+++ b/src/components/quiz/quiz-card.html.twig
@@ -132,6 +132,7 @@
     </div>
     <div
       class="ecl-quiz-card__back"
+      aria-hidden="true"
       hidden
     >
       <div class="ecl-quiz-card__header">

--- a/src/components/quiz/quiz-card.html.twig
+++ b/src/components/quiz/quiz-card.html.twig
@@ -132,7 +132,6 @@
     </div>
     <div
       class="ecl-quiz-card__back"
-      aria-hidden="true"
       hidden
     >
       <div class="ecl-quiz-card__header">

--- a/src/components/quiz/quiz.js
+++ b/src/components/quiz/quiz.js
@@ -685,8 +685,17 @@ export class Quiz {
         );
       }
 
-      front.hidden = isFlipped;
-      back.hidden = !isFlipped;
+      if (isFlipped) {
+        front.hidden = true;
+        front.setAttribute('aria-hidden', true);
+        back.hidden = false;
+        back.removeAttribute('aria-hidden');
+      } else {
+        front.hidden = false;
+        front.removeAttribute('aria-hidden');
+        back.hidden = true;
+        back.setAttribute('aria-hidden', true);
+      }
 
       // Update aria-labelledby
       const question = queryOne(`#${card.id}-question`, card);

--- a/src/components/quiz/quiz.js
+++ b/src/components/quiz/quiz.js
@@ -699,13 +699,6 @@ export class Quiz {
           category = queryOne('.ecl-quiz-card__category--success', back);
         }
 
-        // FRONT-5298 Focus after answering
-        if (isFlipped) {
-          if (category) {
-            category.focus();
-          }
-        }
-
         const options = queryOne('.ecl-quiz-card__options', back);
         Array.from(options.children).forEach((el) =>
           el.classList.remove('ecl-quiz-card__option--selected'),
@@ -715,20 +708,14 @@ export class Quiz {
         );
       }
 
-      if (isFlipped) {
-        front.hidden = true;
-        front.inert = true;
-        front.setAttribute('aria-hidden', true);
-        back.hidden = false;
-        back.inert = false;
-        back.removeAttribute('aria-hidden');
-      } else {
-        front.hidden = false;
-        front.inert = false;
-        front.removeAttribute('aria-hidden');
-        back.hidden = true;
-        back.inert = true;
-        back.setAttribute('aria-hidden', true);
+      front.hidden = isFlipped;
+      front.inert = isFlipped;
+      back.hidden = !isFlipped;
+      back.inert = !isFlipped;
+
+      // FRONT-5298 Focus the status category after answering (poll variant only)
+      if (isFlipped && e.target.hasAttribute('data-match') && category) {
+        category.focus();
       }
 
       // Update aria-labelledby

--- a/src/components/quiz/quiz.js
+++ b/src/components/quiz/quiz.js
@@ -527,73 +527,103 @@ export class Quiz {
 
     if (
       e.key === 'Tab' &&
-      e.target.classList.contains('ecl-quiz-card__category') &&
-      card.nextElementSibling
+      !e.shiftKey &&
+      e.target.classList.contains('ecl-quiz-card__category')
     ) {
-      e.preventDefault();
-      const first = queryOne(
-        `[${this.inputSelector}]`,
-        card.nextElementSibling,
-      );
-      if (first) {
-        first.focus();
+      let nextSlide = card.nextElementSibling;
+      while (nextSlide && nextSlide.classList.contains(this.flippedClass)) {
+        nextSlide = nextSlide.nextElementSibling;
       }
+      if (nextSlide) {
+        e.preventDefault();
+        const idx = Array.from(this.cards).indexOf(nextSlide);
+        if (idx !== -1) this.slider.goTo(idx);
+        const firstInput = queryOne(`[${this.inputSelector}]`, nextSlide);
+        if (firstInput) firstInput.focus();
+      }
+      // No unflipped card ahead: let native Tab exit the quiz naturally
     }
 
     if (
-      (e.key === 'Tab' || e.key === 'ArrowDown' || e.key === 'ArrowUp') &&
+      e.key === 'Tab' &&
+      e.shiftKey &&
+      card.classList.contains(this.flippedClass) &&
+      e.target.closest(this.backClass)
+    ) {
+      let prevSlide = card.previousElementSibling;
+      while (prevSlide && prevSlide.classList.contains(this.flippedClass)) {
+        prevSlide = prevSlide.previousElementSibling;
+      }
+      if (prevSlide) {
+        e.preventDefault();
+        const idx = Array.from(this.cards).indexOf(prevSlide);
+        if (idx !== -1) this.slider.goTo(idx);
+        const lastInput = Array.from(
+          queryAll(`[${this.inputSelector}]`, prevSlide),
+        ).pop();
+        if (lastInput) lastInput.focus();
+      }
+      // No unflipped card before: let native Shift+Tab exit the quiz naturally
+      return;
+    }
+
+    // Tab from a radio input: jump to the nearest unflipped card, skipping flipped ones
+    if (e.key === 'Tab' && e.target.hasAttribute(this.inputSelector)) {
+      if (!e.shiftKey) {
+        let nextSlide = card.nextElementSibling;
+        while (nextSlide && nextSlide.classList.contains(this.flippedClass)) {
+          nextSlide = nextSlide.nextElementSibling;
+        }
+        if (nextSlide) {
+          e.preventDefault();
+          const idx = Array.from(this.cards).indexOf(nextSlide);
+          if (idx !== -1) this.slider.goTo(idx);
+          const firstInput = queryOne(`[${this.inputSelector}]`, nextSlide);
+          if (firstInput) firstInput.focus();
+        }
+        // No unflipped card ahead: let native Tab exit the quiz naturally
+      } else {
+        let prevSlide = card.previousElementSibling;
+        while (prevSlide && prevSlide.classList.contains(this.flippedClass)) {
+          prevSlide = prevSlide.previousElementSibling;
+        }
+        if (prevSlide) {
+          e.preventDefault();
+          const idx = Array.from(this.cards).indexOf(prevSlide);
+          if (idx !== -1) this.slider.goTo(idx);
+          const lastInput = Array.from(
+            queryAll(`[${this.inputSelector}]`, prevSlide),
+          ).pop();
+          if (lastInput) lastInput.focus();
+        }
+        // No unflipped card before: let native Shift+Tab exit the quiz naturally
+      }
+    }
+
+    // Arrow keys: move focus within the card's options without selecting/flipping
+    if (
+      (e.key === 'ArrowDown' ||
+        e.key === 'ArrowUp' ||
+        e.key === 'ArrowRight' ||
+        e.key === 'ArrowLeft') &&
       e.target.hasAttribute(this.inputSelector)
     ) {
       e.preventDefault();
       const focusables = queryAll(`[${this.inputSelector}]`, card);
       const focusableArray = Array.from(focusables);
       const currentIndex = focusableArray.indexOf(item);
-      const isFirst = currentIndex === 0;
-      const isLast = currentIndex === focusableArray.length - 1;
 
-      // Shift + Tab or arrow up
-      if (e.shiftKey || e.key === 'ArrowUp') {
-        if (!isFirst) {
-          focusableArray[currentIndex - 1].setAttribute('tabindex', '0');
-          focusableArray[currentIndex - 1].focus();
-        }
-        // Handle Shift + Tab on the first option of the card
-        if (isFirst || card.classList.contains(this.flippedClass)) {
-          const prevSlide = card.previousElementSibling;
-
-          if (prevSlide) {
-            this.slider.goToPrev();
-            const previousFocusables = queryAll(
-              `[${this.inputSelector}]`,
-              prevSlide,
-            );
-            const previousOption = Array.from(previousFocusables).pop();
-            if (previousOption) {
-              previousOption.setAttribute('tabindex', '0');
-              previousOption.focus();
-            }
-          }
-        }
-
-        return;
-      }
-
-      if (!isLast) {
+      if ((e.key === 'ArrowUp' || e.key === 'ArrowLeft') && currentIndex > 0) {
+        item.setAttribute('tabindex', '-1');
+        focusableArray[currentIndex - 1].setAttribute('tabindex', '0');
+        focusableArray[currentIndex - 1].focus();
+      } else if (
+        (e.key === 'ArrowDown' || e.key === 'ArrowRight') &&
+        currentIndex < focusableArray.length - 1
+      ) {
+        item.setAttribute('tabindex', '-1');
         focusableArray[currentIndex + 1].setAttribute('tabindex', '0');
         focusableArray[currentIndex + 1].focus();
-      }
-      // Handle tab on the last option of the card
-      if (isLast || card.classList.contains(this.flippedClass)) {
-        const nextSlide = item.closest(this.cardSelector).nextElementSibling;
-
-        if (nextSlide) {
-          this.slider.goToNext();
-          const nextOption = queryOne(`[${this.inputSelector}]`, nextSlide);
-          if (nextOption) {
-            nextOption.setAttribute('tabindex', '0');
-            nextOption.focus();
-          }
-        }
       }
     }
   }
@@ -687,13 +717,17 @@ export class Quiz {
 
       if (isFlipped) {
         front.hidden = true;
+        front.inert = true;
         front.setAttribute('aria-hidden', true);
         back.hidden = false;
+        back.inert = false;
         back.removeAttribute('aria-hidden');
       } else {
         front.hidden = false;
+        front.inert = false;
         front.removeAttribute('aria-hidden');
         back.hidden = true;
+        back.inert = true;
         back.setAttribute('aria-hidden', true);
       }
 


### PR DESCRIPTION
Revamp the keyboard navigation, to allow jump from card to card with tab, browse options with arrow, and avoid flipped cards to be focused