### PR TITLE
chore(demo): remove placeholder from demo - FRONT-5431

### DIFF
--- a/src/components/datepicker/demo/data.js
+++ b/src/components/datepicker/demo/data.js
@@ -16,7 +16,6 @@ module.exports = {
     id: 'example-input-id-1',
     name: 'example-input-name-1',
     input_type: 'datepicker',
-    placeholder: 'DD-MM-YYYY',
     min: '2024-06-15',
     max: '2026-08-30',
     autoinit: true,

--- a/src/components/form-group/__snapshots__/form-group.test.js.snap
+++ b/src/components/form-group/__snapshots__/form-group.test.js.snap
@@ -4786,7 +4786,6 @@ exports[`Form group  with Text field renders correctly 1`] = `
       aria-describedby="example-input-id-1-helper"
       class="ecl-text-input ecl-text-input--m"
       id="example-input-id-1"
-      placeholder="Placeholder text"
       type="text"
     />
   </div>
@@ -4821,7 +4820,6 @@ exports[`Form group  with Text field renders correctly when disabled 1`] = `
       class="ecl-text-input ecl-text-input--m"
       disabled=""
       id="example-input-id-1"
-      placeholder="Placeholder text"
       type="text"
     />
   </div>
@@ -4856,7 +4854,6 @@ exports[`Form group  with Text field renders correctly when invalid 1`] = `
       aria-invalid="true"
       class="ecl-text-input ecl-text-input--invalid ecl-text-input--m"
       id="example-input-id-1"
-      placeholder="Placeholder text"
       type="text"
     />
     <div
@@ -4902,7 +4899,6 @@ exports[`Form group  with Text field renders correctly when required 1`] = `
       aria-describedby="example-input-id-1-helper"
       class="ecl-text-input ecl-text-input--m"
       id="example-input-id-1"
-      placeholder="Placeholder text"
       required=""
       type="text"
     />
@@ -4939,7 +4935,6 @@ exports[`Form group  with Text field renders correctly with extra attributes 1`]
       aria-describedby="example-input-id-1-helper"
       class="ecl-text-input ecl-text-input--m"
       id="example-input-id-1"
-      placeholder="Placeholder text"
       type="text"
     />
   </div>
@@ -4973,7 +4968,6 @@ exports[`Form group  with Text field renders correctly with extra class names 1`
       aria-describedby="example-input-id-1-helper"
       class="ecl-text-input ecl-text-input--m"
       id="example-input-id-1"
-      placeholder="Placeholder text"
       type="text"
     />
   </div>
@@ -5007,7 +5001,6 @@ exports[`Form group  with Textarea renders correctly 1`] = `
       aria-describedby="example-textarea-id-1-helper"
       class="ecl-text-area ecl-text-area--m"
       id="example-textarea-id-1"
-      placeholder="Placeholder text"
       rows="4"
     />
   </div>
@@ -5042,7 +5035,6 @@ exports[`Form group  with Textarea renders correctly when disabled 1`] = `
       class="ecl-text-area ecl-text-area--m"
       disabled=""
       id="example-textarea-id-1"
-      placeholder="Placeholder text"
       rows="4"
     />
   </div>
@@ -5077,7 +5069,6 @@ exports[`Form group  with Textarea renders correctly when invalid 1`] = `
       aria-invalid="true"
       class="ecl-text-area ecl-text-area--invalid ecl-text-area--m"
       id="example-textarea-id-1"
-      placeholder="Placeholder text"
       rows="4"
     />
     <div
@@ -5123,7 +5114,6 @@ exports[`Form group  with Textarea renders correctly when required 1`] = `
       aria-describedby="example-textarea-id-1-helper"
       class="ecl-text-area ecl-text-area--m"
       id="example-textarea-id-1"
-      placeholder="Placeholder text"
       required=""
       rows="4"
     />
@@ -5160,7 +5150,6 @@ exports[`Form group  with Textarea renders correctly with extra attributes 1`] =
       aria-describedby="example-textarea-id-1-helper"
       class="ecl-text-area ecl-text-area--m"
       id="example-textarea-id-1"
-      placeholder="Placeholder text"
       rows="4"
     />
   </div>
@@ -5194,7 +5183,6 @@ exports[`Form group  with Textarea renders correctly with extra class names 1`] 
       aria-describedby="example-textarea-id-1-helper"
       class="ecl-text-area ecl-text-area--m"
       id="example-textarea-id-1"
-      placeholder="Placeholder text"
       rows="4"
     />
   </div>

--- a/src/components/highlighted-search/__snapshots__/highlighted-search.test.js.snap
+++ b/src/components/highlighted-search/__snapshots__/highlighted-search.test.js.snap
@@ -39,14 +39,13 @@ exports[`Highlighted search Default renders correctly 1`] = `
               for="highlighted-search-input-id"
               id="highlighted-search-input-id-label"
             >
-              Enter a search keyword
+              Search
             </label>
             <input
               aria-describedby="highlighted-search-helper"
               class="ecl-text-input ecl-text-input--l ecl-highlighted-search__form-input"
               id="highlighted-search-input-id"
               name="highlighted-search-input-name"
-              placeholder="Enter a search keyword"
               type="search"
             />
           </div>
@@ -61,7 +60,7 @@ exports[`Highlighted search Default renders correctly 1`] = `
           class="ecl-highlighted-search__form-helper"
           id="highlighted-search-helper"
         >
-          Enter the job you're looking for
+          e.g. full time, designer, writer
         </div>
       </form>
       <div
@@ -185,14 +184,13 @@ exports[`Highlighted search Default renders correctly with extra attributes 1`] 
               for="highlighted-search-input-id"
               id="highlighted-search-input-id-label"
             >
-              Enter a search keyword
+              Search
             </label>
             <input
               aria-describedby="highlighted-search-helper"
               class="ecl-text-input ecl-text-input--l ecl-highlighted-search__form-input"
               id="highlighted-search-input-id"
               name="highlighted-search-input-name"
-              placeholder="Enter a search keyword"
               type="search"
             />
           </div>
@@ -207,7 +205,7 @@ exports[`Highlighted search Default renders correctly with extra attributes 1`] 
           class="ecl-highlighted-search__form-helper"
           id="highlighted-search-helper"
         >
-          Enter the job you're looking for
+          e.g. full time, designer, writer
         </div>
       </form>
       <div
@@ -329,14 +327,13 @@ exports[`Highlighted search Default renders correctly with extra class names 1`]
               for="highlighted-search-input-id"
               id="highlighted-search-input-id-label"
             >
-              Enter a search keyword
+              Search
             </label>
             <input
               aria-describedby="highlighted-search-helper"
               class="ecl-text-input ecl-text-input--l ecl-highlighted-search__form-input"
               id="highlighted-search-input-id"
               name="highlighted-search-input-name"
-              placeholder="Enter a search keyword"
               type="search"
             />
           </div>
@@ -351,7 +348,7 @@ exports[`Highlighted search Default renders correctly with extra class names 1`]
           class="ecl-highlighted-search__form-helper"
           id="highlighted-search-helper"
         >
-          Enter the job you're looking for
+          e.g. full time, designer, writer
         </div>
       </form>
       <div

--- a/src/components/highlighted-search/demo/data.js
+++ b/src/components/highlighted-search/demo/data.js
@@ -8,9 +8,8 @@ module.exports = {
   search_input: {
     id: 'highlighted-search-input-id',
     name: 'highlighted-search-input-name',
-    placeholder: 'Enter a search keyword',
   },
-  search_helper: "Enter the job you're looking for",
+  search_helper: 'e.g. full time, designer, writer',
   search_button: {
     label: 'Search',
   },

--- a/src/components/search-form/__snapshots__/search-form.test.js.snap
+++ b/src/components/search-form/__snapshots__/search-form.test.js.snap
@@ -19,7 +19,6 @@ exports[`Search Form Default renders correctly 1`] = `
       <input
         class="ecl-text-input ecl-text-input--m ecl-search-form__text-input"
         id="search-input-id"
-        placeholder="Placeholder text"
         type="search"
       />
     </div>
@@ -68,7 +67,6 @@ exports[`Search Form Default renders correctly with extra attributes 1`] = `
       <input
         class="ecl-text-input ecl-text-input--m ecl-search-form__text-input"
         id="search-input-id"
-        placeholder="Placeholder text"
         type="search"
       />
     </div>
@@ -115,7 +113,6 @@ exports[`Search Form Default renders correctly with extra class names 1`] = `
       <input
         class="ecl-text-input ecl-text-input--m ecl-search-form__text-input"
         id="search-input-id"
-        placeholder="Placeholder text"
         type="search"
       />
     </div>
@@ -162,7 +159,6 @@ exports[`Search Form Default renders correctly with extra classes on the button 
       <input
         class="ecl-text-input ecl-text-input--m ecl-search-form__text-input"
         id="search-input-id"
-        placeholder="Placeholder text"
         type="search"
       />
     </div>
@@ -209,7 +205,6 @@ exports[`Search Form Default renders correctly with extra classes on the input 1
       <input
         class="ecl-text-input ecl-text-input--m ecl-search-form__text-input input-extra-class"
         id="search-input-id"
-        placeholder="Placeholder text"
         type="search"
       />
     </div>
@@ -256,7 +251,6 @@ exports[`Search Form Default renders correctly with extra form elements 1`] = `
       <input
         class="ecl-text-input ecl-text-input--m ecl-search-form__text-input"
         id="search-input-id"
-        placeholder="Placeholder text"
         type="search"
       />
     </div>

--- a/src/components/search-form/demo/data--ec.js
+++ b/src/components/search-form/demo/data--ec.js
@@ -4,7 +4,6 @@ module.exports = {
   text_input: {
     id: 'search-input-id',
     label: 'Search',
-    placeholder: 'Placeholder text',
   },
   button: {
     variant: 'tertiary',

--- a/src/components/search-form/demo/data--eu.js
+++ b/src/components/search-form/demo/data--eu.js
@@ -4,7 +4,6 @@ module.exports = {
   text_input: {
     id: 'search-input-id',
     label: 'Search',
-    placeholder: 'Placeholder text',
   },
   button: {
     variant: 'primary',

--- a/src/components/text-area/demo/data.js
+++ b/src/components/text-area/demo/data.js
@@ -15,7 +15,6 @@ module.exports = {
   input: {
     input_type: 'textarea',
     id: 'example-textarea-id-1',
-    placeholder: 'Placeholder text',
     rows: 4,
     width: 'm',
   },

--- a/src/components/text-area/text-area.test.js
+++ b/src/components/text-area/text-area.test.js
@@ -7,7 +7,7 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 
 import specs from './demo/data';
 
-const specDefault = specs.input;
+const specDefault = { ...specs.input, placeholder: 'Placeholder text' };
 
 expect.extend(toHaveNoViolations);
 

--- a/src/components/text-input/demo/data.js
+++ b/src/components/text-input/demo/data.js
@@ -15,7 +15,6 @@ module.exports = {
   input: {
     id: 'example-input-id-1',
     input_type: 'text',
-    placeholder: 'Placeholder text',
     width: 'm',
   },
 };

--- a/src/components/text-input/text-input.test.js
+++ b/src/components/text-input/text-input.test.js
@@ -7,7 +7,7 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 
 import specs from './demo/data';
 
-const specDefault = specs.input;
+const specDefault = { ...specs.input, placeholder: 'Placeholder text' };
 
 const specInvalid = { ...specDefault, invalid: true };
 const specDisabled = { ...specDefault, disabled: true };


### PR DESCRIPTION
Don't display the placeholder by default in form elements.
It is still possible to add it, but it is not considered a good practice for accessibility