### PR TITLE
feat(rating-field): new markup structure - FRONT-5430

### DIFF
--- a/src/components/form-group/__snapshots__/form-group.test.js.snap
+++ b/src/components/form-group/__snapshots__/form-group.test.js.snap
@@ -2941,22 +2941,14 @@ exports[`Form group  with Rating field renders correctly 1`] = `
     <div
       class="ecl-rating-field"
     >
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-5"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="5"
-      />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-5"
+        for="rating-field-1"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          5 stars
+          1 star
         </span>
         <span
           aria-hidden="true"
@@ -2969,63 +2961,11 @@ exports[`Form group  with Rating field renders correctly 1`] = `
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-4"
+        id="rating-field-1"
         name="rating-group"
         required=""
         type="radio"
-        value="4"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-4"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          4 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-3"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="3"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-3"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          3 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-2"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="2"
+        value="1"
       />
       <label
         class="ecl-rating-field__label"
@@ -3047,20 +2987,20 @@ exports[`Form group  with Rating field renders correctly 1`] = `
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-1"
+        id="rating-field-2"
         name="rating-group"
         required=""
         type="radio"
-        value="1"
+        value="2"
       />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-1"
+        for="rating-field-3"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          1 star
+          3 stars
         </span>
         <span
           aria-hidden="true"
@@ -3071,6 +3011,66 @@ exports[`Form group  with Rating field renders correctly 1`] = `
           class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
         />
       </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-3"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="3"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-4"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          4 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-4"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="4"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-5"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          5 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-5"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="5"
+      />
     </div>
   </fieldset>
 </jest>
@@ -3107,23 +3107,14 @@ exports[`Form group  with Rating field renders correctly when disabled 1`] = `
     <div
       class="ecl-rating-field ecl-rating-field--disabled"
     >
-      <input
-        class="ecl-rating-field__input"
-        disabled=""
-        id="rating-field-5"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="5"
-      />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-5"
+        for="rating-field-1"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          5 stars
+          1 star
         </span>
         <span
           aria-hidden="true"
@@ -3137,65 +3128,11 @@ exports[`Form group  with Rating field renders correctly when disabled 1`] = `
       <input
         class="ecl-rating-field__input"
         disabled=""
-        id="rating-field-4"
+        id="rating-field-1"
         name="rating-group"
         required=""
         type="radio"
-        value="4"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-4"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          4 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        disabled=""
-        id="rating-field-3"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="3"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-3"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          3 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        disabled=""
-        id="rating-field-2"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="2"
+        value="1"
       />
       <label
         class="ecl-rating-field__label"
@@ -3218,20 +3155,20 @@ exports[`Form group  with Rating field renders correctly when disabled 1`] = `
       <input
         class="ecl-rating-field__input"
         disabled=""
-        id="rating-field-1"
+        id="rating-field-2"
         name="rating-group"
         required=""
         type="radio"
-        value="1"
+        value="2"
       />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-1"
+        for="rating-field-3"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          1 star
+          3 stars
         </span>
         <span
           aria-hidden="true"
@@ -3242,6 +3179,69 @@ exports[`Form group  with Rating field renders correctly when disabled 1`] = `
           class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
         />
       </label>
+      <input
+        class="ecl-rating-field__input"
+        disabled=""
+        id="rating-field-3"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="3"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-4"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          4 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        disabled=""
+        id="rating-field-4"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="4"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-5"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          5 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        disabled=""
+        id="rating-field-5"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="5"
+      />
     </div>
   </fieldset>
 </jest>
@@ -3284,22 +3284,14 @@ exports[`Form group  with Rating field renders correctly when invalid 1`] = `
     <div
       class="ecl-rating-field"
     >
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-5"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="5"
-      />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-5"
+        for="rating-field-1"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          5 stars
+          1 star
         </span>
         <span
           aria-hidden="true"
@@ -3312,63 +3304,11 @@ exports[`Form group  with Rating field renders correctly when invalid 1`] = `
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-4"
+        id="rating-field-1"
         name="rating-group"
         required=""
         type="radio"
-        value="4"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-4"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          4 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-3"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="3"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-3"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          3 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-2"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="2"
+        value="1"
       />
       <label
         class="ecl-rating-field__label"
@@ -3390,20 +3330,20 @@ exports[`Form group  with Rating field renders correctly when invalid 1`] = `
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-1"
+        id="rating-field-2"
         name="rating-group"
         required=""
         type="radio"
-        value="1"
+        value="2"
       />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-1"
+        for="rating-field-3"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          1 star
+          3 stars
         </span>
         <span
           aria-hidden="true"
@@ -3414,6 +3354,66 @@ exports[`Form group  with Rating field renders correctly when invalid 1`] = `
           class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
         />
       </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-3"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="3"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-4"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          4 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-4"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="4"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-5"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          5 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-5"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="5"
+      />
     </div>
     <div
       aria-hidden="true"
@@ -3463,22 +3463,14 @@ exports[`Form group  with Rating field renders correctly when required 1`] = `
     <div
       class="ecl-rating-field"
     >
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-5"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="5"
-      />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-5"
+        for="rating-field-1"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          5 stars
+          1 star
         </span>
         <span
           aria-hidden="true"
@@ -3491,63 +3483,11 @@ exports[`Form group  with Rating field renders correctly when required 1`] = `
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-4"
+        id="rating-field-1"
         name="rating-group"
         required=""
         type="radio"
-        value="4"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-4"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          4 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-3"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="3"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-3"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          3 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-2"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="2"
+        value="1"
       />
       <label
         class="ecl-rating-field__label"
@@ -3569,20 +3509,20 @@ exports[`Form group  with Rating field renders correctly when required 1`] = `
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-1"
+        id="rating-field-2"
         name="rating-group"
         required=""
         type="radio"
-        value="1"
+        value="2"
       />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-1"
+        for="rating-field-3"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          1 star
+          3 stars
         </span>
         <span
           aria-hidden="true"
@@ -3593,6 +3533,66 @@ exports[`Form group  with Rating field renders correctly when required 1`] = `
           class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
         />
       </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-3"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="3"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-4"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          4 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-4"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="4"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-5"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          5 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-5"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="5"
+      />
     </div>
   </fieldset>
 </jest>
@@ -3631,22 +3631,14 @@ exports[`Form group  with Rating field renders correctly with extra attributes 1
     <div
       class="ecl-rating-field"
     >
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-5"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="5"
-      />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-5"
+        for="rating-field-1"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          5 stars
+          1 star
         </span>
         <span
           aria-hidden="true"
@@ -3659,63 +3651,11 @@ exports[`Form group  with Rating field renders correctly with extra attributes 1
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-4"
+        id="rating-field-1"
         name="rating-group"
         required=""
         type="radio"
-        value="4"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-4"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          4 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-3"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="3"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-3"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          3 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-2"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="2"
+        value="1"
       />
       <label
         class="ecl-rating-field__label"
@@ -3737,20 +3677,20 @@ exports[`Form group  with Rating field renders correctly with extra attributes 1
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-1"
+        id="rating-field-2"
         name="rating-group"
         required=""
         type="radio"
-        value="1"
+        value="2"
       />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-1"
+        for="rating-field-3"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          1 star
+          3 stars
         </span>
         <span
           aria-hidden="true"
@@ -3761,6 +3701,66 @@ exports[`Form group  with Rating field renders correctly with extra attributes 1
           class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
         />
       </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-3"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="3"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-4"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          4 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-4"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="4"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-5"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          5 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-5"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="5"
+      />
     </div>
   </fieldset>
 </jest>
@@ -3797,22 +3797,14 @@ exports[`Form group  with Rating field renders correctly with extra class names 
     <div
       class="ecl-rating-field"
     >
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-5"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="5"
-      />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-5"
+        for="rating-field-1"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          5 stars
+          1 star
         </span>
         <span
           aria-hidden="true"
@@ -3825,63 +3817,11 @@ exports[`Form group  with Rating field renders correctly with extra class names 
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-4"
+        id="rating-field-1"
         name="rating-group"
         required=""
         type="radio"
-        value="4"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-4"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          4 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-3"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="3"
-      />
-      <label
-        class="ecl-rating-field__label"
-        for="rating-field-3"
-      >
-        <span
-          class="ecl-rating-field__sr-label"
-        >
-          3 stars
-        </span>
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-        />
-        <span
-          aria-hidden="true"
-          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-        />
-      </label>
-      <input
-        class="ecl-rating-field__input"
-        id="rating-field-2"
-        name="rating-group"
-        required=""
-        type="radio"
-        value="2"
+        value="1"
       />
       <label
         class="ecl-rating-field__label"
@@ -3903,20 +3843,20 @@ exports[`Form group  with Rating field renders correctly with extra class names 
       </label>
       <input
         class="ecl-rating-field__input"
-        id="rating-field-1"
+        id="rating-field-2"
         name="rating-group"
         required=""
         type="radio"
-        value="1"
+        value="2"
       />
       <label
         class="ecl-rating-field__label"
-        for="rating-field-1"
+        for="rating-field-3"
       >
         <span
           class="ecl-rating-field__sr-label"
         >
-          1 star
+          3 stars
         </span>
         <span
           aria-hidden="true"
@@ -3927,6 +3867,66 @@ exports[`Form group  with Rating field renders correctly with extra class names 
           class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
         />
       </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-3"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="3"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-4"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          4 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-4"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="4"
+      />
+      <label
+        class="ecl-rating-field__label"
+        for="rating-field-5"
+      >
+        <span
+          class="ecl-rating-field__sr-label"
+        >
+          5 stars
+        </span>
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+        />
+        <span
+          aria-hidden="true"
+          class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+        />
+      </label>
+      <input
+        class="ecl-rating-field__input"
+        id="rating-field-5"
+        name="rating-group"
+        required=""
+        type="radio"
+        value="5"
+      />
     </div>
   </fieldset>
 </jest>

--- a/src/components/rating-field/__snapshots__/rating-field.test.js.snap
+++ b/src/components/rating-field/__snapshots__/rating-field.test.js.snap
@@ -5,21 +5,14 @@ exports[`Rating field Default renders correctly 1`] = `
   <div
     class="ecl-rating-field"
   >
-    <input
-      class="ecl-rating-field__input"
-      id="rating-field-5"
-      name="rating-group"
-      type="radio"
-      value="5"
-    />
     <label
       class="ecl-rating-field__label"
-      for="rating-field-5"
+      for="rating-field-1"
     >
       <span
         class="ecl-rating-field__sr-label"
       >
-        5 stars
+        1 star
       </span>
       <span
         aria-hidden="true"
@@ -32,60 +25,10 @@ exports[`Rating field Default renders correctly 1`] = `
     </label>
     <input
       class="ecl-rating-field__input"
-      id="rating-field-4"
+      id="rating-field-1"
       name="rating-group"
       type="radio"
-      value="4"
-    />
-    <label
-      class="ecl-rating-field__label"
-      for="rating-field-4"
-    >
-      <span
-        class="ecl-rating-field__sr-label"
-      >
-        4 stars
-      </span>
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-      />
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-      />
-    </label>
-    <input
-      class="ecl-rating-field__input"
-      id="rating-field-3"
-      name="rating-group"
-      type="radio"
-      value="3"
-    />
-    <label
-      class="ecl-rating-field__label"
-      for="rating-field-3"
-    >
-      <span
-        class="ecl-rating-field__sr-label"
-      >
-        3 stars
-      </span>
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-      />
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-      />
-    </label>
-    <input
-      class="ecl-rating-field__input"
-      id="rating-field-2"
-      name="rating-group"
-      type="radio"
-      value="2"
+      value="1"
     />
     <label
       class="ecl-rating-field__label"
@@ -107,19 +50,19 @@ exports[`Rating field Default renders correctly 1`] = `
     </label>
     <input
       class="ecl-rating-field__input"
-      id="rating-field-1"
+      id="rating-field-2"
       name="rating-group"
       type="radio"
-      value="1"
+      value="2"
     />
     <label
       class="ecl-rating-field__label"
-      for="rating-field-1"
+      for="rating-field-3"
     >
       <span
         class="ecl-rating-field__sr-label"
       >
-        1 star
+        3 stars
       </span>
       <span
         aria-hidden="true"
@@ -130,6 +73,63 @@ exports[`Rating field Default renders correctly 1`] = `
         class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
       />
     </label>
+    <input
+      class="ecl-rating-field__input"
+      id="rating-field-3"
+      name="rating-group"
+      type="radio"
+      value="3"
+    />
+    <label
+      class="ecl-rating-field__label"
+      for="rating-field-4"
+    >
+      <span
+        class="ecl-rating-field__sr-label"
+      >
+        4 stars
+      </span>
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+      />
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+      />
+    </label>
+    <input
+      class="ecl-rating-field__input"
+      id="rating-field-4"
+      name="rating-group"
+      type="radio"
+      value="4"
+    />
+    <label
+      class="ecl-rating-field__label"
+      for="rating-field-5"
+    >
+      <span
+        class="ecl-rating-field__sr-label"
+      >
+        5 stars
+      </span>
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+      />
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+      />
+    </label>
+    <input
+      class="ecl-rating-field__input"
+      id="rating-field-5"
+      name="rating-group"
+      type="radio"
+      value="5"
+    />
   </div>
 </jest>
 `;
@@ -139,21 +139,14 @@ exports[`Rating field Default renders correctly with extra attributes 1`] = `
   <div
     class="ecl-rating-field"
   >
-    <input
-      class="ecl-rating-field__input"
-      id="rating-field-5"
-      name="rating-group"
-      type="radio"
-      value="5"
-    />
     <label
       class="ecl-rating-field__label"
-      for="rating-field-5"
+      for="rating-field-1"
     >
       <span
         class="ecl-rating-field__sr-label"
       >
-        5 stars
+        1 star
       </span>
       <span
         aria-hidden="true"
@@ -166,60 +159,10 @@ exports[`Rating field Default renders correctly with extra attributes 1`] = `
     </label>
     <input
       class="ecl-rating-field__input"
-      id="rating-field-4"
+      id="rating-field-1"
       name="rating-group"
       type="radio"
-      value="4"
-    />
-    <label
-      class="ecl-rating-field__label"
-      for="rating-field-4"
-    >
-      <span
-        class="ecl-rating-field__sr-label"
-      >
-        4 stars
-      </span>
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-      />
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-      />
-    </label>
-    <input
-      class="ecl-rating-field__input"
-      id="rating-field-3"
-      name="rating-group"
-      type="radio"
-      value="3"
-    />
-    <label
-      class="ecl-rating-field__label"
-      for="rating-field-3"
-    >
-      <span
-        class="ecl-rating-field__sr-label"
-      >
-        3 stars
-      </span>
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-      />
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-      />
-    </label>
-    <input
-      class="ecl-rating-field__input"
-      id="rating-field-2"
-      name="rating-group"
-      type="radio"
-      value="2"
+      value="1"
     />
     <label
       class="ecl-rating-field__label"
@@ -241,19 +184,19 @@ exports[`Rating field Default renders correctly with extra attributes 1`] = `
     </label>
     <input
       class="ecl-rating-field__input"
-      id="rating-field-1"
+      id="rating-field-2"
       name="rating-group"
       type="radio"
-      value="1"
+      value="2"
     />
     <label
       class="ecl-rating-field__label"
-      for="rating-field-1"
+      for="rating-field-3"
     >
       <span
         class="ecl-rating-field__sr-label"
       >
-        1 star
+        3 stars
       </span>
       <span
         aria-hidden="true"
@@ -264,6 +207,63 @@ exports[`Rating field Default renders correctly with extra attributes 1`] = `
         class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
       />
     </label>
+    <input
+      class="ecl-rating-field__input"
+      id="rating-field-3"
+      name="rating-group"
+      type="radio"
+      value="3"
+    />
+    <label
+      class="ecl-rating-field__label"
+      for="rating-field-4"
+    >
+      <span
+        class="ecl-rating-field__sr-label"
+      >
+        4 stars
+      </span>
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+      />
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+      />
+    </label>
+    <input
+      class="ecl-rating-field__input"
+      id="rating-field-4"
+      name="rating-group"
+      type="radio"
+      value="4"
+    />
+    <label
+      class="ecl-rating-field__label"
+      for="rating-field-5"
+    >
+      <span
+        class="ecl-rating-field__sr-label"
+      >
+        5 stars
+      </span>
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+      />
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+      />
+    </label>
+    <input
+      class="ecl-rating-field__input"
+      id="rating-field-5"
+      name="rating-group"
+      type="radio"
+      value="5"
+    />
   </div>
 </jest>
 `;
@@ -273,21 +273,14 @@ exports[`Rating field Default renders correctly with extra class names 1`] = `
   <div
     class="ecl-rating-field"
   >
-    <input
-      class="ecl-rating-field__input"
-      id="rating-field-5"
-      name="rating-group"
-      type="radio"
-      value="5"
-    />
     <label
       class="ecl-rating-field__label"
-      for="rating-field-5"
+      for="rating-field-1"
     >
       <span
         class="ecl-rating-field__sr-label"
       >
-        5 stars
+        1 star
       </span>
       <span
         aria-hidden="true"
@@ -300,60 +293,10 @@ exports[`Rating field Default renders correctly with extra class names 1`] = `
     </label>
     <input
       class="ecl-rating-field__input"
-      id="rating-field-4"
+      id="rating-field-1"
       name="rating-group"
       type="radio"
-      value="4"
-    />
-    <label
-      class="ecl-rating-field__label"
-      for="rating-field-4"
-    >
-      <span
-        class="ecl-rating-field__sr-label"
-      >
-        4 stars
-      </span>
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-      />
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-      />
-    </label>
-    <input
-      class="ecl-rating-field__input"
-      id="rating-field-3"
-      name="rating-group"
-      type="radio"
-      value="3"
-    />
-    <label
-      class="ecl-rating-field__label"
-      for="rating-field-3"
-    >
-      <span
-        class="ecl-rating-field__sr-label"
-      >
-        3 stars
-      </span>
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
-      />
-      <span
-        aria-hidden="true"
-        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
-      />
-    </label>
-    <input
-      class="ecl-rating-field__input"
-      id="rating-field-2"
-      name="rating-group"
-      type="radio"
-      value="2"
+      value="1"
     />
     <label
       class="ecl-rating-field__label"
@@ -375,19 +318,19 @@ exports[`Rating field Default renders correctly with extra class names 1`] = `
     </label>
     <input
       class="ecl-rating-field__input"
-      id="rating-field-1"
+      id="rating-field-2"
       name="rating-group"
       type="radio"
-      value="1"
+      value="2"
     />
     <label
       class="ecl-rating-field__label"
-      for="rating-field-1"
+      for="rating-field-3"
     >
       <span
         class="ecl-rating-field__sr-label"
       >
-        1 star
+        3 stars
       </span>
       <span
         aria-hidden="true"
@@ -398,6 +341,63 @@ exports[`Rating field Default renders correctly with extra class names 1`] = `
         class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
       />
     </label>
+    <input
+      class="ecl-rating-field__input"
+      id="rating-field-3"
+      name="rating-group"
+      type="radio"
+      value="3"
+    />
+    <label
+      class="ecl-rating-field__label"
+      for="rating-field-4"
+    >
+      <span
+        class="ecl-rating-field__sr-label"
+      >
+        4 stars
+      </span>
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+      />
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+      />
+    </label>
+    <input
+      class="ecl-rating-field__input"
+      id="rating-field-4"
+      name="rating-group"
+      type="radio"
+      value="4"
+    />
+    <label
+      class="ecl-rating-field__label"
+      for="rating-field-5"
+    >
+      <span
+        class="ecl-rating-field__sr-label"
+      >
+        5 stars
+      </span>
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-filled ecl-icon ecl-icon--l ecl-rating-field__icon-filled ecl-icon--star-filled"
+      />
+      <span
+        aria-hidden="true"
+        class="wt-icon--star-outline ecl-icon ecl-icon--l ecl-rating-field__icon-outline ecl-icon--star-outline"
+      />
+    </label>
+    <input
+      class="ecl-rating-field__input"
+      id="rating-field-5"
+      name="rating-group"
+      type="radio"
+      value="5"
+    />
   </div>
 </jest>
 `;

--- a/src/components/rating-field/rating-field.html.twig
+++ b/src/components/rating-field/rating-field.html.twig
@@ -50,26 +50,10 @@
 {% if _items is not empty and _items is iterable %}
   <div class="ecl-rating-field
     {{- _disabled ? ' ecl-rating-field--disabled' -}}">
-  {%- for _item in _items|reverse %}
+  {%- for _item in _items %}
     {% set _item_id = _id ~ '-' ~ _item.value|e('html_attr') %}
-    <input
-      id="{{ _item_id }}" 
-      name="{{ _name }}" 
-      class="ecl-rating-field__input" 
-      type="radio" 
-      value="{{ _item.value }}" 
-      {% if _item.checked %}
-        checked 
-      {% endif %}
-      {% if _required %}
-        required 
-      {% endif %}
-      {% if _disabled %}
-        disabled
-      {% endif %}
-    >
-    <label 
-      class="ecl-rating-field__label" 
+    <label
+      class="ecl-rating-field__label"
       for="{{ _item_id }}">
     {% if _item.label %}
       <span class="ecl-rating-field__sr-label">{{ _item.label }}</span>
@@ -83,6 +67,22 @@
         extra_classes: 'ecl-rating-field__icon-outline',
       } only %}
     </label>
+    <input
+      id="{{ _item_id }}"
+      name="{{ _name }}"
+      class="ecl-rating-field__input"
+      type="radio"
+      value="{{ _item.value }}"
+      {% if _item.checked %}
+        checked
+      {% endif %}
+      {% if _required %}
+        required
+      {% endif %}
+      {% if _disabled %}
+        disabled
+      {% endif %}
+    >
   {% endfor -%}
   </div>
   {% endif %}

--- a/src/components/rating-field/rating-field.scss
+++ b/src/components/rating-field/rating-field.scss
@@ -16,45 +16,38 @@ $stroke-width: 4px;
 
 .ecl-rating-field {
   display: inline-flex;
-  flex-direction: row-reverse;
 
-  &--disabled .ecl-rating-field__input + .ecl-rating-field__label {
+  &--disabled .ecl-rating-field__label {
     cursor: not-allowed;
     opacity: 0.5;
   }
 
-  .ecl-rating-field__input {
-    &:checked,
-    &:active {
-      ~ .ecl-rating-field__label {
-        .ecl-rating-field__icon-outline {
-          display: none;
-        }
+  .ecl-rating-field__label {
+    &:has(~ .ecl-rating-field__input:checked),
+    &:has(~ .ecl-rating-field__input:active) {
+      .ecl-rating-field__icon-outline {
+        display: none;
+      }
 
-        .ecl-rating-field__icon-filled {
-          display: inline-block;
-        }
+      .ecl-rating-field__icon-filled {
+        display: inline-block;
+      }
 
-        &:hover .ecl-rating-field__icon-filled {
-          fill: map.get($rating-field, 'checked-hover-color');
-        }
+      &:hover .ecl-rating-field__icon-filled {
+        fill: map.get($rating-field, 'checked-hover-color');
       }
     }
   }
 
   &:not(.ecl-rating-field--disabled) {
-    .ecl-rating-field__input
-      + .ecl-rating-field__label:hover
-      .ecl-rating-field__icon-outline {
+    .ecl-rating-field__label:hover .ecl-rating-field__icon-outline {
       fill: map.get($rating-field, 'hover-stroke-color');
     }
 
-    .ecl-rating-field__input:focus-visible {
-      + .ecl-rating-field__label {
-        outline: 1px solid map.get($rating-field, 'focus-outline');
-        outline-offset: -1px;
-        border-radius: 50%;
-      }
+    .ecl-rating-field__label:has(+ .ecl-rating-field__input:focus-visible) {
+      outline: 1px solid map.get($rating-field, 'focus-outline');
+      outline-offset: -1px;
+      border-radius: 50%;
     }
   }
 }


### PR DESCRIPTION
Use a different markup structure (and corresponding css) for the rating field.
It still uses only css, but now the input are placed in the same order visually and for keyboard.
Data structure is unchanged, but markup has been updated.