### PR TITLE
feat(max-width): override variable in some elements - FRONT-5439

### DIFF
--- a/src/components/blockquote/blockquote-print.scss
+++ b/src/components/blockquote/blockquote-print.scss
@@ -12,6 +12,8 @@ $blockquote-print: null !default;
 
 .ecl-blockquote,
 %ecl-blockquote {
+  --max-w: none;
+
   border-inline-start: map.get($blockquote, 'border-width') solid
     map.get($blockquote, 'border-color');
   display: flex;

--- a/src/components/blockquote/blockquote.scss
+++ b/src/components/blockquote/blockquote.scss
@@ -13,6 +13,8 @@ $blockquote: null !default;
 
 .ecl-blockquote,
 %ecl-blockquote {
+  --max-w: none;
+
   background-color: map.get($blockquote, 'background');
   border-inline-start: map.get($blockquote, 'border-width') solid
     map.get($blockquote, 'border-color');

--- a/src/components/highlight-box/highlight-box-print.scss
+++ b/src/components/highlight-box/highlight-box-print.scss
@@ -10,6 +10,10 @@
 $theme: null !default;
 $highlight-box: null !default;
 
+.ecl-highlight-box {
+  --max-w: none;
+}
+
 .ecl-highlight-box__header {
   align-items: center;
   border-block-end: 1px solid

--- a/src/components/highlight-box/highlight-box.scss
+++ b/src/components/highlight-box/highlight-box.scss
@@ -11,6 +11,8 @@ $theme: null !default;
 $highlight-box: null !default;
 
 .ecl-highlight-box {
+  --max-w: none;
+
   box-shadow: map.get($highlight-box, 'shadow');
 }
 

--- a/src/components/page-summary/page-summary-print.scss
+++ b/src/components/page-summary/page-summary-print.scss
@@ -11,6 +11,8 @@ $theme: null !default;
 $page-summary: null !default;
 
 .ecl-page-summary {
+  --max-w: none;
+
   background-color: map.get($page-summary, 'background');
   border-inline-start: map.get($page-summary, 'border');
   display: flex;

--- a/src/components/page-summary/page-summary.scss
+++ b/src/components/page-summary/page-summary.scss
@@ -11,6 +11,8 @@ $theme: null !default;
 $page-summary: null !default;
 
 .ecl-page-summary {
+  --max-w: none;
+
   background-color: map.get($page-summary, 'background');
   border-inline-start: map.get($page-summary, 'border');
   display: flex;

--- a/src/utilities/typography/typography-print.scss
+++ b/src/utilities/typography/typography-print.scss
@@ -260,6 +260,8 @@ $typography-print: null !default;
 }
 
 .ecl-u-type-enhance {
+  --max-w: none;
+
   background-color: map.get(
     $typography,
     'enhance',
@@ -274,6 +276,8 @@ $typography-print: null !default;
 }
 
 .ecl-u-type-enhance-strong {
+  --max-w: none;
+
   background-color: map.get(
     $typography,
     'enhance',
@@ -287,6 +291,8 @@ $typography-print: null !default;
 }
 
 .ecl-u-type-enhance-light {
+  --max-w: none;
+
   background-color: map.get(
     $typography,
     'enhance',

--- a/src/utilities/typography/typography.scss
+++ b/src/utilities/typography/typography.scss
@@ -289,6 +289,8 @@ $typography: null !default;
 }
 
 .ecl-u-type-enhance {
+  --max-w: none;
+
   background-color: map.get(
     $typography,
     'enhance',
@@ -336,6 +338,8 @@ $typography: null !default;
 }
 
 .ecl-u-type-enhance-strong {
+  --max-w: none;
+
   background-color: map.get(
     $typography,
     'enhance',
@@ -377,6 +381,8 @@ $typography: null !default;
 }
 
 .ecl-u-type-enhance-light {
+  --max-w: none;
+
   background-color: map.get(
     $typography,
     'enhance',


### PR DESCRIPTION
Override max width variable in Page summary, Highlight box and Enhanced text, to let the content take full width, even if placed in a paragraph