### PR TITLE
feat(blockquote): update author markup - FRONT-5413

### DIFF
--- a/src/components/blockquote/__snapshots__/blockquote.test.js.snap
+++ b/src/components/blockquote/__snapshots__/blockquote.test.js.snap
@@ -29,11 +29,14 @@ exports[`Blockquote Default renders correctly 1`] = `
         <footer
           class="ecl-blockquote__attribution"
         >
-          <cite
+          <span
             class="ecl-blockquote__author"
           >
-            Someone
-          </cite>
+            Someone - 
+            <cite>
+              Lorem Ipsum
+            </cite>
+          </span>
         </footer>
       </blockquote>
     </div>
@@ -72,11 +75,14 @@ exports[`Blockquote Default renders correctly with extra attributes 1`] = `
         <footer
           class="ecl-blockquote__attribution"
         >
-          <cite
+          <span
             class="ecl-blockquote__author"
           >
-            Someone
-          </cite>
+            Someone - 
+            <cite>
+              Lorem Ipsum
+            </cite>
+          </span>
         </footer>
       </blockquote>
     </div>
@@ -113,11 +119,14 @@ exports[`Blockquote Default renders correctly with extra class names 1`] = `
         <footer
           class="ecl-blockquote__attribution"
         >
-          <cite
+          <span
             class="ecl-blockquote__author"
           >
-            Someone
-          </cite>
+            Someone - 
+            <cite>
+              Lorem Ipsum
+            </cite>
+          </span>
         </footer>
       </blockquote>
     </div>

--- a/src/components/blockquote/blockquote-print.scss
+++ b/src/components/blockquote/blockquote-print.scss
@@ -15,7 +15,7 @@ $blockquote-print: null !default;
   border-inline-start: map.get($blockquote, 'border-width') solid
     map.get($blockquote, 'border-color');
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: flex-start;
   margin: 0;
   padding: map.get($blockquote, 'padding-desktop');

--- a/src/components/blockquote/blockquote.html.twig
+++ b/src/components/blockquote/blockquote.html.twig
@@ -64,7 +64,7 @@
     <blockquote class="ecl-blockquote__quote">
       <p class="ecl-blockquote__citation" lang="{{ _lang }}">{{ _citation }}</p>
       <footer class="ecl-blockquote__attribution">
-        <cite class="ecl-blockquote__author">{{ _author }}</cite>
+        <span class="ecl-blockquote__author">{{ _author }}</span>
       </footer>
     </blockquote>
     

--- a/src/components/blockquote/demo/data.js
+++ b/src/components/blockquote/demo/data.js
@@ -2,7 +2,7 @@
 module.exports = {
   citation:
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce sodales, nisl tincidunt hendrerit elementum, purus risus tempus dui, sit amet cursus massa odio non lacus.',
-  author: 'Someone',
+  author: 'Someone - <cite>Lorem Ipsum</cite>',
   picture: {
     img: {
       src: 'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',

--- a/src/presets/ec/src/ec-default-print.scss
+++ b/src/presets/ec/src/ec-default-print.scss
@@ -229,8 +229,10 @@ html {
   }
 }
 
-.ecl blockquote cite:not([class*='ecl-'], [class*='wt-']),
-.ecl blockquote cite:is([class*='ecl-u-']) {
+.ecl blockquote > cite:not([class*='ecl-'], [class*='wt-']),
+.ecl blockquote > cite:is([class*='ecl-u-']),
+.ecl blockquote > span:not([class*='ecl-'], [class*='wt-']),
+.ecl blockquote > span:is([class*='ecl-u-']) {
   @extend %ecl-blockquote__author;
 
   display: block;

--- a/src/presets/ec/src/ec-default.scss
+++ b/src/presets/ec/src/ec-default.scss
@@ -218,8 +218,10 @@
   }
 }
 
-.ecl blockquote cite:not([class*='ecl-'], [class*='wt-']),
-.ecl blockquote cite:is([class*='ecl-u-']) {
+.ecl blockquote > cite:not([class*='ecl-'], [class*='wt-']),
+.ecl blockquote > cite:is([class*='ecl-u-']),
+.ecl blockquote > span:not([class*='ecl-'], [class*='wt-']),
+.ecl blockquote > span:is([class*='ecl-u-']) {
   @extend %ecl-blockquote__author;
 
   display: block;

--- a/src/utilities/html-tag/index.story.js
+++ b/src/utilities/html-tag/index.story.js
@@ -139,7 +139,13 @@ export const Default = (args) => {
       <div class="ecl ecl-u-mt-xs">
         <blockquote>
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed efficitur vulputate venenatis.</p>
-          <cite>Someone</cite>
+          <span>Someone - <cite>Lorem Ipsum</cite></span>
+        </blockquote>
+      </div>
+      <div class="ecl ecl-u-mt-xs">
+        <blockquote>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed efficitur vulputate venenatis.</p>
+          <cite>Lorem Ipsum</cite>
         </blockquote>
       </div>
     </details>


### PR DESCRIPTION
Use `<span>`  instead of `<cite>` for the author; it is reserved to cite sources like article or book name.
Changes cover both ECL Blockquote component, and blockquotes used in wysiwyg (with .ecl class).
Existing content would not be affected (using `<cite>` directly would still work, but it is not recommended